### PR TITLE
chore: remove claude-code-proxy references

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -108,10 +108,5 @@
     "label": "Marketplace",
     "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
-  },
-  {
-    "label": "Claude Code Proxy",
-    "url": "https://f5xc-salesdemos.github.io/claude-code-proxy/llms-full.txt",
-    "description": "API proxy translating Claude API requests to OpenAI-compatible providers"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -20,6 +20,5 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
-  "f5xc-salesdemos/marketplace",
-  "f5xc-salesdemos/claude-code-proxy"
+  "f5xc-salesdemos/marketplace"
 ]


### PR DESCRIPTION
## Summary
- Remove `f5xc-salesdemos/claude-code-proxy` from `downstream-repos.json`
- Remove Claude Code Proxy docs-site entry from `docs-sites.json`

## Context
The claude-code-proxy repo has been stripped of ecosystem artifacts (PR f5xc-salesdemos/claude-code-proxy#62). These upstream references should be cleaned up so the org's governance, docs dispatch pipeline, and federated search stop targeting a repo that no longer participates in the ecosystem.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)