### PR TITLE
fix: add 'datas' to codespell ignore list

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,hcl,ves
+ignore-words-list = aks,datas,hcl,ves


### PR DESCRIPTION
## Summary

- Add `datas` to the `ignore-words-list` in `.codespellrc`

## Context

`datas` is a valid [PyInstaller parameter name](https://pyinstaller.org/en/stable/spec-files.html#adding-data-files) used in `BINARY_PACKAGING.md` across downstream repositories. Codespell flags it as a misspelling of `data`, causing false-positive Super-Linter failures.

Example from `claude-code-proxy`:
```python
datas=[('src', 'src')],    # Data files
```

## Impact

Prevents false-positive codespell failures in all downstream repositories that reference PyInstaller's `datas` parameter.

Closes #217