### PR TITLE
fix: detect required_status_checks drift in all directions

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -152,12 +152,20 @@ jobs:
               fi
 
               desired_checks=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_status_checks')
-              if [ "$desired_checks" = "null" ]; then
-                current_checks=$(echo "$CURRENT_PROTECTION" | jq -c '.required_status_checks')
-                if [ "$current_checks" != "null" ]; then
-                  echo "[WARN] Drift in required_status_checks"
-                  PROTECTION_DRIFT=true
-                fi
+              current_checks_raw=$(echo "$CURRENT_PROTECTION" | jq -c '.required_status_checks')
+              if [ "$current_checks_raw" != "null" ]; then
+                current_checks=$(echo "$current_checks_raw" | jq -c '{strict: .strict, contexts: (.contexts | sort)}')
+              else
+                current_checks="null"
+              fi
+              if [ "$desired_checks" != "null" ]; then
+                desired_checks_norm=$(echo "$desired_checks" | jq -c '{strict: .strict, contexts: (.contexts | sort)}')
+              else
+                desired_checks_norm="null"
+              fi
+              if [ "$desired_checks_norm" != "$current_checks" ]; then
+                echo "[WARN] Drift in required_status_checks"
+                PROTECTION_DRIFT=true
               fi
 
               desired_reviews=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_pull_request_reviews')


### PR DESCRIPTION
## Summary
- Replace one-directional `required_status_checks` drift check with symmetric comparison
- Normalize both desired and current values (extract `strict` and sorted `contexts`) before comparing, filtering out extra API fields
- Covers all three previously missed cases: desired non-null / current null, both non-null with differing contexts, both non-null with differing `strict`

Closes #30

## Test plan
- [ ] CI passes on this PR
- [ ] Post-merge `enforce-repo-settings` runs on `docs`, `docs-builder`, and `docs-theme` without false positives
- [ ] Optionally: temporarily remove `required_status_checks` via API on a test repo, re-run enforce, confirm drift is detected and restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)