### PR TITLE
fix: add quoteStyle single and disable CSS formatter in biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,16 @@
     "indentWidth": 2,
     "lineWidth": 120
   },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "css": {
+    "formatter": {
+      "enabled": false
+    }
+  },
   "linter": {
     "enabled": false
   }


### PR DESCRIPTION
## Summary
- Add `javascript.formatter.quoteStyle: "single"` to biome.json template
- Add `css.formatter.enabled: false` to avoid conflicts with Prettier (CSS formatting is handled by super-linter's CSS_PRETTIER check)

## Context
All downstream repos (docs-theme, etc.) use single quotes in JS/TS files. Without this setting, the governance-synced biome.json causes BIOME_FORMAT failures in super-linter, blocking the governance sync PR from merging.

## Test plan
- [ ] Verify biome.json template is valid JSON
- [ ] Verify downstream governance sync creates PR with updated biome.json
- [ ] Verify super-linter BIOME_FORMAT passes in downstream repos

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)