### PR TITLE
feat: add centrally-managed super-linter workflow

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -30,8 +30,8 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues"],
-        "self_contexts": ["Check linked issues"]
+        "contexts": ["check / Check linked issues", "lint / Lint Code Base"],
+        "self_contexts": ["Check linked issues", "Lint Code Base"]
       },
       "required_pull_request_reviews": null,
       "restrictions": null,
@@ -55,6 +55,7 @@
       {"src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml"},
       {"src": "workflows/enforce-repo-settings.yml", "dest": ".github/workflows/enforce-repo-settings.yml"},
       {"src": "workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml"},
+      {"src": "workflows/super-linter.yml", "dest": ".github/workflows/super-linter.yml"},
       {"src": ".github/PULL_REQUEST_TEMPLATE.md", "dest": ".github/PULL_REQUEST_TEMPLATE.md"},
       {"src": ".github/ISSUE_TEMPLATE/bug_report.md", "dest": ".github/ISSUE_TEMPLATE/bug_report.md"},
       {"src": ".github/ISSUE_TEMPLATE/feature_request.md", "dest": ".github/ISSUE_TEMPLATE/feature_request.md"},

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/sync-managed-files.yml'
       - '.github/workflows/github-pages-deploy.yml'
       - '.github/workflows/require-linked-issue.yml'
+      - '.github/workflows/super-linter.yml'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - '.github/ISSUE_TEMPLATE/**'
       - 'CONTRIBUTING.md'

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,31 @@
+---
+name: Super-Linter
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_call:
+
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Super-Linter
+        uses: super-linter/super-linter@v8
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: "."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,7 @@ To change any of these files, open a PR in
 - `.github/workflows/enforce-repo-settings.yml`
 - `.github/workflows/require-linked-issue.yml`
 - `.github/workflows/dependabot-auto-merge.yml`
+- `.github/workflows/super-linter.yml`
 - `.github/PULL_REQUEST_TEMPLATE.md`
 - `.github/ISSUE_TEMPLATE/bug_report.md`
 - `.github/ISSUE_TEMPLATE/feature_request.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ git checkout -b feature/42-add-rate-limiting
 1. Push your branch and open a PR against `main`
 2. **Link the issue** — use `Closes #42` in the PR description, or link from the sidebar
 3. Fill out the PR template (it loads automatically)
-4. The **"Check linked issues"** CI check will block merge if no issue is linked
+4. The **"Check linked issues"** and **"Lint Code Base"** CI checks will block merge if no issue is linked or linting fails
 
 ## Step 5: Review and Merge
 
@@ -68,7 +68,7 @@ The `main` branch is protected. The following rules are enforced:
 
 - No direct pushes to `main` — all changes go through PRs
 - No force pushes
-- Required status check: **"Check linked issues"** must pass
+- Required status checks: **"Check linked issues"** and **"Lint Code Base"** must pass
 - Admin enforcement enabled — these rules apply to everyone
 
 ## AI Assistant Guidelines

--- a/workflows/super-linter.yml
+++ b/workflows/super-linter.yml
@@ -1,0 +1,22 @@
+---
+name: Super-Linter
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/super-linter.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add Super-Linter v8 as a reusable workflow for consistent linting and security scanning across all downstream repositories
- Create thin caller wrapper for downstream sync following the existing reusable + caller pattern
- Register `Lint Code Base` as a required status check in branch protection

## Changes
- **`.github/workflows/super-linter.yml`** — reusable workflow with `pull_request` + `workflow_call` triggers, all default linters enabled
- **`workflows/super-linter.yml`** — caller wrapper synced to downstream repos (produces `lint / Lint Code Base` check name)
- **`.github/config/repo-settings.json`** — added `lint / Lint Code Base` to `contexts` and `Lint Code Base` to `self_contexts`; added managed file entry
- **`.github/workflows/dispatch-downstream.yml`** — added super-linter reusable workflow to trigger paths
- **`CLAUDE.md`** — added to managed files list
- **`CONTRIBUTING.md`** — documented new CI check in steps 4 and branch protection rules

## Test plan
- [ ] Super-linter workflow runs on this PR (picked up from branch)
- [ ] `Check linked issues` check passes
- [ ] After merge, `dispatch-downstream.yml` triggers and dispatches to downstream repos
- [ ] Branch protection on docs-control includes `Lint Code Base` required check
- [ ] Downstream repos receive `super-linter.yml` via managed file sync

## Notes
- Super-linter runs on this PR but won't be a required check until after merge (branch protection updates post-merge)
- If super-linter finds existing issues in the codebase, the check may fail on this PR but won't block merge
- All default linters enabled — leverages existing `.yamllint.yaml` and `.markdownlint.json` already synced to all repos

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)