### PR TITLE
feat: enable Dependabot auto-merge across all repos

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -10,7 +10,7 @@
     "allow_squash_merge": true,
     "allow_merge_commit": true,
     "allow_rebase_merge": true,
-    "allow_auto_merge": false,
+    "allow_auto_merge": true,
     "delete_branch_on_merge": true,
     "web_commit_signoff_required": false,
     "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
@@ -68,7 +68,8 @@
       {"src": "LICENSE", "dest": "LICENSE"},
       {"src": ".pre-commit-config.yaml", "dest": ".pre-commit-config.yaml"},
       {"src": ".yamllint.yaml", "dest": ".yamllint.yaml"},
-      {"src": ".markdownlint.json", "dest": ".markdownlint.json"}
+      {"src": ".markdownlint.json", "dest": ".markdownlint.json"},
+      {"src": "workflows/dependabot-auto-merge.yml", "dest": ".github/workflows/dependabot-auto-merge.yml"}
     ]
   }
 }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+---
+name: Dependabot Auto-Merge
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ To change any of these files, open a PR in
 - `.github/workflows/github-pages-deploy.yml`
 - `.github/workflows/enforce-repo-settings.yml`
 - `.github/workflows/require-linked-issue.yml`
+- `.github/workflows/dependabot-auto-merge.yml`
 - `.github/PULL_REQUEST_TEMPLATE.md`
 - `.github/ISSUE_TEMPLATE/bug_report.md`
 - `.github/ISSUE_TEMPLATE/feature_request.md`

--- a/workflows/dependabot-auto-merge.yml
+++ b/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+---
+name: Dependabot Auto-Merge
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Enable GitHub's auto-merge feature and add a workflow that automatically approves and merges Dependabot PRs across docs-control and all 17 downstream repos.

## Related Issue

Closes #115

## Changes

- Set `allow_auto_merge: true` in `repo-settings.json` (enforced on all repos via `enforce-repo-settings.yml`)
- Create `.github/workflows/dependabot-auto-merge.yml` using `pull_request_target` trigger with `dependabot/fetch-metadata@v2`
- Create downstream caller template at `workflows/dependabot-auto-merge.yml` (synced via managed files)
- Register new workflow in `managed_files.files` array in `repo-settings.json`
- Add `.github/workflows/dependabot-auto-merge.yml` to managed files list in `CLAUDE.md`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions