### PR TITLE
feat: enable biome linting with recommended rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,6 +16,12 @@
     }
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "files": {
+    "maxSize": 5242880
   }
 }


### PR DESCRIPTION
## Summary

- Enable biome linter with recommended rules in managed `biome.json`
- Add `files.maxSize: 5242880` for docs-icons compatibility (icon JSON files exceed biome's 1MB default)

## Motivation

The managed `super-linter.yml` disables ESLint (`VALIDATE_JAVASCRIPT_ES`, `VALIDATE_TYPESCRIPT_ES`, `VALIDATE_JSX`), leaving 3 repos with JS/TS code (docs-builder, docs-theme, docs-icons) without lint coverage in CI.

Super-linter already runs `VALIDATE_BIOME_LINT` (defaults to `true`), but the managed `biome.json` had `"linter": { "enabled": false }`, making it a no-op. Enabling this provides immediate JS/TS lint coverage with zero new workflows, zero new check names, and zero added CI time.

## Pre-merge validation

All 3 downstream JS/TS repos tested locally with the proposed config — zero lint violations found:
- docs-builder: exit 0, no violations
- docs-theme: exit 0, no violations
- docs-icons: exit 0, no violations

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, enforcement dispatches to all downstream repos
- [ ] Content-only repos: biome finds no JS/TS files, passes instantly
- [ ] JS/TS repos: biome lints with recommended rules

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)