### PR TITLE
feat: add f5xc-brand plugin to CLAUDE.md directives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,76 +2,72 @@
 
 ## Organization Overview
 
-This repository is part of the **f5xc-salesdemos** GitHub
-organization (21 repositories). Understanding the full
-ecosystem helps when navigating cross-repo dependencies.
+This repository is part of **f5xc-salesdemos** (21 repos).
 
 ### Infrastructure repos
 
 | Repo | Role |
 | ---- | ---- |
-| `docs-control` | Source-of-truth — CI workflows, governance, settings enforcement |
-| `docs-theme` | npm package — Starlight plugin, Astro config, CSS, fonts, layout |
-| `docs-builder` | Docker image — build orchestration, npm deps, Puppeteer PDF |
-| `docs-icons` | npm packages — Iconify JSON icon sets, Astro icon components |
+| `docs-control` | Source-of-truth — CI, governance, settings enforcement |
+| `docs-theme` | npm — Starlight plugin, Astro config, CSS, fonts, layout |
+| `docs-builder` | Docker — build orchestration, npm deps, Puppeteer PDF |
+| `docs-icons` | npm — Iconify JSON icon sets, Astro icon components |
 | `terraform-provider-f5xc` | Custom Go Terraform provider for F5 XC |
-| `terraform-provider-mcp` | MCP server exposing Terraform provider schemas |
+| `terraform-provider-mcp` | MCP server — Terraform provider schemas |
 | `api-mcp` | MCP server for the F5 XC API |
 
 ### Content repos
 
-All content repos follow the same pattern: a `docs/`
-directory with Markdown/MDX content, built by the shared
-Docker image and deployed to GitHub Pages.
-
-`docs` · `administration` · `nginx` · `observability` ·
-`was` · `mcn` · `dns` · `cdn` · `bot-standard` ·
-`bot-advanced` · `ddos` · `waf` · `api-protection` · `csd`
+`docs` `administration` `nginx` `observability` `was` `mcn` `dns` `cdn` `bot-standard` `bot-advanced` `ddos` `waf` `api-protection` `csd`
 
 ## Plugin Directives
 
-Use these installed plugins for all standard operations.
 Invoke the relevant skill **before** starting work.
 
-| Operation | Plugin/Skill |
-| --------- | ------------ |
+### User-invocable skills
+
+| Operation | Skill |
+| --------- | ----- |
 | Commit, push, and PR | `/commit-push-pr` |
 | Commit only | `/commit` |
 | Branch cleanup | `/clean_gone` |
-| Planning | `superpowers:writing-plans` |
-| Verification mindset | `superpowers:verification-before-completion` |
-| Branch completion | `superpowers:finishing-a-development-branch` |
 | PR review | `/review-pr` |
-| Repo workflow and governance | `f5xc-repo-governance:workflow-lifecycle` |
-| Docs pipeline and ownership | `f5xc-docs-pipeline:pipeline-navigator` |
-| Content authoring | `f5xc-docs-pipeline:content-author` |
+| Brand compliance review | `/review-brand` |
 | MDX validation | `/review-mdx` |
 | Local docs preview | `/preview-docs` |
 
-**Activation rules:**
+### Auto-activated skills
 
-- When starting any development task, invoke
-  `workflow-lifecycle` for the full governance protocol
-- When making docs infrastructure changes, invoke
-  `pipeline-navigator` for config ownership guidance
-- When editing docs content, invoke `content-author`
-  for structure and MDX rules
+| Skill | Activates when... |
+| ----- | ----------------- |
+| `f5xc-repo-governance:workflow-lifecycle` | Starting any development task |
+| `f5xc-docs-pipeline:pipeline-navigator` | Changing docs infrastructure config |
+| `f5xc-docs-pipeline:content-author` | Editing docs content (MDX/Markdown) |
+| `f5xc-brand:brand-guardian` | Creating any visual content or assets |
+| `f5xc-brand:visual-content` | Creating Mermaid, PPT, diagrams, slides |
+| `superpowers:writing-plans` | Planning implementation work |
+| `superpowers:verification-before-completion` | Verifying work before marking complete |
+| `superpowers:finishing-a-development-branch` | Completing work on a branch |
+
+**Activation rules** — invoke the matching skill automatically:
+
+1. Development task → `workflow-lifecycle`
+2. Docs infra change → `pipeline-navigator`
+3. Docs content edit → `content-author`
+4. Visual/brand asset creation → `brand-guardian`
+5. Format-specific creation (Mermaid, PPT) → `visual-content`
 
 ## Project-Specific Overrides
 
 These constraints apply on top of all plugin defaults:
 
 - **Create a GitHub issue** before making any changes
-- **Link PRs to issues** using `Closes #N` — fill out
-  the PR template completely
+- **Link PRs to issues** using `Closes #N` — fill out the PR template completely
 - **Conventional commits** — use `feat:`, `fix:`, `docs:`
-- **Squash merge** —
-  `gh pr merge <NUMBER> --squash --delete-branch`
+- **Squash merge** — `gh pr merge <NUMBER> --squash --delete-branch`
 - **No manual approval required** — merge once CI passes
-- **Branch naming** —
-  `<prefix>/<issue-number>-short-description`
-- **DO NOT STOP after creating a PR** — the task is not
-  complete until post-merge workflows pass
+- **Branch naming** — `<prefix>/<issue-number>-short-description`
+- **DO NOT STOP after creating a PR** — the task is not complete until post-merge workflows pass
 - Never push directly to `main`
 - Never force push
 


### PR DESCRIPTION
## Summary

- Add `/review-brand` to user-invocable skills table
- Add `brand-guardian` and `visual-content` to auto-activated skills table
- Add 2 brand activation rules for visual/brand content
- Restructure plugin directives into two clear tables (user-invocable vs auto-activated)
- Compress organization overview to offset new lines

## Details

The root `CLAUDE.md` is the canonical source distributed to all 23 downstream repos. It covered 4 of 5 marketplace plugins — `f5xc-brand` was entirely missing. This adds all 3 brand skills and keeps the file at 76 lines (down from 80, under the 100-line target).

## Test plan

- [x] `wc -l CLAUDE.md` confirms 76 lines (under 100)
- [x] All 5 marketplace plugins represented across CLAUDE.md + .claude/CLAUDE.md
- [x] All 7 slash commands listed in user-invocable table
- [x] All 8 auto-activated skills listed with trigger conditions
- [ ] CI checks pass (codespell, linting)
- [ ] Post-merge sync distributes to downstream repos

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)