### PR TITLE
fix: add uncomplete to codespellrc ignore-words-list

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,hcl,iterm,ves
+ignore-words-list = aks,datas,hcl,iterm,uncomplete,ves


### PR DESCRIPTION
## Summary

- Add `uncomplete` to `.codespellrc` ignore-words-list
- Valid gogcli alias for `tasks undo` — codespell flags it as misspelling of `incomplete`

## Test plan

- [ ] CI passes

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)