### PR TITLE
feat: add terraform-provider-mcp to downstream governance

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -17,5 +17,6 @@
   "f5xc-salesdemos/api-mcp",
   "f5xc-salesdemos/csd",
   "f5xc-salesdemos/docs-icons",
-  "f5xc-salesdemos/terraform-provider-f5xc"
+  "f5xc-salesdemos/terraform-provider-f5xc",
+  "f5xc-salesdemos/terraform-provider-mcp"
 ]


### PR DESCRIPTION
## Summary
- Add `f5xc-salesdemos/terraform-provider-mcp` to downstream governance list
- New repo was extracted from `terraform-provider-f5xc` and needs managed files

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, governance enforcement dispatches to terraform-provider-mcp
- [ ] terraform-provider-mcp receives managed files (workflows, templates, linter configs)

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)