### PR TITLE
fix: remove pre-commit hooks redundant with super-linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,30 +36,13 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
-  # File hygiene
+  # File size guard (no super-linter equivalent)
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: mixed-line-ending
-        args: ["--fix=lf"]
-      - id: check-yaml
-        args: ["--allow-multiple-documents"]
-      - id: check-json
       - id: check-added-large-files
         args: ["--maxkb=1024"]
-      - id: check-merge-conflict
-      - id: detect-private-key
-
-  # ===========================================================================
-  # Security
-  # ===========================================================================
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
-    hooks:
-      - id: gitleaks
 
   # ===========================================================================
   # Super-Linter (manual stage — run with: pre-commit run super-linter --hook-stage manual)
@@ -78,4 +61,4 @@ repos:
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
-  skip: [local-hooks, gitleaks, super-linter]
+  skip: [local-hooks, super-linter]


### PR DESCRIPTION
## Linked Issue

Closes #170

## Description of Changes

Remove 8 pre-commit hooks from the "File hygiene" and "Security" sections that super-linter already enforces in CI. Retain only `check-added-large-files` which has no super-linter equivalent.

### Removed hooks (covered by super-linter)

| Hook | Super-linter sub-linter |
|---|---|
| `trailing-whitespace` | `EDITORCONFIG` |
| `end-of-file-fixer` | `EDITORCONFIG` |
| `mixed-line-ending` | `EDITORCONFIG` |
| `check-yaml` | `YAML` |
| `check-json` | `JSON` + `BIOME_LINT` |
| `check-merge-conflict` | `GIT_MERGE_CONFLICT_MARKERS` |
| `detect-private-key` | `GITLEAKS` |
| `gitleaks` | `GITLEAKS` |

### Retained

- `check-added-large-files --maxkb=1024` — no super-linter equivalent

### Other changes

- Removed `gitleaks` from `ci.skip` (hook no longer exists)

## Testing

- [x] `pre-commit run --all-files` passes (governance hook correctly blocks main, large files check runs)
- [x] Grep confirms no removed hook IDs remain in the file
- [ ] CI super-linter passes on this PR

## Checklist

- [x] I have linked this PR to a GitHub issue
- [x] I have run the linter locally and fixed any issues
- [x] I have tested my changes
- [x] I have followed the project's coding conventions