### PR TITLE
fix: add biome overrides for CSS/TS and codespell ignore for AKS

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,3 @@
 [codespell]
 skip = *.json
+ignore-words-list = aks

--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,29 @@
           }
         }
       }
+    },
+    {
+      "includes": ["**/*.css"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noImportantStyles": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useNodejsImportProtocol": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add biome overrides to disable `noImportantStyles` for CSS files (`!important` is legitimate in theme overrides)
- Add biome overrides to disable `noExplicitAny` and `useNodejsImportProtocol` for TS files (common in Astro component props)
- Add `aks` to codespell `ignore-words-list` (AKS = Azure Kubernetes Service, not a misspelling)

## Test plan
- [ ] docs-control PR CI passes (super-linter, linked-issue check)
- [ ] After merge, `dispatch-downstream.yml` triggers for `biome.json` and `.codespellrc`
- [ ] Downstream governance sync updates docs-theme PR #231 with fixed canonical configs
- [ ] docs-theme PR #231 auto-merges, closing issue #230

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)