### PR TITLE
feat: split enforce-repo-settings into two workflows for least-privilege tokens

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -9,6 +9,7 @@ on:
       - '.github/config/docs-sites.json'
       - 'workflows/**'
       - '.github/workflows/enforce-repo-settings.yml'
+      - '.github/workflows/sync-managed-files.yml'
       - '.github/workflows/github-pages-deploy.yml'
       - '.github/workflows/require-linked-issue.yml'
       - '.github/PULL_REQUEST_TEMPLATE.md'
@@ -36,7 +37,7 @@ jobs:
 
       - name: Dispatch to downstream repos
         env:
-          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
         run: |
           repos=$(jq -r '.[]' .github/config/downstream-repos.json)
           for repo in $repos; do

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -3,7 +3,7 @@ name: Enforce Repository Settings
 on:
   workflow_call:
     secrets:
-      repo-admin-token:
+      repo-settings-token:
         description: 'PAT with admin permissions for repository settings'
         required: true
 
@@ -16,7 +16,7 @@ jobs:
 
       - name: Enforce repository settings
         env:
-          GH_TOKEN: ${{ secrets.repo-admin-token }}
+          GH_TOKEN: ${{ secrets.repo-settings-token }}
         run: |
           set -euo pipefail
 
@@ -283,219 +283,9 @@ jobs:
             echo "[SKIP] Pages not enabled in config"
           fi
 
-          # ─── Phase 7: Sync Managed Files ──────────────────────────────────────
+          # ─── Phase 7: Verify ──────────────────────────────────────────────────
           echo ""
-          echo "=== Phase 7: Sync Managed Files ==="
-
-          MANAGED_FILES=$(echo "$CONFIG" | jq -c '.managed_files // empty')
-          SYNC_PR_CREATED=false
-          EXISTING_PR=""
-          SOURCE_REPO=""
-
-          if [ -z "$MANAGED_FILES" ]; then
-            echo "[SKIP] No managed_files in config"
-          else
-            SOURCE_REPO=$(echo "$MANAGED_FILES" | jq -r '.source_repo')
-
-            # Guard: skip if running in the source repo itself
-            if [ "${OWNER}/${REPO}" = "$SOURCE_REPO" ]; then
-              echo "[SKIP] Running in source repo — skipping managed file sync"
-            else
-              DRIFT_FILES=""
-              DRIFT_COUNT=0
-
-              for file_obj in $(echo "$MANAGED_FILES" | jq -c '.files[]'); do
-                src=$(echo "$file_obj" | jq -r '.src')
-                dest=$(echo "$file_obj" | jq -r '.dest')
-
-                # Fetch canonical content from source path
-                CANONICAL_RESPONSE=$(gh api "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
-                if [ -z "$CANONICAL_RESPONSE" ]; then
-                  echo "[WARN] Could not fetch canonical: ${src}"
-                  continue
-                fi
-                CANONICAL_CONTENT=$(echo "$CANONICAL_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
-
-                # Fetch downstream content at dest path (handle 404)
-                DOWNSTREAM_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/${dest}" 2>/dev/null) || true
-                if [ -z "$DOWNSTREAM_RESPONSE" ]; then
-                  echo "[DRIFT] Missing downstream: ${dest}"
-                  DRIFT_FILES="${DRIFT_FILES}${dest}\n"
-                  DRIFT_COUNT=$((DRIFT_COUNT + 1))
-                  continue
-                fi
-                DOWNSTREAM_CONTENT=$(echo "$DOWNSTREAM_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
-
-                if [ "$CANONICAL_CONTENT" != "$DOWNSTREAM_CONTENT" ]; then
-                  echo "[DRIFT] Content mismatch: ${dest}"
-                  DRIFT_FILES="${DRIFT_FILES}${dest}\n"
-                  DRIFT_COUNT=$((DRIFT_COUNT + 1))
-                else
-                  echo "[OK] ${dest}"
-                fi
-              done
-
-              # ─── Dynamic dependabot.yml generation ────────────────────────
-              echo ""
-              echo "--- Dynamic dependabot.yml ---"
-              DEPENDABOT_DRIFT=false
-
-              # Detect ecosystems in target repo
-              HAS_NPM=false; HAS_PIP=false; HAS_DOCKER=false
-              if gh api "repos/${OWNER}/${REPO}/contents/package.json" --jq '.sha' >/dev/null 2>&1; then
-                HAS_NPM=true; echo "[INFO] Detected package.json → npm"
-              fi
-              if gh api "repos/${OWNER}/${REPO}/contents/Dockerfile" --jq '.sha' >/dev/null 2>&1; then
-                HAS_DOCKER=true; echo "[INFO] Detected Dockerfile → docker"
-              fi
-              for pyfile in requirements.txt pyproject.toml setup.py; do
-                if gh api "repos/${OWNER}/${REPO}/contents/${pyfile}" --jq '.sha' >/dev/null 2>&1; then
-                  HAS_PIP=true; echo "[INFO] Detected ${pyfile} → pip"; break
-                fi
-              done
-
-              # Build dependabot.yml content
-              DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
-
-              if [ "$HAS_NPM" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
-              fi
-
-              if [ "$HAS_PIP" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
-              fi
-
-              if [ "$HAS_DOCKER" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
-              fi
-
-              DEPBOT="${DEPBOT}\n"
-              GENERATED_DEPENDABOT=$(printf '%b' "$DEPBOT")
-
-              # Compare with current dependabot.yml in target repo
-              CURRENT_DEPBOT_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" 2>/dev/null) || true
-              if [ -n "$CURRENT_DEPBOT_RESPONSE" ]; then
-                CURRENT_DEPENDABOT=$(echo "$CURRENT_DEPBOT_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
-              else
-                CURRENT_DEPENDABOT=""
-              fi
-
-              if [ "$GENERATED_DEPENDABOT" != "$CURRENT_DEPENDABOT" ]; then
-                echo "[DRIFT] .github/dependabot.yml needs update"
-                DEPENDABOT_DRIFT=true
-                DRIFT_FILES="${DRIFT_FILES}.github/dependabot.yml\n"
-                DRIFT_COUNT=$((DRIFT_COUNT + 1))
-              else
-                echo "[OK] .github/dependabot.yml"
-              fi
-
-              if [ "$DRIFT_COUNT" -eq 0 ]; then
-                echo "[OK] All managed files match canonical"
-              else
-                echo "[INFO] Found ${DRIFT_COUNT} drifted file(s)"
-
-                # Check for existing open sync PR (idempotency)
-                EXISTING_PR=$(gh pr list --repo "${OWNER}/${REPO}" \
-                  --head "governance/sync-managed-files" \
-                  --state open --json number --jq '.[0].number // empty' 2>/dev/null) || true
-                if [ -n "$EXISTING_PR" ]; then
-                  echo "[SKIP] Open sync PR #${EXISTING_PR} already exists"
-                else
-                  # Create issue
-                  DRIFT_LIST=$(printf '%b' "$DRIFT_FILES" | sed '/^$/d' | sed 's/^/- /')
-                  ISSUE_BODY=$(printf 'The following managed files have drifted from the canonical source in `%s`:\n\n%s\n\nThis issue was created automatically by the governance enforcement workflow.' \
-                    "$SOURCE_REPO" "$DRIFT_LIST")
-                  ISSUE_NUM=$(gh issue create --repo "${OWNER}/${REPO}" \
-                    --title "chore: sync managed files from governance template" \
-                    --body "$ISSUE_BODY" | grep -o '[0-9]*$')
-                  echo "[OK] Created issue #${ISSUE_NUM}"
-
-                  # Create branch from main HEAD (try create, fall back to update if concurrent run created it)
-                  MAIN_SHA=$(gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
-                  if ! gh api "repos/${OWNER}/${REPO}/git/refs" --method POST \
-                    --input <(jq -n --arg sha "$MAIN_SHA" \
-                      '{"ref":"refs/heads/governance/sync-managed-files","sha":$sha}') >/dev/null 2>&1; then
-                    gh api "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" \
-                      --method PATCH --input <(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}') >/dev/null
-                  fi
-                  echo "[OK] Created or updated branch governance/sync-managed-files"
-
-                  # Commit each drifted file to the branch
-                  for dest_file in $(printf '%b' "$DRIFT_FILES" | sed '/^$/d'); do
-                    # Skip dynamic dependabot.yml — committed separately below
-                    if [ "$dest_file" = ".github/dependabot.yml" ]; then
-                      continue
-                    fi
-
-                    # Look up the source path from the manifest
-                    src_file=$(echo "$MANAGED_FILES" | jq -r --arg d "$dest_file" '.files[] | select(.dest == $d) | .src')
-
-                    # Get canonical content as base64
-                    B64=$(gh api "repos/${SOURCE_REPO}/contents/${src_file}" --jq '.content' | tr -d '\n')
-
-                    # Check if file exists downstream (need SHA for update)
-                    FILE_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --jq '.sha' 2>/dev/null) || true
-
-                    if [ -n "$FILE_SHA" ]; then
-                      # Update existing file
-                      jq -n --arg msg "chore: sync ${dest_file}" \
-                            --arg content "$B64" \
-                            --arg sha "$FILE_SHA" \
-                            --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT --input - >/dev/null
-                    else
-                      # Create new file
-                      jq -n --arg msg "chore: sync ${dest_file}" \
-                            --arg content "$B64" \
-                            --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT --input - >/dev/null
-                    fi
-                    echo "[OK] Synced ${dest_file}"
-                  done
-
-                  # Commit dynamic dependabot.yml if drifted
-                  if [ "$DEPENDABOT_DRIFT" = true ]; then
-                    DEPBOT_B64=$(printf '%s' "$GENERATED_DEPENDABOT" | base64 -w 0)
-                    DEPBOT_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --jq '.sha' 2>/dev/null) || true
-
-                    if [ -n "$DEPBOT_SHA" ]; then
-                      jq -n --arg msg "chore: update .github/dependabot.yml" \
-                            --arg content "$DEPBOT_B64" \
-                            --arg sha "$DEPBOT_SHA" \
-                            --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
-                    else
-                      jq -n --arg msg "chore: create .github/dependabot.yml" \
-                            --arg content "$DEPBOT_B64" \
-                            --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
-                    fi
-                    echo "[OK] Synced .github/dependabot.yml (dynamic)"
-                  fi
-
-                  # Create PR
-                  PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \
-                    "$ISSUE_NUM" "$SOURCE_REPO" "$DRIFT_LIST")
-                  PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
-                    --head governance/sync-managed-files \
-                    --title "chore: sync managed files from governance template" \
-                    --body "$PR_BODY")
-                  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
-                  echo "[OK] Created sync PR #${PR_NUM}"
-
-                  SYNC_PR_CREATED=true
-                fi
-              fi
-            fi
-          fi
-
-          # ─── Phase 8: Verify ──────────────────────────────────────────────────
-          echo ""
-          echo "=== Phase 8: Verify ==="
+          echo "=== Phase 7: Verify ==="
 
           VERIFY_FAILED=false
 
@@ -570,17 +360,6 @@ jobs:
                 echo "[FAIL] pages.build_type: expected=$DESIRED_BUILD_TYPE actual=$ACTUAL_BUILD_TYPE"
                 VERIFY_FAILED=true
               fi
-            fi
-          fi
-
-          # Verify managed files (Phase 7 follow-up)
-          if [ -n "$MANAGED_FILES" ] && [ "${OWNER}/${REPO}" != "$SOURCE_REPO" ]; then
-            if [ "$SYNC_PR_CREATED" = true ]; then
-              echo "[OK] Sync PR created — managed files will match after merge"
-            elif [ -n "$EXISTING_PR" ]; then
-              echo "[OK] Sync PR #${EXISTING_PR} pending — managed files will match after merge"
-            else
-              echo "[OK] Managed files verified"
             fi
           fi
 

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -1,0 +1,290 @@
+name: Sync Managed Files
+
+on:
+  workflow_call:
+    secrets:
+      repo-sync-token:
+        description: 'PAT with contents, issues, and pull-request permissions for file sync'
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout calling repo
+        uses: actions/checkout@v6
+
+      - name: Sync managed files
+        env:
+          GH_TOKEN: ${{ secrets.repo-sync-token }}
+        run: |
+          set -euo pipefail
+
+          OWNER="${GITHUB_REPOSITORY%/*}"
+          REPO="${GITHUB_REPOSITORY#*/}"
+          CONFIG_FILE=".github/config/repo-settings.json"
+          DEFAULTS_REPO="f5xc-salesdemos/docs-control"
+          DEFAULTS_PATH=".github/config/default-repo-settings.json"
+
+          # ─── Phase 1: Validate ─────────────────────────────────────────────
+          echo "=== Phase 1: Validate ==="
+
+          if ! command -v jq &>/dev/null; then
+            echo "[ERROR] jq is not installed" >&2; exit 1
+          fi
+          if ! command -v gh &>/dev/null; then
+            echo "[ERROR] gh CLI is not installed" >&2; exit 1
+          fi
+          if ! gh auth status &>/dev/null; then
+            echo "[ERROR] gh is not authenticated" >&2; exit 1
+          fi
+
+          # Fetch universal defaults from template repo
+          echo "[INFO] Fetching defaults from ${DEFAULTS_REPO}/${DEFAULTS_PATH}..."
+          DEFAULTS=$(gh api "repos/${DEFAULTS_REPO}/contents/${DEFAULTS_PATH}" --jq '.content' | base64 -d)
+          if ! echo "$DEFAULTS" | jq empty 2>/dev/null; then
+            echo "[ERROR] Failed to fetch or parse defaults from ${DEFAULTS_REPO}" >&2; exit 1
+          fi
+          echo "[OK] Fetched universal defaults from ${DEFAULTS_REPO}"
+
+          # Deep-merge defaults with per-repo overrides
+          if [ -f "$CONFIG_FILE" ]; then
+            if ! jq empty "$CONFIG_FILE" 2>/dev/null; then
+              echo "[ERROR] Config file is not valid JSON: $CONFIG_FILE" >&2; exit 1
+            fi
+            CONFIG=$(echo "$DEFAULTS" | jq -s '.[0] * .[1]' - "$CONFIG_FILE")
+            echo "[OK] Merged defaults with per-repo overrides from $CONFIG_FILE"
+          else
+            CONFIG="$DEFAULTS"
+            echo "[OK] No per-repo overrides found — using defaults only"
+          fi
+
+          echo "[OK] Config validated for ${OWNER}/${REPO}"
+
+          # ─── Phase 2: Sync Managed Files ─────────────────────────────────────
+          echo ""
+          echo "=== Phase 2: Sync Managed Files ==="
+
+          MANAGED_FILES=$(echo "$CONFIG" | jq -c '.managed_files // empty')
+          SYNC_PR_CREATED=false
+          EXISTING_PR=""
+          SOURCE_REPO=""
+
+          if [ -z "$MANAGED_FILES" ]; then
+            echo "[SKIP] No managed_files in config"
+          else
+            SOURCE_REPO=$(echo "$MANAGED_FILES" | jq -r '.source_repo')
+
+            # Guard: skip if running in the source repo itself
+            if [ "${OWNER}/${REPO}" = "$SOURCE_REPO" ]; then
+              echo "[SKIP] Running in source repo — skipping managed file sync"
+            else
+              DRIFT_FILES=""
+              DRIFT_COUNT=0
+
+              for file_obj in $(echo "$MANAGED_FILES" | jq -c '.files[]'); do
+                src=$(echo "$file_obj" | jq -r '.src')
+                dest=$(echo "$file_obj" | jq -r '.dest')
+
+                # Fetch canonical content from source path
+                CANONICAL_RESPONSE=$(gh api "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
+                if [ -z "$CANONICAL_RESPONSE" ]; then
+                  echo "[WARN] Could not fetch canonical: ${src}"
+                  continue
+                fi
+                CANONICAL_CONTENT=$(echo "$CANONICAL_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
+
+                # Fetch downstream content at dest path (handle 404)
+                DOWNSTREAM_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/${dest}" 2>/dev/null) || true
+                if [ -z "$DOWNSTREAM_RESPONSE" ]; then
+                  echo "[DRIFT] Missing downstream: ${dest}"
+                  DRIFT_FILES="${DRIFT_FILES}${dest}\n"
+                  DRIFT_COUNT=$((DRIFT_COUNT + 1))
+                  continue
+                fi
+                DOWNSTREAM_CONTENT=$(echo "$DOWNSTREAM_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
+
+                if [ "$CANONICAL_CONTENT" != "$DOWNSTREAM_CONTENT" ]; then
+                  echo "[DRIFT] Content mismatch: ${dest}"
+                  DRIFT_FILES="${DRIFT_FILES}${dest}\n"
+                  DRIFT_COUNT=$((DRIFT_COUNT + 1))
+                else
+                  echo "[OK] ${dest}"
+                fi
+              done
+
+              # ─── Dynamic dependabot.yml generation ────────────────────────
+              echo ""
+              echo "--- Dynamic dependabot.yml ---"
+              DEPENDABOT_DRIFT=false
+
+              # Detect ecosystems in target repo
+              HAS_NPM=false; HAS_PIP=false; HAS_DOCKER=false
+              if gh api "repos/${OWNER}/${REPO}/contents/package.json" --jq '.sha' >/dev/null 2>&1; then
+                HAS_NPM=true; echo "[INFO] Detected package.json → npm"
+              fi
+              if gh api "repos/${OWNER}/${REPO}/contents/Dockerfile" --jq '.sha' >/dev/null 2>&1; then
+                HAS_DOCKER=true; echo "[INFO] Detected Dockerfile → docker"
+              fi
+              for pyfile in requirements.txt pyproject.toml setup.py; do
+                if gh api "repos/${OWNER}/${REPO}/contents/${pyfile}" --jq '.sha' >/dev/null 2>&1; then
+                  HAS_PIP=true; echo "[INFO] Detected ${pyfile} → pip"; break
+                fi
+              done
+
+              # Build dependabot.yml content
+              DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+
+              if [ "$HAS_NPM" = true ]; then
+                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              fi
+
+              if [ "$HAS_PIP" = true ]; then
+                DEPBOT="${DEPBOT}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              fi
+
+              if [ "$HAS_DOCKER" = true ]; then
+                DEPBOT="${DEPBOT}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              fi
+
+              DEPBOT="${DEPBOT}\n"
+              GENERATED_DEPENDABOT=$(printf '%b' "$DEPBOT")
+
+              # Compare with current dependabot.yml in target repo
+              CURRENT_DEPBOT_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" 2>/dev/null) || true
+              if [ -n "$CURRENT_DEPBOT_RESPONSE" ]; then
+                CURRENT_DEPENDABOT=$(echo "$CURRENT_DEPBOT_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
+              else
+                CURRENT_DEPENDABOT=""
+              fi
+
+              if [ "$GENERATED_DEPENDABOT" != "$CURRENT_DEPENDABOT" ]; then
+                echo "[DRIFT] .github/dependabot.yml needs update"
+                DEPENDABOT_DRIFT=true
+                DRIFT_FILES="${DRIFT_FILES}.github/dependabot.yml\n"
+                DRIFT_COUNT=$((DRIFT_COUNT + 1))
+              else
+                echo "[OK] .github/dependabot.yml"
+              fi
+
+              if [ "$DRIFT_COUNT" -eq 0 ]; then
+                echo "[OK] All managed files match canonical"
+              else
+                echo "[INFO] Found ${DRIFT_COUNT} drifted file(s)"
+
+                # Check for existing open sync PR (idempotency)
+                EXISTING_PR=$(gh pr list --repo "${OWNER}/${REPO}" \
+                  --head "governance/sync-managed-files" \
+                  --state open --json number --jq '.[0].number // empty' 2>/dev/null) || true
+                if [ -n "$EXISTING_PR" ]; then
+                  echo "[SKIP] Open sync PR #${EXISTING_PR} already exists"
+                else
+                  # Create issue
+                  DRIFT_LIST=$(printf '%b' "$DRIFT_FILES" | sed '/^$/d' | sed 's/^/- /')
+                  ISSUE_BODY=$(printf 'The following managed files have drifted from the canonical source in `%s`:\n\n%s\n\nThis issue was created automatically by the governance enforcement workflow.' \
+                    "$SOURCE_REPO" "$DRIFT_LIST")
+                  ISSUE_NUM=$(gh issue create --repo "${OWNER}/${REPO}" \
+                    --title "chore: sync managed files from governance template" \
+                    --body "$ISSUE_BODY" | grep -o '[0-9]*$')
+                  echo "[OK] Created issue #${ISSUE_NUM}"
+
+                  # Create branch from main HEAD (try create, fall back to update if concurrent run created it)
+                  MAIN_SHA=$(gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
+                  if ! gh api "repos/${OWNER}/${REPO}/git/refs" --method POST \
+                    --input <(jq -n --arg sha "$MAIN_SHA" \
+                      '{"ref":"refs/heads/governance/sync-managed-files","sha":$sha}') >/dev/null 2>&1; then
+                    gh api "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" \
+                      --method PATCH --input <(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}') >/dev/null
+                  fi
+                  echo "[OK] Created or updated branch governance/sync-managed-files"
+
+                  # Commit each drifted file to the branch
+                  for dest_file in $(printf '%b' "$DRIFT_FILES" | sed '/^$/d'); do
+                    # Skip dynamic dependabot.yml — committed separately below
+                    if [ "$dest_file" = ".github/dependabot.yml" ]; then
+                      continue
+                    fi
+
+                    # Look up the source path from the manifest
+                    src_file=$(echo "$MANAGED_FILES" | jq -r --arg d "$dest_file" '.files[] | select(.dest == $d) | .src')
+
+                    # Get canonical content as base64
+                    B64=$(gh api "repos/${SOURCE_REPO}/contents/${src_file}" --jq '.content' | tr -d '\n')
+
+                    # Check if file exists downstream (need SHA for update)
+                    FILE_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --jq '.sha' 2>/dev/null) || true
+
+                    if [ -n "$FILE_SHA" ]; then
+                      # Update existing file
+                      jq -n --arg msg "chore: sync ${dest_file}" \
+                            --arg content "$B64" \
+                            --arg sha "$FILE_SHA" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT --input - >/dev/null
+                    else
+                      # Create new file
+                      jq -n --arg msg "chore: sync ${dest_file}" \
+                            --arg content "$B64" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT --input - >/dev/null
+                    fi
+                    echo "[OK] Synced ${dest_file}"
+                  done
+
+                  # Commit dynamic dependabot.yml if drifted
+                  if [ "$DEPENDABOT_DRIFT" = true ]; then
+                    DEPBOT_B64=$(printf '%s' "$GENERATED_DEPENDABOT" | base64 -w 0)
+                    DEPBOT_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --jq '.sha' 2>/dev/null) || true
+
+                    if [ -n "$DEPBOT_SHA" ]; then
+                      jq -n --arg msg "chore: update .github/dependabot.yml" \
+                            --arg content "$DEPBOT_B64" \
+                            --arg sha "$DEPBOT_SHA" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
+                    else
+                      jq -n --arg msg "chore: create .github/dependabot.yml" \
+                            --arg content "$DEPBOT_B64" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
+                    fi
+                    echo "[OK] Synced .github/dependabot.yml (dynamic)"
+                  fi
+
+                  # Create PR
+                  PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \
+                    "$ISSUE_NUM" "$SOURCE_REPO" "$DRIFT_LIST")
+                  PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
+                    --head governance/sync-managed-files \
+                    --title "chore: sync managed files from governance template" \
+                    --body "$PR_BODY")
+                  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
+                  echo "[OK] Created sync PR #${PR_NUM}"
+
+                  SYNC_PR_CREATED=true
+                fi
+              fi
+            fi
+          fi
+
+          # ─── Phase 3: Verify ──────────────────────────────────────────────────
+          echo ""
+          echo "=== Phase 3: Verify ==="
+
+          if [ -n "$MANAGED_FILES" ] && [ "${OWNER}/${REPO}" != "$SOURCE_REPO" ]; then
+            if [ "$SYNC_PR_CREATED" = true ]; then
+              echo "[OK] Sync PR created — managed files will match after merge"
+            elif [ -n "$EXISTING_PR" ]; then
+              echo "[OK] Sync PR #${EXISTING_PR} pending — managed files will match after merge"
+            else
+              echo "[OK] Managed files verified"
+            fi
+          else
+            echo "[SKIP] No managed files to verify"
+          fi
+
+          echo "[OK] Managed file sync complete"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,7 +5,7 @@ This runbook documents how to onboard a downstream repo into the docs-control go
 ## Prerequisites
 
 - The repo is owned by `f5xc-salesdemos` on GitHub
-- You have the `REPO_ADMIN_TOKEN` secret configured in the downstream repo
+- You have the `REPO_SETTINGS_TOKEN` and `REPO_SYNC_TOKEN` secrets configured in the downstream repo
 - The docs-builder Docker image (`ghcr.io/f5xc-salesdemos/docs-builder:latest`) supports Astro Starlight builds
 - GitHub Pages is enabled (or will be enabled by enforcement)
 

--- a/docs/02-governance-reference.mdx
+++ b/docs/02-governance-reference.mdx
@@ -20,7 +20,8 @@ The docs-control repository serves two purposes:
 | `.github/config/default-repo-settings.json` | Universal defaults: repo settings, branch protection, Actions permissions, Pages config, and the managed files manifest |
 | `.github/config/downstream-repos.json` | Registry of enrolled downstream repositories |
 | `.github/config/repo-settings.json` | Per-repo override template (checked into each downstream repo) |
-| `.github/workflows/enforce-repo-settings.yml` | Reusable 8-phase enforcement workflow |
+| `.github/workflows/enforce-repo-settings.yml` | Reusable 7-phase enforcement workflow (repo settings, branch protection, Actions, topics, Pages) |
+| `.github/workflows/sync-managed-files.yml` | Reusable 3-phase managed file sync workflow (file comparison, issue/PR creation) |
 | `.github/workflows/dispatch-downstream.yml` | Dispatch trigger that pushes enforcement to all downstream repos |
 | `.github/workflows/github-pages-deploy.yml` | Reusable docs build and deploy workflow |
 | `.github/workflows/require-linked-issue.yml` | PR check requiring a linked GitHub issue |
@@ -29,33 +30,50 @@ The docs-control repository serves two purposes:
 
 ## Enforcement Pipeline
 
-The reusable workflow at `.github/workflows/enforce-repo-settings.yml` runs in 8 phases. Each phase is idempotent: it compares the desired state against the current state and only makes changes when drift is detected.
+Enforcement is split into two reusable workflows that run as parallel jobs, each with its own least-privilege token:
 
-### Phase 1: Validate
+- **`enforce-repo-settings.yml`** uses `REPO_SETTINGS_TOKEN` (Administration R/W, Pages R/W, Contents Read, Metadata Read)
+- **`sync-managed-files.yml`** uses `REPO_SYNC_TOKEN` (Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read)
+
+### enforce-repo-settings.yml (7 phases)
+
+Each phase is idempotent: it compares the desired state against the current state and only makes changes when drift is detected.
+
+#### Phase 1: Validate
 
 Fetches the universal defaults from this template repo via the GitHub API. If the downstream repo has a `.github/config/repo-settings.json` file, it is deep-merged on top of the defaults (per-repo values win). The merged config drives all subsequent phases.
 
-### Phase 2: Apply repository settings
+#### Phase 2: Apply repository settings
 
 Compares each key in the `repository` object (visibility, merge options, branch-on-delete, etc.) against the repo's current settings. Patches only the keys that have drifted.
 
-### Phase 3: Apply Actions permissions
+#### Phase 3: Apply Actions permissions
 
 Compares the `actions_permissions` object (default workflow permissions, PR review approval) against the current Actions workflow permissions and updates if drifted.
 
-### Phase 4: Apply branch protection
+#### Phase 4: Apply branch protection
 
 Iterates over the `branch_protection` array. For each branch, compares enforce-admins, required status checks, required reviews, restrictions, and boolean flags (linear history, force pushes, deletions, etc.). Creates or updates protection rules as needed.
 
-### Phase 5: Apply topics
+#### Phase 5: Apply topics
 
 Compares the `topics` array against the repo's current topics and replaces them if drifted.
 
-### Phase 6: Apply Pages
+#### Phase 6: Apply Pages
 
 Enables GitHub Pages with the configured `build_type` (default: `workflow`) if not already enabled, or updates the build type if it has drifted.
 
-### Phase 7: Sync managed files
+#### Phase 7: Verify
+
+Re-reads all settings via the GitHub API and compares them against the desired state. Fails the workflow if any setting does not match after the apply phases.
+
+### sync-managed-files.yml (3 phases)
+
+#### Phase 1: Validate
+
+Loads and merges the config independently (same logic as the settings workflow) since the two workflows run as separate jobs with separate tokens.
+
+#### Phase 2: Sync managed files
 
 Compares each file listed in the `managed_files.files` array against the canonical version in this template repo. If any file has drifted or is missing, the workflow:
 
@@ -66,9 +84,9 @@ Compares each file listed in the `managed_files.files` array against the canonic
 
 If a sync PR is already open, the phase skips to avoid duplicates.
 
-### Phase 8: Verify
+#### Phase 3: Verify
 
-Re-reads all settings via the GitHub API and compares them against the desired state. Fails the workflow if any setting does not match after the apply phases.
+Confirms that a sync PR was created (or already exists) for any drifted files, or that all managed files match their canonical versions.
 
 ## Managed Files Manifest
 
@@ -82,7 +100,7 @@ When files in this template repo change on the `main` branch, the dispatch workf
 
 The trigger paths are listed in that workflow file. They cover the config directory, the `workflows/` caller templates, the reusable workflows, issue/PR templates, and root-level managed files like `CONTRIBUTING.md`, `CLAUDE.md`, `.editorconfig`, `.gitignore`, and `LICENSE`.
 
-The dispatch reads the downstream repo list from `.github/config/downstream-repos.json` and calls `gh workflow run enforce-repo-settings.yml` for each repo using the `REPO_ADMIN_TOKEN` secret.
+The dispatch reads the downstream repo list from `.github/config/downstream-repos.json` and calls `gh workflow run enforce-repo-settings.yml` for each repo using the `REPO_SETTINGS_TOKEN` secret.
 
 ## Downstream Repos
 
@@ -100,7 +118,7 @@ The `workflows/` directory contains workflow files that downstream repos copy in
 
 | Template | Calls | Trigger |
 |---|---|---|
-| `workflows/enforce-repo-settings.yml` | `.github/workflows/enforce-repo-settings.yml` | Schedule (every 6 hours), push to `.github/config/**`, manual dispatch |
+| `workflows/enforce-repo-settings.yml` | `.github/workflows/enforce-repo-settings.yml` and `.github/workflows/sync-managed-files.yml` (parallel jobs) | Schedule (every 6 hours), push to `.github/config/**`, manual dispatch |
 | `workflows/github-pages-deploy.yml` | `.github/workflows/github-pages-deploy.yml` | Push to `docs/**` on main, manual dispatch |
 
 The `require-linked-issue.yml` workflow is synced directly as a managed file (not via a caller template) because it runs identically in every repo.

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -17,7 +17,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  enforce:
+  enforce-settings:
     uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
     secrets:
-      repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}
+      repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+
+  sync-files:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    secrets:
+      repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

- Extract managed file sync (Phase 7) into new `sync-managed-files.yml` reusable workflow
- Strip `enforce-repo-settings.yml` to 7 phases (settings only), rename secret to `repo-settings-token`
- Update caller template to invoke both workflows as parallel jobs with separate tokens
- Add new workflow to dispatch trigger paths, update dispatch token reference
- Update governance docs and migration guide to reflect two-token model

Closes #3

## Test plan

- [ ] Validate YAML syntax of all workflow files
- [ ] Confirm both reusable workflows have `workflow_call` trigger with correct secret inputs
- [ ] Confirm caller template has two parallel jobs with correct `uses:` and `secrets:` references
- [ ] Confirm dispatch paths include the new workflow file
- [ ] Configure `REPO_SETTINGS_TOKEN` and `REPO_SYNC_TOKEN` in a downstream repo before merging
- [ ] After merge, verify enforcement runs successfully in a downstream repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)