### PR TITLE
feat: update api references to api-protection after repo rename

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -71,7 +71,7 @@
   },
   {
     "label": "API Security",
-    "url": "https://f5xc-salesdemos.github.io/api/llms-full.txt",
+    "url": "https://f5xc-salesdemos.github.io/api-protection/llms-full.txt",
     "description": "F5 XC API security"
   },
   {

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -13,7 +13,7 @@
   "f5xc-salesdemos/bot-advanced",
   "f5xc-salesdemos/ddos",
   "f5xc-salesdemos/waf",
-  "f5xc-salesdemos/api",
+  "f5xc-salesdemos/api-protection",
   "f5xc-salesdemos/api-mcp",
   "f5xc-salesdemos/csd",
   "f5xc-salesdemos/docs-icons"

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -35,7 +35,7 @@ The workflow reads the downstream repo list, then calls `gh workflow run enforce
   "f5xc-salesdemos/bot-advanced",
   "f5xc-salesdemos/ddos",
   "f5xc-salesdemos/waf",
-  "f5xc-salesdemos/api",
+  "f5xc-salesdemos/api-protection",
   "f5xc-salesdemos/csd"
 ]
 ```

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -108,7 +108,7 @@ Each downstream repo receives a generated `README.md` built from two sources:
   },
   {
     "label": "API Security",
-    "url": "https://f5xc-salesdemos.github.io/api/llms-full.txt",
+    "url": "https://f5xc-salesdemos.github.io/api-protection/llms-full.txt",
     "description": "F5 XC API security"
   },
   {


### PR DESCRIPTION
## Summary
- Updates `downstream-repos.json` repo reference from `api` to `api-protection`
- Updates `docs-sites.json` URL from `/api/` to `/api-protection/`
- Updates embedded code examples in `dispatch.mdx` and `file-sync.mdx`

## Test plan
- [ ] CI checks pass
- [ ] Post-merge enforcement dispatches successfully to downstream repos
- [ ] README.md in api-protection gets regenerated with correct URLs

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)