### PR TITLE
fix: enforce strict linting and sync lint configs to downstream repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,3 @@
+---
 blank_issues_enabled: false
 contact_links: []

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
+---
 self-hosted-runner:
   labels: []
 

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -65,7 +65,9 @@
       {"src": ".editorconfig", "dest": ".editorconfig"},
       {"src": ".gitignore", "dest": ".gitignore"},
       {"src": "LICENSE", "dest": "LICENSE"},
-      {"src": ".pre-commit-config.yaml", "dest": ".pre-commit-config.yaml"}
+      {"src": ".pre-commit-config.yaml", "dest": ".pre-commit-config.yaml"},
+      {"src": ".yamllint.yaml", "dest": ".yamllint.yaml"},
+      {"src": ".markdownlint.json", "dest": ".markdownlint.json"}
     ]
   }
 }

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -1,3 +1,4 @@
+---
 name: Dispatch Downstream Enforcement
 
 on:
@@ -20,6 +21,8 @@ on:
       - '.gitignore'
       - 'LICENSE'
       - '.pre-commit-config.yaml'
+      - '.yamllint.yaml'
+      - '.markdownlint.json'
       - 'README.md.tpl'
 
 permissions:

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,3 +1,4 @@
+---
 name: Enforce Repository Settings
 
 on:

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,3 +1,4 @@
+---
 name: Build and Deploy Docs
 on:
   push:

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,3 +1,4 @@
+---
 name: Require Linked Issue
 
 on:

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -1,3 +1,4 @@
+---
 name: Sync Managed Files
 
 on:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,6 @@
 {
   "MD013": false,
-  "MD022": false,
   "MD029": false,
-  "MD032": false,
   "MD040": false,
-  "MD041": false,
-  "MD060": false
+  "MD041": false
 }

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,8 +1,6 @@
 ---
 extends: default
-
 rules:
-  document-start: disable
   line-length: disable
   truthy:
     allowed-values: ["true", "false", "on"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ To change any of these files, open a PR in
 - `.gitignore`
 - `LICENSE`
 - `.pre-commit-config.yaml`
+- `.yamllint.yaml`
+- `.markdownlint.json`
 
 ## Planning Before Execution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Blank issues are disabled. Pick the template that best fits your change.
 Branch from `main` using one of these naming conventions:
 
 | Prefix | Use for | Example |
-|--------|---------|---------|
+| -------- | --------- | --------- |
 | `feature/` | New features | `feature/42-add-rate-limiting` |
 | `fix/` | Bug fixes | `fix/17-correct-threshold-calc` |
 | `docs/` | Documentation | `docs/8-update-setup-guide` |

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -1,3 +1,4 @@
+---
 name: Enforce Repository Settings
 
 on:

--- a/workflows/github-pages-deploy.yml
+++ b/workflows/github-pages-deploy.yml
@@ -1,3 +1,4 @@
+---
 name: GitHub Pages Deploy
 on:
   push:

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -1,3 +1,4 @@
+---
 name: Require Linked Issue
 
 on:


### PR DESCRIPTION
## Summary

- Tighten `.yamllint.yaml`: enable `document-start` rule (was disabled)
- Tighten `.markdownlint.json`: reduce disabled rules from 7 to 4 (MD013, MD029, MD040, MD041)
- Add `---` document-start to 10 YAML files missing it
- Add `.yamllint.yaml` and `.markdownlint.json` to managed files in `repo-settings.json`
- Add lint config paths to dispatch-downstream trigger so changes sync to downstream repos
- Update CLAUDE.md managed files list
- Fix MD060 table formatting in CONTRIBUTING.md

Closes #102
Related: https://github.com/f5xc-salesdemos/docs/issues/28

## Test plan

- [x] `pre-commit run --all-files` passes locally
- [ ] CI checks pass on this PR
- [ ] Post-merge: dispatch workflow triggers downstream sync
- [ ] Post-merge: close https://github.com/f5xc-salesdemos/docs/issues/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)