### PR TITLE
fix: replace blanket .claude/ gitignore with targeted patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,10 @@ reports/
 projects/
 
 # Tool-specific
-.claude/
+.claude/settings.json
+.claude/settings.local.json
+.claude/todos/
+.claude/worktrees/
 .playwright-mcp/
 .serena/
 .auto-claude/


### PR DESCRIPTION
## Summary

- Replace blanket `.claude/` gitignore with targeted patterns for files that should remain local
- Allows `.claude/CLAUDE.md` to be committed for project-specific Claude Code instructions
- Still ignores `.claude/settings.json`, `.claude/settings.local.json`, `.claude/todos/`, and `.claude/worktrees/`

## Context

The `csd` repo needed to commit `.claude/CLAUDE.md` for persona trigger instructions (f5xc-salesdemos/csd#290) but had to use `git add -f` because the managed `.gitignore` blanket-ignores the entire `.claude/` directory.

## Impact

This change will be synced to all downstream repos on the next enforcement run, updating their `.gitignore` to use the targeted patterns instead of the blanket ignore.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, enforcement run syncs updated `.gitignore` to downstream repos
- [ ] Downstream repos can commit `.claude/CLAUDE.md` without `git add -f`

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)