### PR TITLE
fix: add delay before polling CI checks in auto-merge

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -165,7 +165,7 @@ jobs:
                   --state open --json number --jq '.[0].number // empty' 2>/dev/null) || true
                 if [ -n "$EXISTING_PR" ]; then
                   echo "[INFO] Open sync PR #${EXISTING_PR} already exists — attempting merge"
-                  if gh pr checks "${EXISTING_PR}" --repo "${OWNER}/${REPO}" --watch --fail-fast 2>/dev/null; then
+                  if gh pr checks "${EXISTING_PR}" --repo "${OWNER}/${REPO}" --watch; then
                     echo "[INFO] CI passed — merging PR #${EXISTING_PR}..."
                     if gh pr merge "${EXISTING_PR}" --repo "${OWNER}/${REPO}" --squash --delete-branch; then
                       echo "[OK] Merged existing sync PR #${EXISTING_PR}"
@@ -264,7 +264,8 @@ jobs:
 
                   # ─── Auto-merge governance PR ───────────────────────────
                   echo "[INFO] Waiting for CI checks on PR #${PR_NUM}..."
-                  if gh pr checks "${PR_NUM}" --repo "${OWNER}/${REPO}" --watch --fail-fast 2>/dev/null; then
+                  sleep 15  # Give GitHub time to register check runs
+                  if gh pr checks "${PR_NUM}" --repo "${OWNER}/${REPO}" --watch --fail-fast; then
                     echo "[INFO] CI passed — merging PR #${PR_NUM}..."
                     if gh pr merge "${PR_NUM}" --repo "${OWNER}/${REPO}" --squash --delete-branch; then
                       echo "[OK] Merged sync PR #${PR_NUM}"


### PR DESCRIPTION
Closes #24

## Summary
- Add `sleep 15` before `gh pr checks` on new-PR path to let GitHub register check runs
- Remove `--fail-fast` on existing-PR path (checks may still be running)
- Remove `2>/dev/null` so errors are visible in workflow logs

Fixes timing issue observed in docs-theme PR #27 where auto-merge skipped because checks weren't registered yet.

## Test plan
- [ ] PR CI passes on docs-control
- [ ] After merge, re-trigger enforcement on docs-theme
- [ ] Verify existing PR #27 gets merged via the existing-PR path
- [ ] If no open PR exists, verify new PR path creates and merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)