### PR TITLE
feat: add terraform-provider-f5xc to downstream governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -88,5 +88,10 @@
     "label": "Docs Icons",
     "url": "https://f5xc-salesdemos.github.io/docs-icons/llms-full.txt",
     "description": "NPM icon packages and plugins for the F5 XC documentation build system"
+  },
+  {
+    "label": "Terraform Provider",
+    "url": "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms-full.txt",
+    "description": "Terraform provider for F5 Distributed Cloud"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -16,5 +16,6 @@
   "f5xc-salesdemos/api-protection",
   "f5xc-salesdemos/api-mcp",
   "f5xc-salesdemos/csd",
-  "f5xc-salesdemos/docs-icons"
+  "f5xc-salesdemos/docs-icons",
+  "f5xc-salesdemos/terraform-provider-f5xc"
 ]


### PR DESCRIPTION
## Summary

- Add `f5xc-salesdemos/terraform-provider-f5xc` to `downstream-repos.json` for managed file sync and repository settings enforcement
- Add Terraform Provider entry to `docs-sites.json` for README generation and landing page integration

Closes #193

## Test plan

- [ ] CI passes (JSON validation, linting)
- [ ] After merge, `dispatch-downstream.yml` triggers enforcement on the new repo
- [ ] Managed files sync PR is created in terraform-provider-f5xc
- [ ] Repository settings are applied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)