### PR TITLE
fix: update .jscpd.json ignore list and .codespellrc skip patterns

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json
+skip = *.json,*/tools/generated/*
 ignore-words-list = aks

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,12 @@
 {
   "threshold": 10,
   "reporters": ["console"],
-  "ignore": ["**/.github/workflows/**", "**/workflows/**"]
+  "ignore": [
+    "**/.github/workflows/**",
+    "**/workflows/**",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/.git/**"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `**/node_modules/**`, `**/dist/**`, `**/build/**`, `**/.git/**` to `.jscpd.json` ignore array to prevent false-positive duplicate detection in downstream repos
- Add `*/tools/generated/*` to `.codespellrc` skip field so codespell ignores upstream API schema misspellings in machine-generated files

## Related Issue
Closes #184
Closes #180

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] My changes follow the project's code style
- [x] I have verified my changes work as expected
- [x] I have added/updated documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)