### PR TITLE
fix: add secrets-inherit disable to zizmor and fix textlint pattern

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -4,7 +4,7 @@
       "defaultTerms": true,
       "exclude": [
         "repo\\b",
-        "bug[- ]fix(es)?\\b"
+        "[Bb]ug[- ]fix(es)?\\b"
       ]
     }
   }

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -29,3 +29,6 @@ rules:
   # are flagged as cache poisoning vectors; these are first-party actions.
   cache-poisoning:
     disable: true
+  # Caller wrappers use secrets: inherit for reusable workflows
+  secrets-inherit:
+    disable: true


### PR DESCRIPTION
## Summary
- Add `secrets-inherit: disable: true` to `zizmor.yaml` — all downstream caller wrappers use `secrets: inherit` for reusable workflows, which is intentional
- Fix textlint exclude pattern from `"bug[- ]fix(es)?\\b"` to `"[Bb]ug[- ]fix(es)?\\b"` to match the actual default term pattern in textlint-rule-terminology

## Test plan
- [ ] CI passes on this PR (super-linter validates both config files)
- [ ] Verify downstream repos no longer flag `secrets-inherit` or "Bug fixes" in textlint

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)