### PR TITLE
fix: inline code blocks in docs for llms.txt quality

### DIFF
--- a/docs/_imports
+++ b/docs/_imports
@@ -1,6 +1,0 @@
-.github/config/repo-settings.json
-.github/config/downstream-repos.json
-.github/config/docs-sites.json
-workflows/enforce-repo-settings.yml
-workflows/github-pages-deploy.yml
-workflows/require-linked-issue.yml

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -4,12 +4,81 @@ sidebar:
   order: 2
 ---
 
-import { Code } from '@astrojs/starlight/components';
-import repoSettings from './_data/repo-settings.json?raw';
-
 The central configuration file drives all enforcement, sync, and dispatch behavior. It lives at `.github/config/repo-settings.json` in docs-control and is fetched by downstream repos at workflow runtime.
 
-<Code code={repoSettings} lang="json" title=".github/config/repo-settings.json" />
+```json title=".github/config/repo-settings.json"
+{
+  "_comment": "Central repo-settings config — enforced by enforce-repo-settings.yml",
+  "repository": {
+    "private": false,
+    "has_issues": true,
+    "has_projects": false,
+    "has_wiki": false,
+    "is_template": false,
+    "allow_squash_merge": true,
+    "allow_merge_commit": true,
+    "allow_rebase_merge": true,
+    "allow_auto_merge": false,
+    "delete_branch_on_merge": true,
+    "web_commit_signoff_required": false,
+    "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
+    "squash_merge_commit_message": "COMMIT_MESSAGES",
+    "merge_commit_title": "MERGE_MESSAGE",
+    "merge_commit_message": "PR_TITLE",
+    "allow_update_branch": true,
+    "homepage": ""
+  },
+  "actions_permissions": {
+    "default_workflow_permissions": "write",
+    "can_approve_pull_request_reviews": true
+  },
+  "branch_protection": [
+    {
+      "branch": "main",
+      "enforce_admins": true,
+      "required_status_checks": {
+        "strict": false,
+        "contexts": ["check / Check linked issues"],
+        "self_contexts": ["Check linked issues"]
+      },
+      "required_pull_request_reviews": null,
+      "restrictions": null,
+      "required_linear_history": false,
+      "allow_force_pushes": false,
+      "allow_deletions": false,
+      "block_creations": false,
+      "required_conversation_resolution": false,
+      "lock_branch": false,
+      "allow_fork_syncing": false
+    }
+  ],
+  "topics": [],
+  "pages": {
+    "enabled": true,
+    "build_type": "workflow"
+  },
+  "managed_files": {
+    "source_repo": "f5xc-salesdemos/docs-control",
+    "files": [
+      {"src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml"},
+      {"src": "workflows/enforce-repo-settings.yml", "dest": ".github/workflows/enforce-repo-settings.yml"},
+      {"src": "workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml"},
+      {"src": ".github/PULL_REQUEST_TEMPLATE.md", "dest": ".github/PULL_REQUEST_TEMPLATE.md"},
+      {"src": ".github/ISSUE_TEMPLATE/bug_report.md", "dest": ".github/ISSUE_TEMPLATE/bug_report.md"},
+      {"src": ".github/ISSUE_TEMPLATE/feature_request.md", "dest": ".github/ISSUE_TEMPLATE/feature_request.md"},
+      {"src": ".github/ISSUE_TEMPLATE/documentation.md", "dest": ".github/ISSUE_TEMPLATE/documentation.md"},
+      {"src": ".github/ISSUE_TEMPLATE/config.yml", "dest": ".github/ISSUE_TEMPLATE/config.yml"},
+
+      {"src": "CONTRIBUTING.md", "dest": "CONTRIBUTING.md"},
+      {"src": "CLAUDE.md", "dest": "CLAUDE.md"},
+      {"src": ".editorconfig", "dest": ".editorconfig"},
+      {"src": ".gitignore", "dest": ".gitignore"},
+      {"src": "LICENSE", "dest": "LICENSE"},
+      {"src": ".pre-commit-config.yaml", "dest": ".pre-commit-config.yaml"}
+    ]
+  }
+}
+```
 
 ## Field reference
 

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -4,12 +4,6 @@ sidebar:
   order: 5
 ---
 
-import { Code } from '@astrojs/starlight/components';
-import downstreamRepos from './_data/downstream-repos.json?raw';
-import callerEnforce from './_data/enforce-repo-settings.yml?raw';
-import callerDeploy from './_data/github-pages-deploy.yml?raw';
-import callerLinkedIssue from './_data/require-linked-issue.yml?raw';
-
 ## Dispatch trigger
 
 When template files change on docs-control's `main` branch, the dispatch workflow at `.github/workflows/dispatch-downstream.yml` triggers enforcement in every enrolled downstream repo.
@@ -25,7 +19,26 @@ The workflow reads the downstream repo list, then calls `gh workflow run enforce
 
 ## Enrolled repositories
 
-<Code code={downstreamRepos} lang="json" title=".github/config/downstream-repos.json" />
+```json title=".github/config/downstream-repos.json"
+[
+  "f5xc-salesdemos/docs-builder",
+  "f5xc-salesdemos/docs-theme",
+  "f5xc-salesdemos/docs",
+  "f5xc-salesdemos/administration",
+  "f5xc-salesdemos/nginx",
+  "f5xc-salesdemos/observability",
+  "f5xc-salesdemos/was",
+  "f5xc-salesdemos/mcn",
+  "f5xc-salesdemos/dns",
+  "f5xc-salesdemos/cdn",
+  "f5xc-salesdemos/bot-standard",
+  "f5xc-salesdemos/bot-advanced",
+  "f5xc-salesdemos/ddos",
+  "f5xc-salesdemos/waf",
+  "f5xc-salesdemos/api",
+  "f5xc-salesdemos/csd"
+]
+```
 
 To enroll a new repo, add it to this file and follow the [onboarding procedure](./onboarding/).
 
@@ -37,19 +50,89 @@ The `workflows/` directory contains three workflow files that downstream repos c
 
 Calls both `enforce-repo-settings.yml` and `sync-managed-files.yml` as parallel jobs with separate tokens. Triggers on schedule (every 6 hours), push to `.github/config/**`, and manual dispatch.
 
-<Code code={callerEnforce} lang="yaml" title="workflows/enforce-repo-settings.yml" />
+```yaml title="workflows/enforce-repo-settings.yml"
+name: Enforce Repository Settings
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: enforce-repo-settings
+  cancel-in-progress: true
+
+jobs:
+  enforce-settings:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    secrets:
+      repo-settings-token: $\{{ secrets.REPO_SETTINGS_TOKEN }}
+
+  sync-files:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    secrets:
+      repo-sync-token: $\{{ secrets.REPO_SYNC_TOKEN }}
+```
 
 ### github-pages-deploy.yml
 
 Calls the reusable docs build and deploy workflow. Triggers on push to `docs/**` on main and manual dispatch.
 
-<Code code={callerDeploy} lang="yaml" title="workflows/github-pages-deploy.yml" />
+```yaml title="workflows/github-pages-deploy.yml"
+name: GitHub Pages Deploy
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/github-pages-deploy.yml@main
+```
 
 ### require-linked-issue.yml
 
 Calls the reusable linked-issue check workflow. Triggers on `pull_request_target` events.
 
-<Code code={callerLinkedIssue} lang="yaml" title="workflows/require-linked-issue.yml" />
+```yaml title="workflows/require-linked-issue.yml"
+name: Require Linked Issue
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+concurrency:
+  group: $\{{ github.workflow }}-$\{{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main
+    secrets: inherit
+```
 
 ## Check name format
 

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -4,9 +4,6 @@ sidebar:
   order: 4
 ---
 
-import { Code } from '@astrojs/starlight/components';
-import docsSites from './_data/docs-sites.json?raw';
-
 The file sync workflow at `.github/workflows/sync-managed-files.yml` runs as a parallel job alongside [settings enforcement](./settings-enforcement/), using the `REPO_SYNC_TOKEN` (Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read).
 
 It skips execution when running on the source repo itself (docs-control), since the canonical files already live here.
@@ -37,7 +34,90 @@ Each downstream repo receives a generated `README.md` built from two sources:
 - **`README.md.tpl`** -- a template in the docs-control root with placeholders (`__TITLE__`, `__DESCRIPTION__`, `__REPO_NAME__`, `__DOCS_URL__`)
 - **`docs-sites.json`** -- provides the human-readable label and description for each repo by matching the repo name against the URL field
 
-<Code code={docsSites} lang="json" title=".github/config/docs-sites.json" />
+```json title=".github/config/docs-sites.json"
+[
+  {
+    "label": "f5xc Docs Builder",
+    "url": "https://f5xc-salesdemos.github.io/docs-builder/llms-full.txt",
+    "description": "Containerized Astro + Starlight documentation build system"
+  },
+  {
+    "label": "XC Docs Theme",
+    "url": "https://f5xc-salesdemos.github.io/docs-theme/llms-full.txt",
+    "description": "Shared branding and styling for F5 Distributed Cloud documentation sites"
+  },
+  {
+    "label": "F5 XC Docs",
+    "url": "https://f5xc-salesdemos.github.io/docs/llms-full.txt",
+    "description": "Organization landing page for F5 Distributed Cloud documentation"
+  },
+  {
+    "label": "Administration",
+    "url": "https://f5xc-salesdemos.github.io/administration/llms-full.txt",
+    "description": "F5 XC administration and tenant management"
+  },
+  {
+    "label": "NGINX",
+    "url": "https://f5xc-salesdemos.github.io/nginx/llms-full.txt",
+    "description": "F5 XC NGINX integration and configuration"
+  },
+  {
+    "label": "Observability",
+    "url": "https://f5xc-salesdemos.github.io/observability/llms-full.txt",
+    "description": "F5 XC observability and monitoring"
+  },
+  {
+    "label": "Web App Scanning",
+    "url": "https://f5xc-salesdemos.github.io/was/llms-full.txt",
+    "description": "F5 XC web application scanning"
+  },
+  {
+    "label": "Multi-Cloud Networking",
+    "url": "https://f5xc-salesdemos.github.io/mcn/llms-full.txt",
+    "description": "F5 XC multi-cloud networking"
+  },
+  {
+    "label": "DNS",
+    "url": "https://f5xc-salesdemos.github.io/dns/llms-full.txt",
+    "description": "F5 XC DNS management"
+  },
+  {
+    "label": "CDN",
+    "url": "https://f5xc-salesdemos.github.io/cdn/llms-full.txt",
+    "description": "F5 XC content delivery network"
+  },
+  {
+    "label": "Bot Standard",
+    "url": "https://f5xc-salesdemos.github.io/bot-standard/llms-full.txt",
+    "description": "F5 XC standard bot defense"
+  },
+  {
+    "label": "Bot Advanced",
+    "url": "https://f5xc-salesdemos.github.io/bot-advanced/llms-full.txt",
+    "description": "F5 XC advanced bot defense"
+  },
+  {
+    "label": "DDoS",
+    "url": "https://f5xc-salesdemos.github.io/ddos/llms-full.txt",
+    "description": "F5 XC DDoS protection"
+  },
+  {
+    "label": "WAF",
+    "url": "https://f5xc-salesdemos.github.io/waf/llms-full.txt",
+    "description": "F5 XC web application firewall"
+  },
+  {
+    "label": "API Security",
+    "url": "https://f5xc-salesdemos.github.io/api/llms-full.txt",
+    "description": "F5 XC API security"
+  },
+  {
+    "label": "Client-Side Defense",
+    "url": "https://f5xc-salesdemos.github.io/csd/llms-full.txt",
+    "description": "F5 XC client-side defense"
+  }
+]
+```
 
 The workflow matches the repo name against docs-sites.json URLs to find the label and description. It falls back to a capitalized repo name for the title and the GitHub API repo description if no match is found.
 


### PR DESCRIPTION
## Summary

- Replace `import` + `<Code>` MDX components with fenced markdown code blocks in 3 doc pages
- Delete `docs/_imports` (no longer needed)
- Ensures Starlight `llms.txt` plugin can extract actual file contents instead of rendering raw JSX

## Linked Issue

Closes #78

## Changes

| File | Change |
|------|--------|
| `docs/configuration.mdx` | Inline `repo-settings.json` as fenced JSON |
| `docs/dispatch.mdx` | Inline `downstream-repos.json` + 3 caller workflows as fenced blocks |
| `docs/file-sync.mdx` | Inline `docs-sites.json` as fenced JSON |
| `docs/_imports` | Deleted |

## Trade-off

Loses live sync — if a source file changes, docs won't auto-update. Acceptable for now.

## Test plan

- [ ] CI passes (docs build succeeds)
- [ ] After deploy, verify `llms-full.txt` contains actual file contents (not `import`/`<Code>` JSX)
- [ ] Docs site renders code blocks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)