### PR TITLE
fix: replace dispatch paths allowlist with paths-ignore blocklist

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -4,35 +4,9 @@ name: Dispatch Downstream Enforcement
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/config/repo-settings.json'
-      - '.github/config/downstream-repos.json'
-      - '.github/config/docs-sites.json'
-      - 'workflows/**'
-      - '.github/workflows/enforce-repo-settings.yml'
-      - '.github/workflows/sync-managed-files.yml'
-      - '.github/workflows/github-pages-deploy.yml'
-      - '.github/workflows/require-linked-issue.yml'
-      - '.github/workflows/super-linter.yml'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'CONTRIBUTING.md'
-      - 'CLAUDE.md'
-      - '.editorconfig'
-      - '.gitignore'
-      - 'LICENSE'
-      - '.pre-commit-config.yaml'
-      - '.yamllint.yaml'
-      - '.markdownlint.json'
-      - 'biome.json'
-      - '.jscpd.json'
-      - '.textlintrc'
-      - '.editorconfig-checker.json'
-      - '.checkov.yaml'
-      - 'zizmor.yaml'
-      - '.shellcheckrc'
-      - '.codespellrc'
-      - 'README.md.tpl'
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Replace the manually maintained `paths:` allowlist in `dispatch-downstream.yml` with a `paths-ignore:` blocklist.

## Problem

The workflow used an explicit allowlist of ~28 file paths that had to be kept in sync with the managed files in `repo-settings.json`. Every time a managed file was added, the workflow also needed updating — or dispatch would silently skip that file. This already caused a miss with `.codespellrc` (#205).

## Solution

Switch to `paths-ignore:` with only 2 entries:
- `docs/**` — docs-control's own site content (not synced downstream)
- `README.md` — docs-control's own readme (not synced downstream)

Any push to main that touches anything else — managed files, config, workflows — will trigger downstream dispatch automatically. No more maintenance burden.

Closes #207