### PR TITLE
fix: add compatibility shim for deleted reusable-require-linked-issue.yml

### DIFF
--- a/.github/workflows/reusable-require-linked-issue.yml
+++ b/.github/workflows/reusable-require-linked-issue.yml
@@ -1,0 +1,22 @@
+name: Require Linked Issue (compat shim)
+
+on:
+  workflow_call:
+
+permissions:
+  issues: read
+  pull-requests: write
+
+jobs:
+  check-linked-issue:
+    runs-on: ubuntu-latest
+    name: Check linked issues
+    steps:
+      - uses: nearform-actions/github-action-check-linked-issues@v1
+        with:
+          exclude-branches: "dependabot/**,release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*"
+          custom-message: >-
+            This PR must be linked to a GitHub issue. Use 'Closes #123'
+            in the PR description, or link an issue from the sidebar.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Restores `.github/workflows/reusable-require-linked-issue.yml` as a compatibility shim so downstream repos can reference the old path while their governance sync PRs merge
- Contains the full `check-linked-issue` implementation inline (not chaining to `require-linked-issue.yml`) to preserve the correct check name `check / Check linked issues`
- Unblocks all 16 downstream repos with stuck sync PRs from PR #67

## Test plan

- [ ] Shim file is available at `reusable-require-linked-issue.yml@main` after merge
- [ ] Trigger enforcement on docs-theme: close PR #51, run `enforce-repo-settings.yml`
- [ ] Verify new sync PR gets `check / Check linked issues` status check
- [ ] Spot-check 2-3 other downstream repos for unblocked sync PRs

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)