### PR TITLE
feat: onboard docs-icons repository

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -78,5 +78,10 @@
     "label": "Client-Side Defense",
     "url": "https://f5xc-salesdemos.github.io/csd/llms-full.txt",
     "description": "F5 XC client-side defense"
+  },
+  {
+    "label": "Docs Icons",
+    "url": "https://f5xc-salesdemos.github.io/docs-icons/llms-full.txt",
+    "description": "NPM icon packages and plugins for the F5 XC documentation build system"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -14,5 +14,6 @@
   "f5xc-salesdemos/ddos",
   "f5xc-salesdemos/waf",
   "f5xc-salesdemos/api",
-  "f5xc-salesdemos/csd"
+  "f5xc-salesdemos/csd",
+  "f5xc-salesdemos/docs-icons"
 ]


### PR DESCRIPTION
## Summary
- Register `f5xc-salesdemos/docs-icons` in `downstream-repos.json`
- Add docs-icons entry to `docs-sites.json`

## Linked Issue
Closes #109

## Changes Made
- Added `f5xc-salesdemos/docs-icons` to the downstream repos list
- Added docs-icons docs site entry with label, URL, and description

## Test plan
- [ ] PR CI checks pass (require-linked-issue, linting)
- [ ] After merge, enforce-repo-settings dispatches to docs-icons
- [ ] sync-managed-files dispatches to docs-icons
- [ ] Branch protection applied on docs-icons
- [ ] Docs site accessible at https://f5xc-salesdemos.github.io/docs-icons/

🤖 Generated with [Claude Code](https://claude.com/claude-code)