### PR TITLE
feat: add templated README.md to governance sync

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -20,6 +20,7 @@ on:
       - '.gitignore'
       - 'LICENSE'
       - '.pre-commit-config.yaml'
+      - 'README.md.tpl'
 
 permissions:
   contents: read

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -154,6 +154,64 @@ jobs:
                 echo "[OK] .github/dependabot.yml"
               fi
 
+              # ─── Dynamic README.md generation ──────────────────────────────
+              echo ""
+              echo "--- Dynamic README.md ---"
+              README_DRIFT=false
+
+              # Fetch docs-sites.json from docs-control
+              DOCS_SITES_JSON=$(gh api "repos/${CONFIG_REPO}/contents/.github/config/docs-sites.json" --jq '.content' | base64 -d)
+
+              # Look up label and description by matching repo name in URL
+              README_TITLE=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
+                '.[] | select(.url | contains("/" + $r + "/")) | .label' 2>/dev/null) || true
+              README_DESC=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
+                '.[] | select(.url | contains("/" + $r + "/")) | .description' 2>/dev/null) || true
+
+              # Fallback: capitalize repo name for title
+              if [ -z "$README_TITLE" ] || [ "$README_TITLE" = "null" ]; then
+                README_TITLE=$(echo "$REPO" | sed 's/-/ /g; s/\b\(.\)/\u\1/g')
+                echo "[INFO] No docs-sites.json match — using capitalized repo name: ${README_TITLE}"
+              fi
+
+              # Fallback: GitHub API repo description
+              if [ -z "$README_DESC" ] || [ "$README_DESC" = "null" ]; then
+                README_DESC=$(gh api "repos/${OWNER}/${REPO}" --jq '.description // ""') || true
+                if [ -z "$README_DESC" ] || [ "$README_DESC" = "null" ]; then
+                  README_DESC=""
+                fi
+                echo "[INFO] No docs-sites.json description — using GitHub API description"
+              fi
+
+              DOCS_URL="https://f5xc-salesdemos.github.io/${REPO}/"
+
+              # Fetch README.md.tpl from docs-control
+              README_TPL=$(gh api "repos/${CONFIG_REPO}/contents/README.md.tpl" --jq '.content' | base64 -d)
+
+              # Substitute placeholders
+              GENERATED_README=$(echo "$README_TPL" | \
+                sed "s|__TITLE__|${README_TITLE}|g" | \
+                sed "s|__DESCRIPTION__|${README_DESC}|g" | \
+                sed "s|__REPO_NAME__|${REPO}|g" | \
+                sed "s|__DOCS_URL__|${DOCS_URL}|g")
+
+              # Compare with current README.md in target repo
+              CURRENT_README_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/README.md" 2>/dev/null) || true
+              if [ -n "$CURRENT_README_RESPONSE" ]; then
+                CURRENT_README=$(echo "$CURRENT_README_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
+              else
+                CURRENT_README=""
+              fi
+
+              if [ "$GENERATED_README" != "$CURRENT_README" ]; then
+                echo "[DRIFT] README.md needs update"
+                README_DRIFT=true
+                DRIFT_FILES="${DRIFT_FILES}README.md\n"
+                DRIFT_COUNT=$((DRIFT_COUNT + 1))
+              else
+                echo "[OK] README.md"
+              fi
+
               if [ "$DRIFT_COUNT" -eq 0 ]; then
                 echo "[OK] All managed files match canonical"
               else
@@ -197,8 +255,8 @@ jobs:
 
                   # Commit each drifted file to the branch
                   for dest_file in $(printf '%b' "$DRIFT_FILES" | sed '/^$/d'); do
-                    # Skip dynamic dependabot.yml — committed separately below
-                    if [ "$dest_file" = ".github/dependabot.yml" ]; then
+                    # Skip dynamically generated files — committed separately below
+                    if [ "$dest_file" = ".github/dependabot.yml" ] || [ "$dest_file" = "README.md" ]; then
                       continue
                     fi
 
@@ -250,6 +308,28 @@ jobs:
                         gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
                     fi
                     echo "[OK] Synced .github/dependabot.yml (dynamic)"
+                  fi
+
+                  # Commit dynamic README.md if drifted
+                  if [ "$README_DRIFT" = true ]; then
+                    README_B64=$(printf '%s' "$GENERATED_README" | base64 -w 0)
+                    README_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/README.md" --jq '.sha' 2>/dev/null) || true
+
+                    if [ -n "$README_SHA" ]; then
+                      jq -n --arg msg "chore: update README.md" \
+                            --arg content "$README_B64" \
+                            --arg sha "$README_SHA" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/README.md" --method PUT --input - >/dev/null
+                    else
+                      jq -n --arg msg "chore: create README.md" \
+                            --arg content "$README_B64" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/README.md" --method PUT --input - >/dev/null
+                    fi
+                    echo "[OK] Synced README.md (dynamic)"
                   fi
 
                   # Create PR

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -1,0 +1,29 @@
+# __TITLE__
+
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/github-pages-deploy.yml)
+[![Repo Settings](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5xc-salesdemos/__REPO_NAME__)](LICENSE)
+
+__DESCRIPTION__
+
+## Documentation
+
+Full documentation is available at **[__DOCS_URL__](__DOCS_URL__)**.
+
+## Getting Started
+
+```bash
+git clone https://github.com/f5xc-salesdemos/__REPO_NAME__.git
+```
+
+See the [documentation](__DOCS_URL__) for detailed setup
+and usage guides.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow rules,
+branch naming, and CI requirements.
+
+## License
+
+See [LICENSE](LICENSE).


### PR DESCRIPTION
Closes #41

## Summary

- Add `README.md.tpl` template with `__TITLE__`, `__DESCRIPTION__`, `__REPO_NAME__`, `__DOCS_URL__` placeholders
- Extend `sync-managed-files.yml` to generate per-repo README.md from template using `docs-sites.json` lookups (with fallbacks to capitalized repo name and GitHub API description)
- Add `README.md.tpl` to `dispatch-downstream.yml` paths trigger so template changes dispatch enforcement

Follows the same dynamic generation pattern as `dependabot.yml`.

## Test plan

- [x] Verified jq lookup pattern matches repos in `docs-sites.json`
- [ ] Monitor dispatch-downstream workflow after merge
- [ ] Verify downstream repos receive sync PRs with generated README.md
- [ ] Confirm badge URLs resolve for a sample repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)