### PR TITLE
fix: replace specific specs/ gitignore entries with blanket exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,10 +76,7 @@ out/
 docs/_data/
 
 # API spec pipeline
-specs/original/
-specs/discovered/diffs/
-specs/discovered/endpoints/
-specs/discovered/schemas/
+specs/
 docs/specifications/api/
 docs/api-reference/
 .version


### PR DESCRIPTION
## Summary
- Replaces 4 specific `specs/` subdirectory entries (`specs/original/`, `specs/discovered/diffs/`, `specs/discovered/endpoints/`, `specs/discovered/schemas/`) with a single blanket `specs/` exclusion
- Prevents accidental commits of API spec files (e.g., `specs/domains/`, `specs/index.json`) in downstream repos
- Safe for repos without a `specs/` directory — gitignore rules for nonexistent paths are inert

Closes #182

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, verify downstream sync dispatches to api-mcp
- [ ] Verify api-mcp receives updated `.gitignore` with blanket `specs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)