### PR TITLE
fix: remove api-mcp additional_contexts from repo-settings.json

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -44,12 +44,7 @@
       "allow_fork_syncing": false
     }
   ],
-  "repo_overrides": {
-    "api-mcp": {
-      "additional_contexts": ["Lint & Type Check", "Test", "Build"],
-      "additional_self_contexts": []
-    }
-  },
+  "repo_overrides": {},
   "topics": [],
   "pages": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Remove `repo_overrides.api-mcp` entry from `repo-settings.json` that added `Build`, `Lint & Type Check`, and `Test` as required branch protection checks
- These checks come from api-mcp's own CI which uses `paths-ignore: ['docs/**']`, permanently blocking docs-only PRs (e.g., api-mcp PR #20)
- Post-merge enforcement will update api-mcp branch protection and re-sync managed files to all downstream repos, picking up super-linter fixes from PRs #134-#146

## Test plan
- [ ] CI passes on this PR (`Check linked issues`, `Lint Code Base`)
- [ ] Post-merge enforcement workflow completes successfully
- [ ] api-mcp branch protection shows only `["check / Check linked issues", "lint / Lint Code Base"]`
- [ ] Downstream sync PRs get updated commits and pass CI with fixed super-linter config
- [ ] api-mcp PR #20 becomes mergeable

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)