### PR TITLE
fix: correct textlint exclude pattern for build system

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -5,7 +5,7 @@
       "exclude": [
         "repo\\b",
         "bug[- ]fix(es)?",
-        "build system"
+        "build system(s)?"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Fix textlint-rule-terminology exclude pattern from `"build system"` to `"build system(s)?"` to match the exact default term regex

## Why

The exclude mechanism in textlint-rule-terminology requires an exact string match against the regex pattern from the default terms list. The default term entry is `["build system(s)?", "build tool$1"]`, so the exclude must be `"build system(s)?"` not `"build system"`.

This was causing NATURAL_LANGUAGE lint failures in downstream repos (e.g., docs-builder PR #149) where README.md contains "build system".

## Test plan

- [ ] CI passes on this PR (super-linter NATURAL_LANGUAGE check)
- [ ] After merge, docs-builder sync PR #149 should pass NATURAL_LANGUAGE linter

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)