### PR TITLE
feat: register devcontainer in downstream repos and docs sites

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -93,5 +93,10 @@
     "label": "Terraform Provider",
     "url": "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms-full.txt",
     "description": "Terraform provider for F5 Distributed Cloud"
+  },
+  {
+    "label": "Dev Container",
+    "url": "https://f5xc-salesdemos.github.io/devcontainer/llms-full.txt",
+    "description": "Isolated development environment with AI coding tools"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -18,5 +18,6 @@
   "f5xc-salesdemos/csd",
   "f5xc-salesdemos/docs-icons",
   "f5xc-salesdemos/terraform-provider-f5xc",
-  "f5xc-salesdemos/terraform-provider-mcp"
+  "f5xc-salesdemos/terraform-provider-mcp",
+  "f5xc-salesdemos/devcontainer"
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ wheels/
 .installed.cfg
 *.egg
 
+# Docker
+.docker-data/
+
 # Go
 *.exe
 *.exe~


### PR DESCRIPTION
## Summary

Onboard the devcontainer repository into the f5xc-salesdemos ecosystem.

## Changes

- `.github/config/downstream-repos.json` — Add `f5xc-salesdemos/devcontainer` (21 → 22 entries)
- `.github/config/docs-sites.json` — Add Dev Container entry for federated search
- `.gitignore` — Add `.docker-data/` under new Docker section (consolidates devcontainer-specific entry)

## Impact

After merge, the enforcement workflow will:
1. Sync all 26 managed files to devcontainer (new downstream repo)
2. Sync the updated `.gitignore` to all 22 downstream repos

## Testing

- Verify `downstream-repos.json` has 22 entries
- Verify `docs-sites.json` has the Dev Container entry
- Verify `.gitignore` includes `.docker-data/`

Closes #209