### PR TITLE
refactor: convert require-linked-issue to reusable workflow pattern

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -29,7 +29,7 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["Check linked issues"]
+        "contexts": ["check / Check linked issues"]
       },
       "required_pull_request_reviews": null,
       "restrictions": null,
@@ -52,7 +52,7 @@
     "files": [
       {"src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml"},
       {"src": "workflows/enforce-repo-settings.yml", "dest": ".github/workflows/enforce-repo-settings.yml"},
-      {"src": ".github/workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml"},
+      {"src": "workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml"},
       {"src": ".github/PULL_REQUEST_TEMPLATE.md", "dest": ".github/PULL_REQUEST_TEMPLATE.md"},
       {"src": ".github/ISSUE_TEMPLATE/bug_report.md", "dest": ".github/ISSUE_TEMPLATE/bug_report.md"},
       {"src": ".github/ISSUE_TEMPLATE/feature_request.md", "dest": ".github/ISSUE_TEMPLATE/feature_request.md"},

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,17 +1,11 @@
 name: Require Linked Issue
 
 on:
-  pull_request_target:
-    types: [opened, edited, reopened, synchronize]
   workflow_call:
 
 permissions:
   issues: read
   pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   check-linked-issue:

--- a/docs/01-getting-started.mdx
+++ b/docs/01-getting-started.mdx
@@ -14,7 +14,7 @@ This repository is the governance control plane for F5 Distributed Cloud (F5 XC)
 | `.github/config/downstream-repos.json` | Registry of enrolled downstream repositories |
 | `.github/config/docs-sites.json` | Metadata for each downstream docs site (label, URL, description) used by README templating |
 | `.github/workflows/` | Reusable workflows: enforcement, file sync, pages deploy, linked-issue check, and dispatch |
-| `workflows/` | Caller templates downstream repos install into `.github/workflows/` (enforce-repo-settings, github-pages-deploy) |
+| `workflows/` | Caller templates downstream repos install into `.github/workflows/` (enforce-repo-settings, github-pages-deploy, require-linked-issue) |
 | `docs/` | Documentation source (built and deployed via Astro Starlight) |
 | `CONTRIBUTING.md` | Contributor workflow rules (synced to all downstream repos) |
 | `CLAUDE.md` | AI assistant instructions (synced to all downstream repos) |

--- a/docs/02-governance-reference.mdx
+++ b/docs/02-governance-reference.mdx
@@ -25,9 +25,10 @@ The docs-control repository serves three purposes:
 | `.github/workflows/sync-managed-files.yml` | Reusable managed file sync workflow with dynamic generation and auto-merge |
 | `.github/workflows/dispatch-downstream.yml` | Dispatch trigger that pushes enforcement to all downstream repos |
 | `.github/workflows/github-pages-deploy.yml` | Reusable docs build and deploy workflow |
-| `.github/workflows/require-linked-issue.yml` | PR check requiring a linked GitHub issue (synced directly as a managed file) |
+| `.github/workflows/require-linked-issue.yml` | Reusable PR check requiring a linked GitHub issue |
 | `workflows/enforce-repo-settings.yml` | Caller template -- downstream repos install this to call the reusable enforcement workflow |
 | `workflows/github-pages-deploy.yml` | Caller template -- downstream repos install this for docs deployment |
+| `workflows/require-linked-issue.yml` | Caller template -- downstream repos install this for the linked-issue PR check |
 | `README.md.tpl` | Template with placeholders for dynamically generated downstream README files |
 
 ## Enforcement Pipeline
@@ -114,8 +115,7 @@ The canonical list of managed files is defined in `.github/config/repo-settings.
 
 The manifest includes:
 
-- Caller workflows (`enforce-repo-settings.yml`, `github-pages-deploy.yml`)
-- The `require-linked-issue.yml` workflow (synced directly, not via a caller template, because it runs identically in every repo)
+- Caller workflows (`enforce-repo-settings.yml`, `github-pages-deploy.yml`, `require-linked-issue.yml`)
 - Issue and PR templates
 - `CONTRIBUTING.md`, `CLAUDE.md`, `.editorconfig`, `.gitignore`, `LICENSE`
 - `.pre-commit-config.yaml`
@@ -176,14 +176,13 @@ The registry of enrolled downstream repositories is maintained in `.github/confi
 
 ## Caller Workflow Templates
 
-The `workflows/` directory contains two workflow files that downstream repos copy into their `.github/workflows/` directory. These are thin callers that invoke the reusable workflows hosted in this template repo.
+The `workflows/` directory contains three workflow files that downstream repos copy into their `.github/workflows/` directory. These are thin callers that invoke the reusable workflows hosted in this template repo.
 
 | Template | Calls | Trigger |
 |---|---|---|
 | `workflows/enforce-repo-settings.yml` | `.github/workflows/enforce-repo-settings.yml` and `.github/workflows/sync-managed-files.yml` (parallel jobs) | Schedule (every 6 hours), push to `.github/config/**`, manual dispatch |
 | `workflows/github-pages-deploy.yml` | `.github/workflows/github-pages-deploy.yml` | Push to `docs/**` on main, manual dispatch |
-
-The `require-linked-issue.yml` workflow is not a caller template. It is synced directly as a managed file because it runs identically in every repo without needing to call back to a reusable workflow.
+| `workflows/require-linked-issue.yml` | `.github/workflows/require-linked-issue.yml` | `pull_request_target` (opened, edited, reopened, synchronize) |
 
 ## Onboarding
 

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -1,0 +1,18 @@
+name: Require Linked Issue
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Convert `require-linked-issue.yml` from directly-synced file to reusable workflow + thin caller pattern, matching the other distributed workflows
- Update branch protection context from `Check linked issues` to `check / Check linked issues`
- Update documentation to reflect the new three-caller pattern

## Details

The reusable workflow (`.github/workflows/require-linked-issue.yml`) now only has `workflow_call` trigger. A new thin caller template (`workflows/require-linked-issue.yml`) has `pull_request_target` trigger and calls the reusable workflow via `@main`. This means downstream repos automatically pick up changes without needing file re-syncs.

The status check name changes from `Check linked issues` to `check / Check linked issues` (GitHub's `<caller_job> / <reusable_job_name>` format). Branch protection contexts in `repo-settings.json` are updated to match.

Closes #50

## Test plan

- [ ] CI passes on this PR (the require-linked-issue check itself will still work since this repo uses `pull_request_target` directly until the caller is synced)
- [ ] After merge, verify dispatch triggers fire (paths include both `.github/workflows/require-linked-issue.yml` and `workflows/**`)
- [ ] Verify at least one downstream repo receives the new caller template via governance sync
- [ ] Verify the status check name `check / Check linked issues` appears in downstream PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)