### PR TITLE
feat: add push trigger to enforce-repo-settings for self-enforcement

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,11 +1,18 @@
 name: Enforce Repository Settings
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/repo-settings.json'
   workflow_call:
     secrets:
       repo-settings-token:
         description: 'PAT with admin permissions for repository settings'
         required: true
+
+permissions:
+  contents: read
 
 jobs:
   enforce:
@@ -16,7 +23,7 @@ jobs:
 
       - name: Enforce repository settings
         env:
-          GH_TOKEN: ${{ secrets.repo-settings-token }}
+          GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Adds a `push` trigger (on `main`, filtered to `.github/config/repo-settings.json`) to the reusable `enforce-repo-settings.yml` workflow so docs-control enforces its own repository settings when the config changes
- Adds a `permissions: contents: read` block for least-privilege on push-triggered runs
- Uses `secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN` fallback so the workflow works both via `workflow_call` (downstream repos pass their secret) and via direct `push` (uses repo-level secret)

Closes #14

## Test plan

- [ ] PR CI checks pass
- [ ] After merge, verify `enforce-repo-settings` workflow triggers on the merge commit (push to `main` includes the config path)
- [ ] Verify downstream repos are unaffected — `workflow_call` path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)