### PR TITLE
fix: re-enable enforce_admins in branch protection

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -26,7 +26,7 @@
   "branch_protection": [
     {
       "branch": "main",
-      "enforce_admins": false,
+      "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
         "contexts": ["check / Check linked issues"]


### PR DESCRIPTION
## Summary
- Re-enable `enforce_admins` (`false` → `true`) in `.github/config/repo-settings.json`
- PR #55 temporarily disabled it for the reusable workflow migration; PR #57 completed that migration
- Also serves as end-to-end verification that retry helpers from PR #59 work correctly

Closes #60

## Test plan
- [ ] `check / Check linked issues` CI check passes
- [ ] After merge, `enforce-repo-settings` workflow succeeds on docs-control
- [ ] After merge, `dispatch-downstream` workflow succeeds
- [ ] `enforce_admins` reads `true` on docs-control via API
- [ ] `enforce_admins` reads `true` on downstream repo (e.g. `f5xc-salesdemos/docs`) via API
- [ ] No `[WARN]` retry messages in enforce workflow logs (healthy case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)