### PR TITLE
fix: correct textlint bugfix exclude pattern

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -4,7 +4,7 @@
       "defaultTerms": true,
       "exclude": [
         "repo\\b",
-        "[Bb]ug[- ]fix(es)?\\b"
+        "bug[- ]fix(es)?"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- Fix textlint exclude pattern from `"[Bb]ug[- ]fix(es)?\\b"` to `"bug[- ]fix(es)?"` to match the actual default term pattern in textlint-rule-terminology
- The `Set.has()` comparison requires exact string match; the previous pattern had extra `[Bb]` prefix and `\\b` suffix not present in the default term

## Test plan
- [ ] CI passes (NATURAL_LANGUAGE sub-check)
- [ ] Downstream repos no longer flag "Bug fixes" in CONTRIBUTING.md

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)