### PR TITLE
feat: temporarily disable enforce_admins for reusable workflow migration

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -26,7 +26,7 @@
   "branch_protection": [
     {
       "branch": "main",
-      "enforce_admins": true,
+      "enforce_admins": false,
       "required_status_checks": {
         "strict": false,
         "contexts": ["Check linked issues"]


### PR DESCRIPTION
## Summary

- Set `enforce_admins` to `false` in branch protection config to allow admin bypass during the require-linked-issue reusable workflow migration

## Context

This is a temporary change. Converting require-linked-issue to the reusable workflow pattern changes the check name from `Check linked issues` to `check / Check linked issues`. During transition, sync PRs will have the old check name while protection requires the new one. Disabling `enforce_admins` lets the governance sync token (admin) merge these PRs despite the mismatch.

Will be reverted after the migration completes successfully.

Closes #54

## Test plan

- [ ] CI passes
- [ ] After merge, enforcement propagates `enforce_admins: false` to all downstream repos
- [ ] Verify with `gh api repos/f5xc-salesdemos/docs/branches/main/protection --jq '.enforce_admins'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)