### PR TITLE
fix: add .codespellrc to dispatch-downstream.yml paths

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -31,6 +31,7 @@ on:
       - '.checkov.yaml'
       - 'zizmor.yaml'
       - '.shellcheckrc'
+      - '.codespellrc'
       - 'README.md.tpl'
 
 permissions:


### PR DESCRIPTION
## Summary

Add `.codespellrc` to the `on.push.paths` trigger list in `dispatch-downstream.yml`.

## Problem

`.codespellrc` is a managed file synced to all 20 downstream repos, but was missing from the dispatch trigger paths. If `.codespellrc` was the only file changed in a docs-control push, the downstream dispatch would not fire and repos would not receive the update.

## Fix

Single-line addition of `'.codespellrc'` to the paths list.

Closes #205