### PR TITLE
fix: chmod 777 /output volume mount to fix container permission denied

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -108,6 +108,7 @@ jobs:
       - name: Build docs with container
         run: |
           mkdir -p ${{ runner.temp }}/docs-output
+          chmod 777 ${{ runner.temp }}/docs-output
 
           docker run --rm \
             --name docs-builder \


### PR DESCRIPTION
## Summary
- Adds `chmod 777` after `mkdir -p` for the `/output` volume mount directory in `github-pages-deploy.yml`
- Fixes UID mismatch: runner creates dir as UID 1001, container runs as UID 1000 (node)
- Safe on ephemeral CI runners — no security implications

## Test plan
- [ ] CI checks pass on this PR (super-linter, linked-issue)
- [ ] After merge, enforcement workflow syncs the updated workflow to downstream repos
- [ ] Downstream content repo docs builds no longer fail with `Permission denied`
- [ ] Verify docs site accessible: `curl -sf https://f5xc-salesdemos.github.io/docs-control/`

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)