### PR TITLE
fix: remove PR approval requirement from branch protection

### DIFF
--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -29,12 +29,7 @@
         "strict": false,
         "contexts": ["Check linked issues"]
       },
-      "required_pull_request_reviews": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews": false,
-        "require_code_owner_reviews": false,
-        "require_last_push_approval": false
-      },
+      "required_pull_request_reviews": null,
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,


### PR DESCRIPTION
## Summary

- Set `required_pull_request_reviews` to `null` in `default-repo-settings.json` to completely remove the review gate from branch protection
- Having the review object present (even with `required_approving_review_count: 0`) causes AI assistants to poll indefinitely waiting for human approval instead of merging via `gh pr merge`

## Test plan

- [x] JSON syntax validated (`python -c "import json; json.load(..."`)
- [ ] After merge, dispatch enforcement to downstream repos
- [ ] Confirm `gh api repos/f5xc-salesdemos/<repo>/branches/main/protection --jq '.required_pull_request_reviews'` returns `null`
- [ ] Verify `gh pr merge` works without approval on a downstream repo

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)