### PR TITLE
fix: add iterm to codespellrc ignore-words-list

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,hcl,ves
+ignore-words-list = aks,datas,hcl,iterm,ves


### PR DESCRIPTION
## Summary

- Add `iterm` to `.codespellrc` ignore-words-list
- The devcontainer repo references iTerm extensively in INSTALL.md and codespell flags `iTerm ==> term, item, intern` without this entry
- Prevents downstream repos from needing local overrides to the managed file

## Test plan

- [ ] CI passes with the new ignore word
- [ ] `codespell` no longer flags iTerm references in downstream repos

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)