### PR TITLE
feat: add retry with exponential backoff to governance workflows

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -41,12 +41,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
         run: |
+          # Retry with exponential backoff
+          # Usage: retry <max_attempts> <command> [args...]
+          retry() {
+            local max="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           repos=$(jq -r '.[]' .github/config/downstream-repos.json)
           for repo in $repos; do
             echo "Dispatching to $repo..."
-            if gh workflow run enforce-repo-settings.yml --repo "$repo"; then
+            if retry 3 gh workflow run enforce-repo-settings.yml --repo "$repo"; then
               echo "  [OK] $repo"
             else
-              echo "  [FAIL] $repo"
+              echo "  [FAIL] $repo (failed after retries)"
             fi
           done

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -27,6 +27,46 @@ jobs:
         run: |
           set -euo pipefail
 
+          # ─── Retry helpers ─────────────────────────────────────────────────
+          # Retry with exponential backoff (for commands without stdin)
+          # Usage: retry <max_attempts> <command> [args...]
+          retry() {
+            local max="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          # Retry with JSON body (for gh api --input - calls)
+          # Usage: retry_json <max_attempts> <json_string> <gh api args...>
+          retry_json() {
+            local max="$1"; shift
+            local json="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if echo "$json" | gh api "$@" --input -; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: gh api $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           OWNER="${GITHUB_REPOSITORY%/*}"
           REPO="${GITHUB_REPOSITORY#*/}"
           CONFIG_REPO="f5xc-salesdemos/docs-control"
@@ -47,7 +87,8 @@ jobs:
 
           # Fetch central config from docs-control
           echo "[INFO] Fetching config from ${CONFIG_REPO}/${CONFIG_PATH}..."
-          CONFIG=$(gh api "repos/${CONFIG_REPO}/contents/${CONFIG_PATH}" --jq '.content' | base64 -d)
+          CONFIG_B64=$(retry 5 gh api "repos/${CONFIG_REPO}/contents/${CONFIG_PATH}" --jq '.content')
+          CONFIG=$(echo "$CONFIG_B64" | base64 -d)
           if ! echo "$CONFIG" | jq empty 2>/dev/null; then
             echo "[ERROR] Failed to fetch or parse config from ${CONFIG_REPO}" >&2; exit 1
           fi
@@ -68,7 +109,7 @@ jobs:
           echo "=== Phase 2: Apply repo settings ==="
 
           DESIRED_REPO=$(echo "$CONFIG" | jq -c '.repository')
-          CURRENT_REPO=$(gh api "repos/${OWNER}/${REPO}" 2>/dev/null)
+          CURRENT_REPO=$(retry 3 gh api "repos/${OWNER}/${REPO}")
 
           REPO_DRIFT=false
           REPO_PATCH="{}"
@@ -85,7 +126,7 @@ jobs:
 
           if [ "$REPO_DRIFT" = true ]; then
             echo "[INFO] Patching repository settings..."
-            echo "$REPO_PATCH" | gh api "repos/${OWNER}/${REPO}" --method PATCH --input - >/dev/null
+            retry_json 3 "$REPO_PATCH" "repos/${OWNER}/${REPO}" --method PATCH >/dev/null
             echo "[OK] Repository settings updated"
           else
             echo "[OK] Repository settings match — no changes needed"
@@ -98,7 +139,7 @@ jobs:
           DESIRED_ACTIONS=$(echo "$CONFIG" | jq -c '.actions_permissions // empty')
 
           if [ -n "$DESIRED_ACTIONS" ]; then
-            CURRENT_ACTIONS=$(gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow" 2>/dev/null)
+            CURRENT_ACTIONS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow")
             ACTIONS_DRIFT=false
 
             for key in $(echo "$DESIRED_ACTIONS" | jq -r 'keys[]'); do
@@ -112,8 +153,8 @@ jobs:
 
             if [ "$ACTIONS_DRIFT" = true ]; then
               echo "[INFO] Updating Actions workflow permissions..."
-              echo "$DESIRED_ACTIONS" | gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
-                --method PUT --input - >/dev/null
+              retry_json 3 "$DESIRED_ACTIONS" "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
+                --method PUT >/dev/null
               echo "[OK] Actions permissions updated"
             else
               echo "[OK] Actions permissions match — no changes needed"
@@ -134,9 +175,9 @@ jobs:
 
             DESIRED_PAYLOAD=$(echo "$CONFIG" | jq -c ".branch_protection[$i] | del(.branch)")
 
-            HTTP_CODE=$(gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+            HTTP_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
               --include 2>/dev/null | head -1 | awk '{print $2}') || true
-            CURRENT_PROTECTION=$(gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
+            CURRENT_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
 
             PROTECTION_DRIFT=false
 
@@ -227,8 +268,8 @@ jobs:
                   allow_fork_syncing: $desired.allow_fork_syncing
                 }')
 
-              echo "$PUT_PAYLOAD" | gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
-                --method PUT --input - >/dev/null
+              retry_json 3 "$PUT_PAYLOAD" "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+                --method PUT >/dev/null
               echo "[OK] Branch protection updated for $BRANCH"
             else
               echo "[OK] Branch protection matches — no changes needed"
@@ -241,12 +282,12 @@ jobs:
 
           DESIRED_TOPICS=$(echo "$CONFIG" | jq -c '.topics // []')
           if [ "$DESIRED_TOPICS" != "[]" ]; then
-            CURRENT_TOPICS=$(gh api "repos/${OWNER}/${REPO}/topics" 2>/dev/null | jq -c '.names // []')
+            CURRENT_TOPICS=$(retry 3 gh api "repos/${OWNER}/${REPO}/topics" | jq -c '.names // []')
             if [ "$DESIRED_TOPICS" != "$CURRENT_TOPICS" ]; then
               echo "[WARN] Drift in topics: current=$CURRENT_TOPICS desired=$DESIRED_TOPICS"
               echo "[INFO] Updating topics..."
-              jq -n --argjson names "$DESIRED_TOPICS" '{"names": $names}' | \
-                gh api "repos/${OWNER}/${REPO}/topics" --method PUT --input - >/dev/null
+              TOPICS_JSON=$(jq -n --argjson names "$DESIRED_TOPICS" '{"names": $names}')
+              retry_json 3 "$TOPICS_JSON" "repos/${OWNER}/${REPO}/topics" --method PUT >/dev/null
               echo "[OK] Topics updated"
             else
               echo "[OK] Topics match — no changes needed"
@@ -262,20 +303,19 @@ jobs:
           PAGES_ENABLED=$(echo "$CONFIG" | jq -r '.pages.enabled // false')
           DESIRED_BUILD_TYPE=$(echo "$CONFIG" | jq -r '.pages.build_type // "workflow"')
           if [ "$PAGES_ENABLED" = "true" ]; then
-            PAGES_HTTP_CODE=$(gh api "repos/${OWNER}/${REPO}/pages" --include 2>/dev/null | head -1 | awk '{print $2}') || true
+            PAGES_HTTP_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" --include 2>/dev/null | head -1 | awk '{print $2}') || true
+            PAGES_JSON=$(jq -n --arg bt "$DESIRED_BUILD_TYPE" '{"build_type": $bt, "source": {"branch": "main", "path": "/"}}')
             if [ "$PAGES_HTTP_CODE" = "404" ]; then
               echo "[INFO] Enabling GitHub Pages with ${DESIRED_BUILD_TYPE} source..."
-              jq -n --arg bt "$DESIRED_BUILD_TYPE" '{"build_type": $bt, "source": {"branch": "main", "path": "/"}}' | \
-                gh api "repos/${OWNER}/${REPO}/pages" --method POST --input - >/dev/null 2>&1 || true
+              retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1 || true
               echo "[OK] Pages enabled with build_type=${DESIRED_BUILD_TYPE}"
             else
-              PAGES_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
+              PAGES_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
               CURRENT_BUILD_TYPE=$(echo "$PAGES_RESPONSE" | jq -r '.build_type // empty')
               if [ "$CURRENT_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
                 echo "[WARN] Drift in pages.build_type: current=$CURRENT_BUILD_TYPE desired=$DESIRED_BUILD_TYPE"
                 echo "[INFO] Updating Pages build_type to ${DESIRED_BUILD_TYPE}..."
-                jq -n --arg bt "$DESIRED_BUILD_TYPE" '{"build_type": $bt, "source": {"branch": "main", "path": "/"}}' | \
-                  gh api "repos/${OWNER}/${REPO}/pages" --method PUT --input - >/dev/null 2>&1
+                retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method PUT >/dev/null 2>&1
                 echo "[OK] Pages build_type updated to ${DESIRED_BUILD_TYPE}"
               else
                 echo "[OK] Pages build_type matches (${CURRENT_BUILD_TYPE}) — no changes needed"
@@ -291,7 +331,7 @@ jobs:
 
           VERIFY_FAILED=false
 
-          VERIFY_REPO=$(gh api "repos/${OWNER}/${REPO}" 2>/dev/null)
+          VERIFY_REPO=$(retry 3 gh api "repos/${OWNER}/${REPO}")
           for key in $(echo "$DESIRED_REPO" | jq -r 'keys[]'); do
             desired_val=$(echo "$DESIRED_REPO" | jq -c ".[\"$key\"]")
             actual_val=$(echo "$VERIFY_REPO" | jq -c ".[\"$key\"]")
@@ -302,7 +342,7 @@ jobs:
           done
 
           if [ -n "$DESIRED_ACTIONS" ]; then
-            VERIFY_ACTIONS=$(gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow" 2>/dev/null)
+            VERIFY_ACTIONS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/permissions/workflow")
             for key in $(echo "$DESIRED_ACTIONS" | jq -r 'keys[]'); do
               desired_val=$(echo "$DESIRED_ACTIONS" | jq -c ".[\"$key\"]")
               actual_val=$(echo "$VERIFY_ACTIONS" | jq -c ".[\"$key\"]")
@@ -316,7 +356,7 @@ jobs:
           for i in $(seq 0 $((BRANCH_COUNT - 1))); do
             BRANCH=$(echo "$CONFIG" | jq -r ".branch_protection[$i].branch")
             DESIRED_PAYLOAD=$(echo "$CONFIG" | jq -c ".branch_protection[$i] | del(.branch)")
-            VERIFY_PROTECTION=$(gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
+            VERIFY_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
 
             if [ -z "$VERIFY_PROTECTION" ]; then
               echo "[FAIL] Branch protection for $BRANCH not found after apply"
@@ -352,11 +392,11 @@ jobs:
           done
 
           if [ "$PAGES_ENABLED" = "true" ]; then
-            VERIFY_PAGES_CODE=$(gh api "repos/${OWNER}/${REPO}/pages" --include 2>/dev/null | head -1 | awk '{print $2}') || true
+            VERIFY_PAGES_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" --include 2>/dev/null | head -1 | awk '{print $2}') || true
             if [ "$VERIFY_PAGES_CODE" = "404" ]; then
               echo "[WARN] Pages not found after apply — repo may lack a deploy workflow"
             else
-              VERIFY_PAGES=$(gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
+              VERIFY_PAGES=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
               ACTUAL_BUILD_TYPE=$(echo "$VERIFY_PAGES" | jq -r '.build_type // empty')
               if [ "$ACTUAL_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
                 echo "[FAIL] pages.build_type: expected=$DESIRED_BUILD_TYPE actual=$ACTUAL_BUILD_TYPE"

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -20,6 +20,46 @@ jobs:
         run: |
           set -euo pipefail
 
+          # ─── Retry helpers ─────────────────────────────────────────────────
+          # Retry with exponential backoff (for commands without stdin)
+          # Usage: retry <max_attempts> <command> [args...]
+          retry() {
+            local max="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          # Retry with JSON body (for gh api --input - calls)
+          # Usage: retry_json <max_attempts> <json_string> <gh api args...>
+          retry_json() {
+            local max="$1"; shift
+            local json="$1"; shift
+            local attempt=1
+            local delay=2
+            while true; do
+              if echo "$json" | gh api "$@" --input -; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "[ERROR] Failed after ${max} attempts: gh api $*" >&2
+                return 1
+              fi
+              echo "[WARN] Attempt ${attempt}/${max} failed — retrying in ${delay}s..." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           OWNER="${GITHUB_REPOSITORY%/*}"
           REPO="${GITHUB_REPOSITORY#*/}"
           CONFIG_REPO="f5xc-salesdemos/docs-control"
@@ -58,8 +98,9 @@ jobs:
                     return 0
                   fi
                   merge_attempts=$((merge_attempts + 1))
-                  echo "[WARN] Merge attempt ${merge_attempts}/3 failed — retrying in 10s..."
-                  sleep 10
+                  local merge_delay=$((5 * (2 ** (merge_attempts - 1))))
+                  echo "[WARN] Merge attempt ${merge_attempts}/3 failed — retrying in ${merge_delay}s..."
+                  sleep "$merge_delay"
                 done
                 echo "[WARN] Failed to merge PR #${pr_num} after 3 attempts — may need manual merge"
                 return 1
@@ -88,7 +129,8 @@ jobs:
 
           # Fetch central config from docs-control
           echo "[INFO] Fetching config from ${CONFIG_REPO}/${CONFIG_PATH}..."
-          CONFIG=$(gh api "repos/${CONFIG_REPO}/contents/${CONFIG_PATH}" --jq '.content' | base64 -d)
+          CONFIG_B64=$(retry 5 gh api "repos/${CONFIG_REPO}/contents/${CONFIG_PATH}" --jq '.content')
+          CONFIG=$(echo "$CONFIG_B64" | base64 -d)
           if ! echo "$CONFIG" | jq empty 2>/dev/null; then
             echo "[ERROR] Failed to fetch or parse config from ${CONFIG_REPO}" >&2; exit 1
           fi
@@ -122,7 +164,7 @@ jobs:
                 dest=$(echo "$file_obj" | jq -r '.dest')
 
                 # Fetch canonical content from source path
-                CANONICAL_RESPONSE=$(gh api "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
+                CANONICAL_RESPONSE=$(retry 3 gh api "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
                 if [ -z "$CANONICAL_RESPONSE" ]; then
                   echo "[WARN] Could not fetch canonical: ${src}"
                   continue
@@ -130,7 +172,7 @@ jobs:
                 CANONICAL_CONTENT=$(echo "$CANONICAL_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
 
                 # Fetch downstream content at dest path (handle 404)
-                DOWNSTREAM_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/${dest}" 2>/dev/null) || true
+                DOWNSTREAM_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/contents/${dest}" 2>/dev/null) || true
                 if [ -z "$DOWNSTREAM_RESPONSE" ]; then
                   echo "[DRIFT] Missing downstream: ${dest}"
                   DRIFT_FILES="${DRIFT_FILES}${dest}\n"
@@ -155,14 +197,14 @@ jobs:
 
               # Detect ecosystems in target repo
               HAS_NPM=false; HAS_PIP=false; HAS_DOCKER=false
-              if gh api "repos/${OWNER}/${REPO}/contents/package.json" --jq '.sha' >/dev/null 2>&1; then
+              if retry 3 gh api "repos/${OWNER}/${REPO}/contents/package.json" --jq '.sha' >/dev/null 2>&1; then
                 HAS_NPM=true; echo "[INFO] Detected package.json → npm"
               fi
-              if gh api "repos/${OWNER}/${REPO}/contents/Dockerfile" --jq '.sha' >/dev/null 2>&1; then
+              if retry 3 gh api "repos/${OWNER}/${REPO}/contents/Dockerfile" --jq '.sha' >/dev/null 2>&1; then
                 HAS_DOCKER=true; echo "[INFO] Detected Dockerfile → docker"
               fi
               for pyfile in requirements.txt pyproject.toml setup.py; do
-                if gh api "repos/${OWNER}/${REPO}/contents/${pyfile}" --jq '.sha' >/dev/null 2>&1; then
+                if retry 3 gh api "repos/${OWNER}/${REPO}/contents/${pyfile}" --jq '.sha' >/dev/null 2>&1; then
                   HAS_PIP=true; echo "[INFO] Detected ${pyfile} → pip"; break
                 fi
               done
@@ -186,7 +228,7 @@ jobs:
               GENERATED_DEPENDABOT=$(printf '%b' "$DEPBOT")
 
               # Compare with current dependabot.yml in target repo
-              CURRENT_DEPBOT_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" 2>/dev/null) || true
+              CURRENT_DEPBOT_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" 2>/dev/null) || true
               if [ -n "$CURRENT_DEPBOT_RESPONSE" ]; then
                 CURRENT_DEPENDABOT=$(echo "$CURRENT_DEPBOT_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
               else
@@ -208,7 +250,8 @@ jobs:
               README_DRIFT=false
 
               # Fetch docs-sites.json from docs-control
-              DOCS_SITES_JSON=$(gh api "repos/${CONFIG_REPO}/contents/.github/config/docs-sites.json" --jq '.content' | base64 -d)
+              DOCS_SITES_B64=$(retry 3 gh api "repos/${CONFIG_REPO}/contents/.github/config/docs-sites.json" --jq '.content')
+              DOCS_SITES_JSON=$(echo "$DOCS_SITES_B64" | base64 -d)
 
               # Look up label and description by matching repo name in URL
               README_TITLE=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
@@ -234,7 +277,8 @@ jobs:
               DOCS_URL="https://f5xc-salesdemos.github.io/${REPO}/"
 
               # Fetch README.md.tpl from docs-control
-              README_TPL=$(gh api "repos/${CONFIG_REPO}/contents/README.md.tpl" --jq '.content' | base64 -d)
+              README_TPL_B64=$(retry 3 gh api "repos/${CONFIG_REPO}/contents/README.md.tpl" --jq '.content')
+              README_TPL=$(echo "$README_TPL_B64" | base64 -d)
 
               # Substitute placeholders
               GENERATED_README=$(echo "$README_TPL" | \
@@ -244,7 +288,7 @@ jobs:
                 sed "s|__DOCS_URL__|${DOCS_URL}|g")
 
               # Compare with current README.md in target repo
-              CURRENT_README_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/README.md" 2>/dev/null) || true
+              CURRENT_README_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/contents/README.md" 2>/dev/null) || true
               if [ -n "$CURRENT_README_RESPONSE" ]; then
                 CURRENT_README=$(echo "$CURRENT_README_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
               else
@@ -283,12 +327,11 @@ jobs:
                   echo "[OK] Created issue #${ISSUE_NUM}"
 
                   # Create branch from main HEAD (try create, fall back to update if concurrent run created it)
-                  MAIN_SHA=$(gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
-                  if ! gh api "repos/${OWNER}/${REPO}/git/refs" --method POST \
-                    --input <(jq -n --arg sha "$MAIN_SHA" \
-                      '{"ref":"refs/heads/governance/sync-managed-files","sha":$sha}') >/dev/null 2>&1; then
-                    gh api "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" \
-                      --method PATCH --input <(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}') >/dev/null
+                  MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
+                  BRANCH_CREATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"ref":"refs/heads/governance/sync-managed-files","sha":$sha}')
+                  if ! retry_json 3 "$BRANCH_CREATE_JSON" "repos/${OWNER}/${REPO}/git/refs" --method POST >/dev/null 2>&1; then
+                    BRANCH_UPDATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}')
+                    retry_json 3 "$BRANCH_UPDATE_JSON" "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" --method PATCH >/dev/null
                   fi
                   echo "[OK] Created or updated branch governance/sync-managed-files"
 
@@ -303,26 +346,26 @@ jobs:
                     src_file=$(echo "$MANAGED_FILES" | jq -r --arg d "$dest_file" '.files[] | select(.dest == $d) | .src')
 
                     # Get canonical content as base64
-                    B64=$(gh api "repos/${SOURCE_REPO}/contents/${src_file}" --jq '.content' | tr -d '\n')
+                    B64=$(retry 3 gh api "repos/${SOURCE_REPO}/contents/${src_file}" --jq '.content' | tr -d '\n')
 
                     # Check if file exists downstream (need SHA for update)
-                    FILE_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --jq '.sha' 2>/dev/null) || true
+                    FILE_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --jq '.sha' 2>/dev/null) || true
 
                     if [ -n "$FILE_SHA" ]; then
                       # Update existing file
-                      jq -n --arg msg "chore: sync ${dest_file}" \
+                      COMMIT_JSON=$(jq -n --arg msg "chore: sync ${dest_file}" \
                             --arg content "$B64" \
                             --arg sha "$FILE_SHA" \
                             --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT --input - >/dev/null
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}')
+                      retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
                     else
                       # Create new file
-                      jq -n --arg msg "chore: sync ${dest_file}" \
+                      COMMIT_JSON=$(jq -n --arg msg "chore: sync ${dest_file}" \
                             --arg content "$B64" \
                             --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT --input - >/dev/null
+                        '{"message":$msg,"content":$content,"branch":$branch}')
+                      retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
                     fi
                     echo "[OK] Synced ${dest_file}"
                   done
@@ -330,21 +373,21 @@ jobs:
                   # Commit dynamic dependabot.yml if drifted
                   if [ "$DEPENDABOT_DRIFT" = true ]; then
                     DEPBOT_B64=$(printf '%s' "$GENERATED_DEPENDABOT" | base64 -w 0)
-                    DEPBOT_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --jq '.sha' 2>/dev/null) || true
+                    DEPBOT_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --jq '.sha' 2>/dev/null) || true
 
                     if [ -n "$DEPBOT_SHA" ]; then
-                      jq -n --arg msg "chore: update .github/dependabot.yml" \
+                      DEPBOT_COMMIT=$(jq -n --arg msg "chore: update .github/dependabot.yml" \
                             --arg content "$DEPBOT_B64" \
                             --arg sha "$DEPBOT_SHA" \
                             --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}')
+                      retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
                     else
-                      jq -n --arg msg "chore: create .github/dependabot.yml" \
+                      DEPBOT_COMMIT=$(jq -n --arg msg "chore: create .github/dependabot.yml" \
                             --arg content "$DEPBOT_B64" \
                             --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
+                        '{"message":$msg,"content":$content,"branch":$branch}')
+                      retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
                     fi
                     echo "[OK] Synced .github/dependabot.yml (dynamic)"
                   fi
@@ -352,21 +395,21 @@ jobs:
                   # Commit dynamic README.md if drifted
                   if [ "$README_DRIFT" = true ]; then
                     README_B64=$(printf '%s' "$GENERATED_README" | base64 -w 0)
-                    README_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/README.md" --jq '.sha' 2>/dev/null) || true
+                    README_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/contents/README.md" --jq '.sha' 2>/dev/null) || true
 
                     if [ -n "$README_SHA" ]; then
-                      jq -n --arg msg "chore: update README.md" \
+                      README_COMMIT=$(jq -n --arg msg "chore: update README.md" \
                             --arg content "$README_B64" \
                             --arg sha "$README_SHA" \
                             --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/README.md" --method PUT --input - >/dev/null
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}')
+                      retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
                     else
-                      jq -n --arg msg "chore: create README.md" \
+                      README_COMMIT=$(jq -n --arg msg "chore: create README.md" \
                             --arg content "$README_B64" \
                             --arg branch "governance/sync-managed-files" \
-                        '{"message":$msg,"content":$content,"branch":$branch}' | \
-                        gh api "repos/${OWNER}/${REPO}/contents/README.md" --method PUT --input - >/dev/null
+                        '{"message":$msg,"content":$content,"branch":$branch}')
+                      retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
                     fi
                     echo "[OK] Synced README.md (dynamic)"
                   fi

--- a/docs/02-governance-reference.mdx
+++ b/docs/02-governance-reference.mdx
@@ -107,8 +107,19 @@ Governance sync PRs are automatically merged when CI checks pass. The auto-merge
 
 1. **Polling** -- waits up to 180 seconds for CI checks to appear, polling every 15 seconds
 2. **Watch** -- once checks are detected, watches them to completion
-3. **Merge with retries** -- if CI passes, attempts a squash merge up to 3 times with 10-second backoff between attempts
+3. **Merge with retries** -- if CI passes, attempts a squash merge up to 3 times with exponential backoff (5s, 10s, 20s)
 4. **Graceful fallback** -- if CI fails or the merge cannot complete after retries, the PR is left open for manual review
+
+## Transient Error Handling
+
+All GitHub API calls in the enforcement, sync, and dispatch workflows use exponential backoff retry. Two helper functions provide this:
+
+- **`retry`** wraps any command with backoff (2s, 4s, 8s between attempts)
+- **`retry_json`** handles piped JSON input to `gh api --input -`, replaying the body on each attempt
+
+Read operations and idempotent writes retry up to 3 attempts. The config fetch (most critical single point of failure) retries up to 5 attempts. Dispatch calls to downstream repos also retry 3 times.
+
+Non-idempotent operations (issue creation, PR creation) are **not** retried to avoid duplicates. If these operations fail, the workflow aborts and can be safely rerun.
 
 ## Managed Files Manifest
 


### PR DESCRIPTION
## Summary

Closes #58

- Add `retry()` and `retry_json()` helper functions with exponential backoff (2s, 4s, 8s) to all three governance workflows
- Wrap all GitHub API calls: config fetch (5 attempts), reads and idempotent writes (3 attempts), dispatch calls (3 attempts)
- Update `wait_and_merge()` merge retry from fixed 10s delay to exponential backoff (5s, 10s, 20s)
- Non-idempotent operations (issue/PR creation) are intentionally not retried to avoid duplicates
- Document retry behavior in governance reference docs

## Test plan

- [ ] PR passes CI (require-linked-issue check)
- [ ] After merge, `enforce-repo-settings` runs successfully on docs-control itself
- [ ] After merge, dispatch triggers downstream enforcement without failures
- [ ] Verify no retry `[WARN]` messages appear in healthy run logs (confirms backoff is transparent when no errors occur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)