### PR TITLE
test: trigger enforce-repo-settings push workflow for E2E validation

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -1,5 +1,6 @@
 {
   "_comment": "Central repo-settings config — enforced by enforce-repo-settings.yml",
+  "_last_verified": "2026-02-16",
   "repository": {
     "private": false,
     "has_issues": true,


### PR DESCRIPTION
## Summary
- Add `_last_verified` timestamp to `repo-settings.json` to trigger the push-path filter and exercise the enforce-repo-settings workflow on push

## Linked Issue
Closes #107

## Test plan
- [ ] CI checks pass on PR
- [ ] Post-merge: `Enforce Repository Settings` workflow triggers on push and **succeeds** (no more `gh is not authenticated` error)
- [ ] Post-merge: `Dispatch Downstream Enforcement` succeeds
- [ ] Branch protection verified via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)