### PR TITLE
chore: add .claude/ to managed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ reports/
 projects/
 
 # Tool-specific
+.claude/
 .playwright-mcp/
 .serena/
 .auto-claude/


### PR DESCRIPTION
## Summary
Add `.claude/` to the Tool-specific section of the managed `.gitignore`.

## Changes
- Added `.claude/` entry to `.gitignore` under the Tool-specific section

## Why
The `.claude/` directory contains local Claude Code configuration (settings, agents, commands, skills) that should not be committed to repositories. This managed gitignore entry will propagate to all downstream repos via the enforcement sync workflow.

## Impact
- Propagates to all 20+ downstream repos via `sync-managed-files.yml`
- Prevents accidental commits of local Claude Code configuration
- Complements the cleanup of `.claude/` from `terraform-provider-f5xc` (tracked there currently)

## Testing
- Verified the entry is placed correctly in the Tool-specific section
- No functional impact — gitignore is additive

Closes #201