### PR TITLE
feat: support per-repo branch protection context overrides

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -44,6 +44,12 @@
       "allow_fork_syncing": false
     }
   ],
+  "repo_overrides": {
+    "api-mcp": {
+      "additional_contexts": ["Lint & Type Check", "Test", "Build"],
+      "additional_self_contexts": []
+    }
+  },
   "topics": [],
   "pages": {
     "enabled": true,

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -202,6 +202,22 @@ jobs:
                 .required_status_checks |= del(.self_contexts)
               else . end')
 
+            # Merge per-repo additional contexts from repo_overrides
+            REPO_OVERRIDES=$(echo "$CONFIG" | jq -c ".repo_overrides[\"${REPO}\"] // empty")
+            if [ -n "$REPO_OVERRIDES" ] && [ "$REPO_OVERRIDES" != "null" ]; then
+              if [ "$IS_SELF" = true ]; then
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_self_contexts // []')
+              else
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_contexts // []')
+              fi
+              if [ "$EXTRA_CTX" != "[]" ]; then
+                DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+                  --argjson extra "$EXTRA_CTX" \
+                  '.required_status_checks.contexts = (.required_status_checks.contexts + $extra | unique)')
+                echo "[INFO] Merged additional contexts for ${REPO}: $EXTRA_CTX"
+              fi
+            fi
+
             HTTP_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
               --include 2>/dev/null | head -1 | awk '{print $2}') || true
             CURRENT_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
@@ -396,6 +412,21 @@ jobs:
               'if .required_status_checks then
                 .required_status_checks |= del(.self_contexts)
               else . end')
+
+            # Merge per-repo additional contexts (same as Phase 4)
+            REPO_OVERRIDES=$(echo "$CONFIG" | jq -c ".repo_overrides[\"${REPO}\"] // empty")
+            if [ -n "$REPO_OVERRIDES" ] && [ "$REPO_OVERRIDES" != "null" ]; then
+              if [ "$IS_SELF" = true ]; then
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_self_contexts // []')
+              else
+                EXTRA_CTX=$(echo "$REPO_OVERRIDES" | jq -c '.additional_contexts // []')
+              fi
+              if [ "$EXTRA_CTX" != "[]" ]; then
+                DESIRED_PAYLOAD=$(echo "$DESIRED_PAYLOAD" | jq -c \
+                  --argjson extra "$EXTRA_CTX" \
+                  '.required_status_checks.contexts = (.required_status_checks.contexts + $extra | unique)')
+              fi
+            fi
 
             VERIFY_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
 


### PR DESCRIPTION
## Summary
- Add `repo_overrides` section to `repo-settings.json` for per-repo `additional_contexts` and `additional_self_contexts`
- Update `enforce-repo-settings.yml` to merge overrides in Phase 4 (apply) and Phase 7 (verify)
- Initial override: api-mcp gets `Lint & Type Check`, `Test`, `Build` as additional required checks

## Test plan
- [ ] Verify `enforce-repo-settings.yml` runs successfully on push to main
- [ ] Verify repos without overrides are unaffected (contexts unchanged)
- [ ] Verify api-mcp gets the additional contexts after migration PR merges

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)