### PR TITLE
fix: close orphaned sync issues before creating new ones

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -317,6 +317,17 @@ jobs:
                   echo "[INFO] Open sync PR #${EXISTING_PR} already exists — attempting merge"
                   wait_and_merge "${EXISTING_PR}" "${OWNER}/${REPO}" || true
                 else
+                  # Close any orphaned sync issues from previous runs
+                  STALE_ISSUES=$(gh issue list --repo "${OWNER}/${REPO}" \
+                    --state open \
+                    --search "chore: sync managed files from governance template" \
+                    --json number --jq '.[].number' 2>/dev/null) || true
+                  for stale_num in $STALE_ISSUES; do
+                    gh issue close "$stale_num" --repo "${OWNER}/${REPO}" \
+                      --comment "Superseded by new sync run. Closing stale issue." 2>/dev/null || true
+                    echo "[INFO] Closed stale sync issue #${stale_num}"
+                  done
+
                   # Create issue
                   DRIFT_LIST=$(printf '%b' "$DRIFT_FILES" | sed '/^$/d' | sed 's/^/- /')
                   ISSUE_BODY=$(printf 'The following managed files have drifted from the canonical source in `%s`:\n\n%s\n\nThis issue was created automatically by the governance enforcement workflow.' \


### PR DESCRIPTION
## Summary

- Fixes a systemic bug where `sync-managed-files.yml` leaves orphaned issues when sync PRs are superseded
- Before creating a new sync issue, the workflow now searches for and closes any existing open issues matching the sync title
- Also closed stale docs-builder issue #61 which was orphaned by this bug

## Context

When a sync PR is superseded (branch force-updated, old PR closed by branch deletion), GitHub only auto-closes issues on **merge**, not on close. The old issue from the superseded PR stays open indefinitely.

**Root cause**: Lines 312-326 of `sync-managed-files.yml` — when no existing open PR is found, a new issue and PR are created, but no check is made for existing open issues from previous runs.

**Example**: docs-builder issue #61 was orphaned when its PR (#62) was closed and replaced by PR #64 (with new issue #63).

## Changes

- **`.github/workflows/sync-managed-files.yml`**: Added stale issue cleanup before new issue creation in the `else` branch (no existing open PR found)
- **docs-builder issue #61**: Closed with explanatory comment

## Test plan

- [ ] CI checks pass on this PR
- [ ] Post-merge: trigger a sync on a downstream repo and verify no orphaned issues accumulate
- [ ] Verify the `gh issue list --search` query correctly matches sync issues

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)