### PR TITLE
fix: add push and schedule triggers to reusable workflow

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -21,6 +21,12 @@ on:
         required: false
         default: 'https://f5xc-salesdemos.github.io'
         type: string
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  schedule:
+    - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       content-path:


### PR DESCRIPTION
## Summary
- Added `push` trigger (`docs/**` on main) so docs-control auto-builds on content changes
- Added daily `schedule` trigger (`0 7 * * *`) to pick up Docker image updates
- When triggered via `push`/`schedule`, workflow inputs default to their declared defaults
- Part of the pull-based rebuild architecture replacing cross-repo dispatch

Closes #2

## Test plan
- [ ] Verify `push` trigger fires when `docs/` changes are merged to main
- [ ] Verify scheduled runs appear in the Actions tab
- [ ] Confirm `workflow_call` from downstream repos still works
- [ ] Confirm `workflow_dispatch` manual trigger still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)