### PR TITLE
fix: temporarily remove super-linter from required status checks

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -30,8 +30,8 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues", "lint / Lint Code Base"],
-        "self_contexts": ["Check linked issues", "Lint Code Base"]
+        "contexts": ["check / Check linked issues"],
+        "self_contexts": ["Check linked issues"]
       },
       "required_pull_request_reviews": null,
       "restrictions": null,


### PR DESCRIPTION
## Summary
- Temporarily removes `lint / Lint Code Base` from `required_status_checks.contexts` and `self_contexts` in `repo-settings.json`
- Unblocks terraform-provider-f5xc PR #30, which is blocked by pre-existing super-linter failures on the 730K-line OpenAPI spec
- Super-linter will be re-enabled after triage is complete (separate issue/PR)

## Test plan
- [ ] Governance enforcement workflow runs successfully on merge
- [ ] Branch protection updates propagate to downstream repos
- [ ] terraform-provider-f5xc PR #30 can merge without super-linter blocking
- [ ] Verify `lint / Lint Code Base` is no longer a required check

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)