### PR TITLE
fix: ensure super-linter uses managed yamllint config file

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -48,3 +48,6 @@ jobs:
           # embedded shellcheck also skips it (.shellcheckrc only works
           # for the direct BASH linter, not actionlint's subprocess)
           SHELLCHECK_OPTS: "-e SC2016"
+          # Explicit config file name — super-linter v8 defaults to
+          # .yamllint.yml but our managed config uses .yamllint.yaml
+          YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,5 +1,9 @@
 ---
 extends: default
+ignore: |
+  vendor/
+  node_modules/
+  docs/specifications/
 rules:
   line-length: disable
   truthy:


### PR DESCRIPTION
## Summary

- Add `YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml` to super-linter reusable workflow so the managed yamllint config is actually loaded (super-linter v8 defaults to `.yamllint.yml`)
- Add `ignore:` patterns for `vendor/`, `node_modules/`, and `docs/specifications/` directories to `.yamllint.yaml`

## Context

The terraform-provider-f5xc repo has a 730K-line OpenAPI spec at `docs/specifications/api/openapi.yaml`. Without the managed config being loaded, yamllint uses its built-in defaults which flag thousands of issues in the spec, blocking all PRs.

Closes #195

## Test plan

- [ ] Super-linter passes on this PR (verifies the config is loaded for docs-control itself)
- [ ] After merge + governance sync, terraform-provider-f5xc super-linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)