### PR TITLE
fix: instruct Claude Code to merge its own PRs after CI passes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,18 +21,18 @@ workflows succeed, and local branches are cleaned.
    `gh pr checks <NUMBER>`, fix locally, push to
    trigger re-runs
 
-### Waiting for Merge (Step 6)
+### Merging (Step 6)
 
-6. **Wait for merge** — PRs require manual approval.
-   After CI checks pass, wait for a reviewer to
-   approve and merge. Poll until the PR state is
-   `MERGED`:
+6. **Merge after CI passes** — once all status checks
+   are green, merge the PR yourself. Do not wait for
+   manual approval (none is required).
 
    ```
-   gh pr view <NUMBER> --json state --jq '.state'
+   gh pr checks <NUMBER> --watch
+   gh pr merge <NUMBER> --squash --delete-branch
    ```
 
-   If the PR is not merging, check for issues:
+   If the merge fails, check why:
 
    ```
    gh pr view <NUMBER> --json mergeable,mergeStateStatus


### PR DESCRIPTION
## Summary
- Replace passive "Waiting for Merge" Step 6 with active "Merging" instructions
- Claude Code now merges PRs itself after CI passes instead of polling for manual approval
- Aligns CLAUDE.md with actual branch protection (no PR review required)

Closes #18

## Test plan
- [ ] PR CI (`Check linked issues`) passes
- [ ] After merge, post-merge workflows succeed
- [ ] New instructions work correctly in next task — Claude Code merges its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)