### PR TITLE
test: verify self-enforcement push trigger on repo-settings.json

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Central repo-settings config — enforced by enforce-repo-settings.yml",
   "repository": {
     "private": false,
     "has_issues": true,


### PR DESCRIPTION
## Summary

- Adds a `_comment` field to `repo-settings.json` — a no-op that doesn't affect enforcement
- Purpose: verify that `enforce-repo-settings.yml` triggers via push when `repo-settings.json` is in the changeset (feature added in #15)

Closes #16

## Test plan

- [ ] PR CI passes
- [ ] After merge, `Enforce Repository Settings` workflow triggers on the merge commit (push path filter matches)
- [ ] Workflow completes successfully (self-enforcement works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)