### PR TITLE
fix: make require-linked-issue.yml a reusable workflow

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -52,7 +52,7 @@
     "files": [
       {"src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml"},
       {"src": "workflows/enforce-repo-settings.yml", "dest": ".github/workflows/enforce-repo-settings.yml"},
-      {"src": ".github/workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml"},
+      {"src": "workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml"},
       {"src": ".github/PULL_REQUEST_TEMPLATE.md", "dest": ".github/PULL_REQUEST_TEMPLATE.md"},
       {"src": ".github/ISSUE_TEMPLATE/bug_report.md", "dest": ".github/ISSUE_TEMPLATE/bug_report.md"},
       {"src": ".github/ISSUE_TEMPLATE/feature_request.md", "dest": ".github/ISSUE_TEMPLATE/feature_request.md"},

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -3,6 +3,7 @@ name: Require Linked Issue
 on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
+  workflow_call:
 
 permissions:
   issues: read

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -1,0 +1,17 @@
+name: Require Linked Issue
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-linked-issue:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main


### PR DESCRIPTION
## Summary
- Add `workflow_call` trigger to `.github/workflows/require-linked-issue.yml` so it can be used as a reusable workflow
- Create thin caller `workflows/require-linked-issue.yml` that downstream repos receive via sync
- Update `repo-settings.json` managed_files source from `.github/workflows/` to `workflows/`

This aligns `require-linked-issue` with the caller→reusable pattern already used by `enforce-repo-settings` and `github-pages-deploy`.

Closes #32

## Test plan
- [ ] PR CI passes — `Check linked issues` status check still works on docs-control via `pull_request_target`
- [ ] Post-merge: `sync-managed-files` detects the new caller content and creates sync PRs on downstream repos
- [ ] After sync PRs merge, downstream repos' `require-linked-issue.yml` is a thin caller referencing the reusable

🤖 Generated with [Claude Code](https://claude.com/claude-code)