### PR TITLE
feat: onboard 12 downstream repos to governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -13,5 +13,65 @@
     "label": "F5 XC Docs",
     "url": "https://f5xc-salesdemos.github.io/docs/llms-full.txt",
     "description": "Organization landing page for F5 Distributed Cloud documentation"
+  },
+  {
+    "label": "Administration",
+    "url": "https://f5xc-salesdemos.github.io/administration/llms-full.txt",
+    "description": "F5 XC administration and tenant management"
+  },
+  {
+    "label": "NGINX",
+    "url": "https://f5xc-salesdemos.github.io/nginx/llms-full.txt",
+    "description": "F5 XC NGINX integration and configuration"
+  },
+  {
+    "label": "Observability",
+    "url": "https://f5xc-salesdemos.github.io/observability/llms-full.txt",
+    "description": "F5 XC observability and monitoring"
+  },
+  {
+    "label": "Web App Scanning",
+    "url": "https://f5xc-salesdemos.github.io/was/llms-full.txt",
+    "description": "F5 XC web application scanning"
+  },
+  {
+    "label": "Multi-Cloud Networking",
+    "url": "https://f5xc-salesdemos.github.io/mcn/llms-full.txt",
+    "description": "F5 XC multi-cloud networking"
+  },
+  {
+    "label": "DNS",
+    "url": "https://f5xc-salesdemos.github.io/dns/llms-full.txt",
+    "description": "F5 XC DNS management"
+  },
+  {
+    "label": "CDN",
+    "url": "https://f5xc-salesdemos.github.io/cdn/llms-full.txt",
+    "description": "F5 XC content delivery network"
+  },
+  {
+    "label": "Bot Standard",
+    "url": "https://f5xc-salesdemos.github.io/bot-standard/llms-full.txt",
+    "description": "F5 XC standard bot defense"
+  },
+  {
+    "label": "Bot Advanced",
+    "url": "https://f5xc-salesdemos.github.io/bot-advanced/llms-full.txt",
+    "description": "F5 XC advanced bot defense"
+  },
+  {
+    "label": "DDoS",
+    "url": "https://f5xc-salesdemos.github.io/ddos/llms-full.txt",
+    "description": "F5 XC DDoS protection"
+  },
+  {
+    "label": "WAAP",
+    "url": "https://f5xc-salesdemos.github.io/waap/llms-full.txt",
+    "description": "F5 XC web application and API protection"
+  },
+  {
+    "label": "Client-Side Defense",
+    "url": "https://f5xc-salesdemos.github.io/csd/llms-full.txt",
+    "description": "F5 XC client-side defense"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -1,5 +1,17 @@
 [
   "f5xc-salesdemos/docs-builder",
   "f5xc-salesdemos/docs-theme",
-  "f5xc-salesdemos/docs"
+  "f5xc-salesdemos/docs",
+  "f5xc-salesdemos/administration",
+  "f5xc-salesdemos/nginx",
+  "f5xc-salesdemos/observability",
+  "f5xc-salesdemos/was",
+  "f5xc-salesdemos/mcn",
+  "f5xc-salesdemos/dns",
+  "f5xc-salesdemos/cdn",
+  "f5xc-salesdemos/bot-standard",
+  "f5xc-salesdemos/bot-advanced",
+  "f5xc-salesdemos/ddos",
+  "f5xc-salesdemos/waap",
+  "f5xc-salesdemos/csd"
 ]


### PR DESCRIPTION
## Summary

- Register 12 new F5 XC SalesDemos documentation repos in docs-control governance
- Add all 12 repos to `downstream-repos.json` for enforcement dispatch
- Add all 12 entries to `docs-sites.json` for documentation site registry

New repos: administration, nginx, observability, was, mcn, dns, cdn, bot-standard, bot-advanced, ddos, waap, csd

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, `dispatch-downstream.yml` fires across all 15 repos
- [ ] Each new repo receives sync PRs with managed files
- [ ] Spot-check repo settings enforcement on a few repos

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)