### PR TITLE
fix: add biome overrides for Astro lint false positives

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,5 +24,18 @@
   "files": {
     "maxSize": 5242880,
     "includes": ["**", "!packages/*/icons.json"]
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.astro"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `overrides` in `biome.json` to disable `noUnusedVariables` and `noUnusedImports` for `.astro` files
- Biome's Astro support doesn't understand template-section references, causing 128+ false-positive warnings in `docs-icons`

## Test plan
- [ ] Verify CI passes (biome format + lint on docs-control)
- [ ] After merge, verify governance sync delivers overrides to docs-icons

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)