### PR TITLE
feat: register f5xc-salesdemos/docs as downstream repo

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -8,5 +8,10 @@
     "label": "XC Docs Theme",
     "url": "https://f5xc-salesdemos.github.io/docs-theme/llms-full.txt",
     "description": "Shared branding and styling for F5 Distributed Cloud documentation sites"
+  },
+  {
+    "label": "F5 XC Docs",
+    "url": "https://f5xc-salesdemos.github.io/docs/llms-full.txt",
+    "description": "Organization landing page for F5 Distributed Cloud documentation"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -1,4 +1,5 @@
 [
   "f5xc-salesdemos/docs-builder",
-  "f5xc-salesdemos/docs-theme"
+  "f5xc-salesdemos/docs-theme",
+  "f5xc-salesdemos/docs"
 ]


### PR DESCRIPTION
Closes #28

## Summary
- Add `f5xc-salesdemos/docs` to `downstream-repos.json` so governance enforcement dispatches to it
- Add docs site entry to `docs-sites.json` for the organization landing page

## Test plan
- [ ] Verify JSON files are valid
- [ ] Merge and monitor `Dispatch Downstream Enforcement` workflow
- [ ] Confirm enforcement dispatched to all three downstream repos including `docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)