### PR TITLE
fix: update biome schema to 2.3.14 and add .codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = *.json

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -79,7 +79,8 @@
       { "src": ".editorconfig-checker.json", "dest": ".editorconfig-checker.json" },
       { "src": ".checkov.yaml", "dest": ".checkov.yaml" },
       { "src": "zizmor.yaml", "dest": "zizmor.yaml" },
-      { "src": ".shellcheckrc", "dest": ".shellcheckrc" }
+      { "src": ".shellcheckrc", "dest": ".shellcheckrc" },
+      { "src": ".codespellrc", "dest": ".codespellrc" }
     ]
   }
 }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,
@@ -22,6 +22,7 @@
     }
   },
   "files": {
-    "maxSize": 5242880
+    "maxSize": 5242880,
+    "includes": ["**", "!packages/*/icons.json"]
   }
 }


### PR DESCRIPTION
## Summary

- Update `biome.json` schema from 2.0.0 to 2.3.14 to match super-linter v8.5.0's biome version
- Add `files.includes` with negation pattern to exclude generated `packages/*/icons.json` from formatting
- Create `.codespellrc` with `skip = *.json` to prevent false positives from brand names in generated icon data
- Add `.codespellrc` to `managed_files` in `repo-settings.json`

## Context

These changes complete the super-linter rollout for `docs-icons`. PR [docs-icons#90](https://github.com/f5xc-salesdemos/docs-icons/pull/90) merged with temporary local versions of these files, but they will be overwritten on the next governance sync unless docs-control is updated.

Closes #163

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, verify governance sync dispatches to downstream repos
- [ ] Verify docs-icons governance sync PR auto-merges successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)