### PR TITLE
fix: re-enable useNodejsImportProtocol biome lint rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -54,9 +54,6 @@
       "includes": ["**/*.ts"],
       "linter": {
         "rules": {
-          "style": {
-            "useNodejsImportProtocol": "off"
-          },
           "suspicious": {
             "noExplicitAny": "off"
           }


### PR DESCRIPTION
## Summary
- Remove `useNodejsImportProtocol: off` from the `**/*.ts` override in `biome.json`
- All downstream repos now use `node:` prefix for Node.js imports (api-mcp fixed in PR f5xc-salesdemos/api-mcp#63)
- No other downstream repos have `.ts` files with bare Node.js imports

Closes #186

## Test plan
- [ ] CI passes (super-linter, biome format/lint)
- [ ] Downstream enforcement dispatches successfully after merge
- [ ] api-mcp enforcement runs with updated biome.json without violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)