### PR TITLE
fix: resolve YAML warnings and super-linter config gaps

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,3 +1,4 @@
+---
 skip-check:
   - CKV_GHA_7
   - CKV2_GHA_1

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -51,3 +51,8 @@ jobs:
           # Explicit config file name — super-linter v8 defaults to
           # .yamllint.yml but our managed config uses .yamllint.yaml
           YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml
+          SAVE_SUPER_LINTER_SUMMARY: true
+          # No commitlint config exists in managed repos
+          VALIDATE_GIT_COMMITLINT: false
+          # Keep Ruff Format (faster, recommended over Black)
+          VALIDATE_PYTHON_BLACK: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,10 @@ repos:
     hooks:
       - id: local-hooks
         name: Repository-specific hooks
-        entry: bash -c 'if [ -x scripts/pre-commit-local.sh ]; then scripts/pre-commit-local.sh; fi'
+        entry: >-
+          bash -c
+          'if [ -x scripts/pre-commit-local.sh ];
+          then scripts/pre-commit-local.sh; fi'
         language: system
         always_run: true
         pass_filenames: false
@@ -52,7 +55,25 @@ repos:
     hooks:
       - id: super-linter
         name: Super-Linter (local Docker)
-        entry: bash -c 'docker run --rm -v "$(pwd):/tmp/lint" -w /tmp/lint -e RUN_LOCAL=true -e VALIDATE_ALL_CODEBASE=false -e DEFAULT_BRANCH=main -e LINTER_RULES_PATH="." -e VALIDATE_JSON_PRETTIER=false -e VALIDATE_MARKDOWN_PRETTIER=false -e VALIDATE_YAML_PRETTIER=false -e VALIDATE_JAVASCRIPT_PRETTIER=false -e VALIDATE_TYPESCRIPT_PRETTIER=false -e VALIDATE_JAVASCRIPT_ES=false -e VALIDATE_TYPESCRIPT_ES=false -e VALIDATE_TSX=false -e VALIDATE_PRE_COMMIT=false -e SHELLCHECK_OPTS="-e SC2016" ghcr.io/super-linter/super-linter:v8'
+        entry: >-
+          bash -c
+          'docker run --rm
+          -v "$(pwd):/tmp/lint" -w /tmp/lint
+          -e RUN_LOCAL=true
+          -e VALIDATE_ALL_CODEBASE=false
+          -e DEFAULT_BRANCH=main
+          -e LINTER_RULES_PATH="."
+          -e VALIDATE_JSON_PRETTIER=false
+          -e VALIDATE_MARKDOWN_PRETTIER=false
+          -e VALIDATE_YAML_PRETTIER=false
+          -e VALIDATE_JAVASCRIPT_PRETTIER=false
+          -e VALIDATE_TYPESCRIPT_PRETTIER=false
+          -e VALIDATE_JAVASCRIPT_ES=false
+          -e VALIDATE_TYPESCRIPT_ES=false
+          -e VALIDATE_TSX=false
+          -e VALIDATE_PRE_COMMIT=false
+          -e SHELLCHECK_OPTS="-e SC2016"
+          ghcr.io/super-linter/super-linter:v8'
         language: system
         pass_filenames: false
 

--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -1,34 +1,48 @@
 ---
 rules:
-  # pull_request_target required for dependabot-auto-merge and require-linked-issue
+  # pull_request_target required for
+  # dependabot-auto-merge and require-linked-issue
   pull-request-target:
     disable: true
-  # We use version tags (@v6, @v8) for first-party GitHub actions, not SHAs
+  # We use version tags (@v6, @v8) for
+  # first-party GitHub actions, not SHAs
   unpinned-uses:
     disable: true
-  # Low-confidence finding; persist-credentials: false not required for our use case
+  # Low-confidence finding;
+  # persist-credentials: false not required
+  # for our use case
   artipacked:
     disable: true
-  # pull_request_target is intentional in this governance repo
+  # pull_request_target is intentional in
+  # this governance repo
   dangerous-triggers:
     disable: true
-  # dependabot[bot] actor check is standard practice for auto-merge
+  # dependabot[bot] actor check is standard
+  # practice for auto-merge
   bot-conditions:
     disable: true
-  # Dependabot cooldown config not required for our update frequency
+  # Dependabot cooldown config not required
+  # for our update frequency
   dependabot-cooldown:
     disable: true
-  # Template injection findings are false positives in controlled workflow contexts
+  # Template injection findings are false
+  # positives in controlled workflow contexts
   template-injection:
     disable: true
-  # Reusable workflow callers inherit permissions from callers, making zizmor's
-  # analysis unreliable. Repos manage permissions via workflow-level blocks.
+  # Reusable workflow callers inherit
+  # permissions from callers, making
+  # zizmor's analysis unreliable. Repos
+  # manage permissions via workflow-level
+  # blocks.
   excessive-permissions:
     disable: true
-  # Standard GitHub Actions cache patterns (setup-node, upload-artifact)
-  # are flagged as cache poisoning vectors; these are first-party actions.
+  # Standard GitHub Actions cache patterns
+  # (setup-node, upload-artifact) are flagged
+  # as cache poisoning vectors; these are
+  # first-party actions.
   cache-poisoning:
     disable: true
-  # Caller wrappers use secrets: inherit for reusable workflows
+  # Caller wrappers use secrets: inherit
+  # for reusable workflows
   secrets-inherit:
     disable: true


### PR DESCRIPTION
## Summary

Fix YAML lint warnings and super-linter configuration gaps flagged by downstream CI in `claude-code-proxy` (run `23131568205`). All modified files are centrally managed and synced to downstream repos.

## Related Issue

Closes #219

## Changes

- **`.checkov.yaml`** — Add missing `---` document start marker
- **`.pre-commit-config.yaml`** — Break long `entry` lines (105 and 523 chars) using YAML folded scalars (`>-`)
- **`zizmor.yaml`** — Wrap all comment lines to stay under 80 characters
- **`.github/workflows/super-linter.yml`** — Add `SAVE_SUPER_LINTER_SUMMARY: true`, disable `VALIDATE_GIT_COMMITLINT` (no commitlint config exists), disable `VALIDATE_PYTHON_BLACK` (Ruff Format preferred)

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions