### PR TITLE
docs: add org overview, missing repos, and .codespellrc to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ ecosystem helps when navigating cross-repo dependencies.
 ### Infrastructure repos
 
 | Repo | Role |
-|------|------|
+| ---- | ---- |
 | `docs-control` | Source-of-truth — CI workflows, governance, settings enforcement |
 | `docs-theme` | npm package — Starlight plugin, Astro config, CSS, fonts, layout |
 | `docs-builder` | Docker image — build orchestration, npm deps, Puppeteer PDF |
@@ -589,7 +589,7 @@ dispatch chain but do receive managed files and publish
 docs sites:
 
 | Repo | Role |
-|------|------|
+| ---- | ---- |
 | `terraform-provider-f5xc` | Go Terraform provider for F5 Distributed Cloud |
 | `terraform-provider-mcp` | MCP server exposing Terraform provider schemas |
 | `api-mcp` | MCP server for the F5 XC API |


### PR DESCRIPTION
## Summary

Add ecosystem-wide context to the per-repo CLAUDE.md so that standalone sessions in any repo understand the full organizational structure.

## Changes

### 1. Organization Overview section (new)
Inserted after the heading, before Repository Workflow. Lists all 21 repos:
- **Infrastructure repos** (7): docs-control, docs-theme, docs-builder, docs-icons, terraform-provider-f5xc, terraform-provider-mcp, api-mcp
- **Content repos** (14): docs, administration, nginx, observability, was, mcn, dns, cdn, bot-standard, bot-advanced, ddos, waf, api-protection, csd

### 2. Other Infrastructure Repos subsection (new)
Added after Release dispatch chain, before Content Authoring. Documents the 3 repos that have their own CI pipelines but aren't part of the docs theme/build dispatch chain.

### 3. `.codespellrc` added to managed files list
`repo-settings.json` has 26 managed file entries but CLAUDE.md only listed 25. Added the missing `.codespellrc`.

### 4. Org name references
Added `f5xc-salesdemos` in the Managed Files section intro and Documentation Pipeline intro for clarity.

## Impact

This CLAUDE.md change will sync to all 20 downstream repositories via the enforcement workflow, giving every repo full ecosystem awareness.

Closes #203