### PR TITLE
fix: add noExplicitAny override for Astro files in biome.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,9 @@
           "correctness": {
             "noUnusedVariables": "off",
             "noUnusedImports": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Add `noExplicitAny: "off"` to the existing `.astro` overrides in `biome.json`
- PR #177 added CSS and TS overrides but missed that `Icon.astro` is an `.astro` file, not `.ts`

## Test plan
- [ ] docs-control PR CI passes
- [ ] After merge, downstream dispatch triggers enforcement in docs-theme
- [ ] docs-theme sync PR #237 lint passes and auto-merges
- [ ] docs-theme issue #230 closes

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)