### PR TITLE
fix: update linter configs for Go/Terraform compatibility

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*/tools/generated/*
-ignore-words-list = aks
+skip = *.json,*/tools/generated/*,vendor/*
+ignore-words-list = aks,hcl,ves

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,28 @@ wheels/
 .installed.cfg
 *.egg
 
+# Go
+*.exe
+*.exe~
+*.dll
+*.dylib
+*.test
+*.out
+vendor/
+
+# Terraform
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
 # Python virtual environments
 venv/
 env/

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -7,6 +7,9 @@
     "**/node_modules/**",
     "**/dist/**",
     "**/build/**",
-    "**/.git/**"
+    "**/.git/**",
+    "**/vendor/**",
+    "**/internal/client/**",
+    "**/templates/**"
   ]
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,7 @@
 {
   "MD013": false,
   "MD029": false,
+  "MD033": false,
   "MD040": false,
   "MD041": false
 }


### PR DESCRIPTION
## Summary

- Add Go build artifacts (`.exe`, `.dll`, `.dylib`, `.test`, `.out`, `vendor/`) and Terraform state files (`.terraform/`, `*.tfstate`, etc.) to `.gitignore`
- Allow inline HTML in markdownlint (`MD033: false`) for terraform-generated documentation
- Exclude `vendor/`, `internal/client/`, and `templates/` from jscpd copy detection
- Add `vendor/*` to codespell skip list and `hcl`, `ves` to ignore-words-list

Closes #191

## Test plan

- [ ] Verify `.markdownlint.json` is valid JSON
- [ ] Verify `.jscpd.json` is valid JSON
- [ ] Verify `.codespellrc` is valid INI format
- [ ] CI linter passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)