### PR TITLE
docs: fix sidebar ordering for prev/next navigation

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,7 +1,7 @@
 ---
 title: Architecture
 sidebar:
-  order: 1
+  order: 2
 ---
 
 ## Three-repo pipeline

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration Reference
 sidebar:
-  order: 2
+  order: 3
 ---
 
 The central configuration file drives all enforcement, sync, and dispatch behavior. It lives at `.github/config/repo-settings.json` in docs-control and is fetched by downstream repos at workflow runtime.

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -1,7 +1,7 @@
 ---
 title: Downstream Dispatch
 sidebar:
-  order: 5
+  order: 6
 ---
 
 ## Dispatch trigger

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -1,7 +1,7 @@
 ---
 title: File Synchronization
 sidebar:
-  order: 4
+  order: 5
 ---
 
 The file sync workflow at `.github/workflows/sync-managed-files.yml` runs as a parallel job alongside [settings enforcement](./settings-enforcement/), using the `REPO_SYNC_TOKEN` (Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: Docs Control
 description: Central governance hub for managing CI workflows, repo settings, and documentation pipelines across F5 Distributed Cloud repositories
+sidebar:
+  order: 1
+  hidden: true
 hero:
   tagline: Central governance hub for F5 Distributed Cloud downstream repositories
 ---

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -1,7 +1,7 @@
 ---
 title: Onboarding
 sidebar:
-  order: 6
+  order: 7
 ---
 
 This page covers the procedure to enroll a new repository in the docs-control governance system and optionally migrate existing documentation to Astro Starlight.

--- a/docs/settings-enforcement.mdx
+++ b/docs/settings-enforcement.mdx
@@ -1,7 +1,7 @@
 ---
 title: Settings Enforcement
 sidebar:
-  order: 3
+  order: 4
 ---
 
 The enforcement workflow at `.github/workflows/enforce-repo-settings.yml` is a reusable, idempotent workflow that compares desired repository state against current state and patches any drift. Downstream repos call it via a [caller workflow](./dispatch/). Docs-control also runs it directly on push to `.github/config/repo-settings.json`.


### PR DESCRIPTION
## Summary
- Add `sidebar: { order: 1, hidden: true }` to `docs/index.mdx` so it anchors page ordering without appearing in the sidebar
- Bump all other page sidebar orders by 1 to maintain correct prev/next navigation sequence

## Test plan
- [ ] Verify CI checks pass
- [ ] Confirm prev/next navigation renders in correct order on the docs site
- [ ] Confirm index page does not appear in the sidebar

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)