### PR TITLE
fix: disable redundant and false-positive super-linter checks

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,3 +29,16 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: "."
+          # Disable formatters that conflict with existing linters
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_JSON_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false
+          # Disable linters inappropriate for governance repo
+          VALIDATE_JSCPD: false
+          VALIDATE_NATURAL_LANGUAGE: false
+          VALIDATE_EDITORCONFIG: false
+          # Disable linters with false positives on reusable workflows
+          VALIDATE_CHECKOV: false
+          VALIDATE_GITHUB_ACTIONS: false
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false


### PR DESCRIPTION
## Summary
- Disable 10 super-linter checks that conflict with existing tools or produce false positives
- Keeps 9 valuable passing linters: GITLEAKS, TRIVY, YAML, MARKDOWN, JSON, SPELL_CODESPELL, BIOME_LINT, PRE_COMMIT, GIT_MERGE_CONFLICT_MARKERS

## Changes
- **`.github/workflows/super-linter.yml`** — added `VALIDATE_*: false` env vars for 10 linters

## Linters Disabled

| Linter | Reason |
|--------|--------|
| BIOME_FORMAT | Wants tabs; project uses 2-space indent per `.editorconfig` |
| JSON_PRETTIER | Redundant with JSON (eslint) |
| MARKDOWN_PRETTIER | Redundant with MARKDOWN (markdownlint) |
| YAML_PRETTIER | Redundant with YAML (yamllint) |
| JSCPD | Flags intentional duplication in caller wrappers |
| NATURAL_LANGUAGE | Flags "repo" and "Code Base" as incorrect terms |
| EDITORCONFIG | False positives on markdown nested list indentation |
| CHECKOV | CKV_GHA_7 too strict for reusable workflow inputs |
| GITHUB_ACTIONS | Can't validate org-level secrets; info-level shellcheck |
| GITHUB_ACTIONS_ZIZMOR | Flags intentional `pull_request_target` and bot checks |

## Test plan
- [ ] Super-linter check passes on this PR
- [ ] `Check linked issues` passes
- [ ] After merge, downstream dispatch triggers successfully

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)