### PR TITLE
fix: disable VALIDATE_TSX in super-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -41,6 +41,7 @@ jobs:
           # TypeScript run ESLint in their own CI with proper dependencies.
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_TYPESCRIPT_ES: false
+          VALIDATE_TSX: false
           # Disable pre-commit — cannot execute inside super-linter container
           VALIDATE_PRE_COMMIT: false
           # Pass SC2016 exclusion to shellcheck via env so actionlint's


### PR DESCRIPTION
## Summary

- Disable `VALIDATE_TSX` in the managed super-linter workflow

## Why

TSX validation uses ESLint, which requires `npm ci` and tsconfig resolution to work. Since super-linter runs in a generic container without project dependencies, TSX validation crashes with:

```
Error while loading rule 'n/no-extraneous-import': File 'astro/tsconfigs/strict' not found.
```

This is the exact same limitation that led to disabling `VALIDATE_JAVASCRIPT_ES` and `VALIDATE_TYPESCRIPT_ES`. The comment block already documents this reasoning — the new `VALIDATE_TSX: false` sits alongside those existing disables.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge and enforcement dispatch, docs-builder sync PR #149 TSX check no longer fails

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)