### PR TITLE
feat: onboard claude-code-proxy into governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -98,5 +98,20 @@
     "label": "Dev Container",
     "url": "https://f5xc-salesdemos.github.io/devcontainer/llms-full.txt",
     "description": "Isolated development environment with AI coding tools"
+  },
+  {
+    "label": "Terraform Provider MCP",
+    "url": "https://f5xc-salesdemos.github.io/terraform-provider-mcp/llms-full.txt",
+    "description": "MCP server exposing Terraform provider schemas"
+  },
+  {
+    "label": "Marketplace",
+    "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
+    "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
+  },
+  {
+    "label": "Claude Code Proxy",
+    "url": "https://f5xc-salesdemos.github.io/claude-code-proxy/llms-full.txt",
+    "description": "API proxy translating Claude API requests to OpenAI-compatible providers"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -20,5 +20,6 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
-  "f5xc-salesdemos/marketplace"
+  "f5xc-salesdemos/marketplace",
+  "f5xc-salesdemos/claude-code-proxy"
 ]


### PR DESCRIPTION
## Summary

Register `claude-code-proxy` in the downstream repos inventory and add three missing repos (`claude-code-proxy`, `marketplace`, `terraform-provider-mcp`) to docs-sites.json for the federated build dispatch chain.

## Related Issue

Closes #214

## Changes

- Added `f5xc-salesdemos/claude-code-proxy` to `downstream-repos.json`
- Added `Terraform Provider MCP`, `Marketplace`, and `Claude Code Proxy` entries to `docs-sites.json`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions