### PR TITLE
fix: re-enable noExplicitAny and noImportantStyles biome rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,29 +33,6 @@
           "correctness": {
             "noUnusedVariables": "off",
             "noUnusedImports": "off"
-          },
-          "suspicious": {
-            "noExplicitAny": "off"
-          }
-        }
-      }
-    },
-    {
-      "includes": ["**/*.css"],
-      "linter": {
-        "rules": {
-          "complexity": {
-            "noImportantStyles": "off"
-          }
-        }
-      }
-    },
-    {
-      "includes": ["**/*.ts"],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noExplicitAny": "off"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Remove `noExplicitAny: "off"` from `**/*.astro` and `**/*.ts` overrides in `biome.json`
- Remove entire `**/*.css` override (only contained `noImportantStyles: "off"`)
- Remove entire `**/*.ts` override (only contained `noExplicitAny: "off"`)
- All downstream violations were fixed in docs-theme #248

## Test plan
- [ ] CI passes (super-linter with biome)
- [ ] Enforcement dispatch succeeds after merge
- [ ] No new violations in downstream repos

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)