### PR TITLE
fix: update docs-builder link in CLAUDE.md after filename rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ Serve with `npx serve output/ -l 8080` and open
 `http://localhost:8080/<repo>/`.
 
 Full content authoring guide:
-<https://f5xc-salesdemos.github.io/docs-builder/06-content-authors/>
+<https://f5xc-salesdemos.github.io/docs-builder/content-authors/>
 
 ## Reference
 


### PR DESCRIPTION
## Summary
- Update broken link in CLAUDE.md from `06-content-authors` to `content-authors` after docs-builder filename rename

## Test plan
- [ ] CI checks pass
- [ ] Link resolves to correct page

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)