### PR TITLE
fix: resolve gh auth failure on push-triggered enforcement

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,3 +8,6 @@ paths:
   .github/workflows/**/*.yml:
     ignore:
       - "SC2016:.+"
+  .github/workflows/enforce-repo-settings.yml:
+    ignore:
+      - 'property "repo_settings_token" is not defined'

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Enforce repository settings
         env:
-          GH_TOKEN: ${{ secrets.repo-settings-token }}
+          GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Add `|| secrets.REPO_SETTINGS_TOKEN` fallback to `enforce-repo-settings.yml` so the push trigger (self-enforcement on docs-control) uses the repo-level PAT when no caller provides the `workflow_call` secret
- Add path-specific actionlint ignore for the undeclared secret reference

## Linked Issue
Closes #104

## Test plan
- [ ] Pre-commit hooks pass locally (actionlint, yamllint, etc.)
- [ ] CI checks pass on PR
- [ ] Post-merge: `Enforce Repository Settings` workflow succeeds on push trigger (no more `gh is not authenticated` error)
- [ ] Verify branch protection still matches expected state

🤖 Generated with [Claude Code](https://claude.com/claude-code)