### PR TITLE
feat: make super-linter pre-commit hook run automatically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,18 +45,16 @@ repos:
         args: ["--maxkb=1024"]
 
   # ===========================================================================
-  # Super-Linter (manual stage — run with: pre-commit run super-linter --hook-stage manual)
-  # Replaces individual yamllint, markdownlint, shellcheck, and actionlint hooks.
+  # Super-Linter (lints files changed vs main)
   # Requires Docker installed locally (~2GB image pull on first run).
   # ===========================================================================
   - repo: local
     hooks:
       - id: super-linter
         name: Super-Linter (local Docker)
-        entry: bash -c 'docker run --rm -v "$(pwd):/tmp/lint" -w /tmp/lint -e RUN_LOCAL=true -e DEFAULT_BRANCH=main -e LINTER_RULES_PATH="." -e VALIDATE_JSON_PRETTIER=false -e VALIDATE_MARKDOWN_PRETTIER=false -e VALIDATE_YAML_PRETTIER=false ghcr.io/super-linter/super-linter:v8'
+        entry: bash -c 'docker run --rm -v "$(pwd):/tmp/lint" -w /tmp/lint -e RUN_LOCAL=true -e VALIDATE_ALL_CODEBASE=false -e DEFAULT_BRANCH=main -e LINTER_RULES_PATH="." -e VALIDATE_JSON_PRETTIER=false -e VALIDATE_MARKDOWN_PRETTIER=false -e VALIDATE_YAML_PRETTIER=false -e VALIDATE_JAVASCRIPT_PRETTIER=false -e VALIDATE_TYPESCRIPT_PRETTIER=false -e VALIDATE_JAVASCRIPT_ES=false -e VALIDATE_TYPESCRIPT_ES=false -e VALIDATE_TSX=false -e VALIDATE_PRE_COMMIT=false -e SHELLCHECK_OPTS="-e SC2016" ghcr.io/super-linter/super-linter:v8'
         language: system
         pass_filenames: false
-        stages: [manual]
 
 ci:
   autofix_prs: true


### PR DESCRIPTION
## Summary

Makes the super-linter pre-commit hook run automatically on every `git commit` instead of requiring manual invocation.

## Changes

- Remove `stages: [manual]` so the hook runs in the default `pre-commit` stage
- Add `VALIDATE_ALL_CODEBASE=false` so super-linter only lints files changed vs `main`
- Align env vars with CI workflow (`VALIDATE_JAVASCRIPT_PRETTIER`, `VALIDATE_TYPESCRIPT_PRETTIER`, `VALIDATE_JAVASCRIPT_ES`, `VALIDATE_TYPESCRIPT_ES`, `VALIDATE_TSX`, `VALIDATE_PRE_COMMIT`, `SHELLCHECK_OPTS`)

## Test plan

- [ ] Verify `stages: [manual]` is removed from `.pre-commit-config.yaml`
- [ ] Verify `VALIDATE_ALL_CODEBASE=false` is present in the Docker entry
- [ ] Verify env vars match `.github/workflows/super-linter.yml`
- [ ] Verify `super-linter` remains in `ci.skip`
- [ ] CI super-linter workflow passes
- [ ] Downstream repos receive updated file via enforcement

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)