### PR TITLE
docs: remove numeric prefixes from documentation filenames

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -26,6 +26,6 @@ This repository is the governance control plane for F5 Distributed Cloud (F5 XC)
 
 ## Next Steps
 
-- Read the [Governance Reference](../02-governance-reference/) for a detailed explanation of the enforcement system, dynamic file generation, and auto-merge behavior
+- Read the [Governance Reference](../governance-reference/) for a detailed explanation of the enforcement system, dynamic file generation, and auto-merge behavior
 - See `CONTRIBUTING.md` for the branch, commit, and PR workflow that all repos follow
 - See `MIGRATION.md` in the repository root for the step-by-step procedure to onboard a new downstream repo to the Astro Starlight documentation pipeline

--- a/docs/governance-reference.mdx
+++ b/docs/governance-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Governance Reference
 sidebar:
-  order: 1
+  order: 2
 ---
 
 This page documents the governance enforcement system that keeps downstream repositories aligned with this template. It references source files rather than duplicating their contents so that the documentation stays current as the system evolves.


### PR DESCRIPTION
## Summary
- Remove `01-`/`02-` numeric prefixes from `docs/` filenames — Starlight `sidebar.order` frontmatter handles ordering
- Fix `governance-reference.mdx` sidebar order from 1 to 2
- Update internal link in `getting-started.mdx`

## Test plan
- [ ] CI checks pass
- [ ] Docs build succeeds (GitHub Pages deploy workflow)
- [ ] Sidebar renders in correct order (Getting Started = 1, Governance Reference = 2)
- [ ] Internal link from Getting Started to Governance Reference works

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)