### PR TITLE
feat: add GitHub Operations Routing to distributed CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Invoke the relevant skill **before** starting work.
 
 ## GitHub Operations Routing
 
-ALL git and GitHub operations are handled exclusively by the
+ALL Git and GitHub operations are handled exclusively by the
 `f5xc-repo-governance:github-ops` agent. This supersedes the
 `commit-commands` official plugin for all f5xc-salesdemos repos.
 


### PR DESCRIPTION
## Summary

- Add GitHub Operations Routing section routing all git ops to `github-ops` agent
- Remove `/commit` and `/commit-push-pr` from user-invocable skills table
- Add pre-commit lint gate to project-specific overrides
- Includes delegation pattern and error handling instructions

Closes #235

## Test plan

- [ ] CI checks pass
- [ ] CLAUDE.md syntax is valid markdown
- [ ] Routing section clearly prohibits direct git operations in main session