### PR TITLE
fix: disable cache-poisoning zizmor rule in managed config

### DIFF
--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -25,3 +25,7 @@ rules:
   # analysis unreliable. Repos manage permissions via workflow-level blocks.
   excessive-permissions:
     disable: true
+  # Standard GitHub Actions cache patterns (setup-node, upload-artifact)
+  # are flagged as cache poisoning vectors; these are first-party actions.
+  cache-poisoning:
+    disable: true


### PR DESCRIPTION
## Summary

- Add `cache-poisoning: disable: true` to managed `zizmor.yaml`
- Standard GitHub Actions cache patterns (setup-node, upload-artifact) are first-party with well-understood security properties

## Test plan

- [ ] `lint / Lint Code Base` passes on this PR
- [ ] Downstream repos' GITHUB_ACTIONS_ZIZMOR check no longer fails on cache patterns

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)