### PR TITLE
feat: replace waap with waf and api in governance config

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -65,9 +65,14 @@
     "description": "F5 XC DDoS protection"
   },
   {
-    "label": "WAAP",
-    "url": "https://f5xc-salesdemos.github.io/waap/llms-full.txt",
-    "description": "F5 XC web application and API protection"
+    "label": "WAF",
+    "url": "https://f5xc-salesdemos.github.io/waf/llms-full.txt",
+    "description": "F5 XC web application firewall"
+  },
+  {
+    "label": "API Security",
+    "url": "https://f5xc-salesdemos.github.io/api/llms-full.txt",
+    "description": "F5 XC API security"
   },
   {
     "label": "Client-Side Defense",

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -12,6 +12,7 @@
   "f5xc-salesdemos/bot-standard",
   "f5xc-salesdemos/bot-advanced",
   "f5xc-salesdemos/ddos",
-  "f5xc-salesdemos/waap",
+  "f5xc-salesdemos/waf",
+  "f5xc-salesdemos/api",
   "f5xc-salesdemos/csd"
 ]


### PR DESCRIPTION
## Summary
- Remove `waap` from downstream repos and docs sites config
- Add `waf` (Web Application Firewall) and `api` (API Security) as replacements
- Both new repos already created and initialized with governance workflows

Closes #39

## Test plan
- [ ] CI checks pass on this PR
- [ ] Post-merge enforcement dispatches to waf and api repos
- [ ] Pages deploy succeeds on both new repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)