### PR TITLE
fix: replace Docker super-linter with native pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
-  # File size guard (no super-linter equivalent)
+  # File size guard
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -48,36 +48,158 @@ repos:
         args: ["--maxkb=1024"]
 
   # ===========================================================================
-  # Super-Linter (lints files changed vs main)
-  # Requires Docker installed locally (~2GB image pull on first run).
+  # YAML lint — config: .yamllint.yaml
+  # Replaces: VALIDATE_YAML_PRETTIER=false + yamllint in super-linter
   # ===========================================================================
   - repo: local
     hooks:
-      - id: super-linter
-        name: Super-Linter (local Docker)
-        entry: >-
-          bash -c
-          'docker run --rm
-          -v "$(pwd):/tmp/lint" -w /tmp/lint
-          -e RUN_LOCAL=true
-          -e VALIDATE_ALL_CODEBASE=false
-          -e DEFAULT_BRANCH=main
-          -e LINTER_RULES_PATH="."
-          -e VALIDATE_JSON_PRETTIER=false
-          -e VALIDATE_MARKDOWN_PRETTIER=false
-          -e VALIDATE_YAML_PRETTIER=false
-          -e VALIDATE_JAVASCRIPT_PRETTIER=false
-          -e VALIDATE_TYPESCRIPT_PRETTIER=false
-          -e VALIDATE_JAVASCRIPT_ES=false
-          -e VALIDATE_TYPESCRIPT_ES=false
-          -e VALIDATE_TSX=false
-          -e VALIDATE_PRE_COMMIT=false
-          -e SHELLCHECK_OPTS="-e SC2016"
-          ghcr.io/super-linter/super-linter:v8'
+      - id: yamllint
+        name: YAML lint
+        entry: yamllint
+        args: ["-c", ".yamllint.yaml"]
+        language: system
+        types: [yaml]
+
+  # ===========================================================================
+  # Markdown lint — config: .markdownlint.json
+  # Replaces: VALIDATE_MARKDOWN_PRETTIER=false + markdownlint in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: markdownlint
+        name: Markdown lint
+        entry: markdownlint-cli2
+        language: system
+        types: [markdown]
+
+  # ===========================================================================
+  # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)
+  # Replaces: shellcheck in super-linter (was passing SHELLCHECK_OPTS="-e SC2016")
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: Shell script lint
+        entry: shellcheck
+        language: system
+        types: [shell]
+
+  # ===========================================================================
+  # GitHub Actions workflow lint
+  # Replaces: actionlint in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: actionlint
+        name: GitHub Actions lint
+        entry: actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+
+  # ===========================================================================
+  # Dockerfile lint
+  # Replaces: hadolint in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: hadolint
+        name: Dockerfile lint
+        entry: hadolint
+        language: system
+        types: [dockerfile]
+
+  # ===========================================================================
+  # JS / TS / JSON lint — config: biome.json
+  # Replaces: VALIDATE_JAVASCRIPT_ES=false, VALIDATE_TYPESCRIPT_ES=false,
+  #           VALIDATE_JSON_PRETTIER=false in super-linter; uses biome instead
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: biome-check
+        name: Biome lint (JS/TS/JSON)
+        entry: biome check --no-errors-on-unmatched
+        language: system
+        types_or: [javascript, jsx, ts, tsx, json]
+
+  # ===========================================================================
+  # Spell check — config: .codespellrc
+  # Replaces: codespell in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: codespell
+        name: Spelling check
+        entry: codespell
+        language: system
+        types: [text]
+
+  # ===========================================================================
+  # EditorConfig conformance — config: .editorconfig-checker.json
+  # Replaces: editorconfig-checker in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: editorconfig-checker
+        name: EditorConfig check
+        entry: editorconfig-checker
+        language: system
+        pass_filenames: false
+
+  # ===========================================================================
+  # GitHub Actions security scan — config: zizmor.yaml
+  # Replaces: zizmor in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: zizmor
+        name: GitHub Actions security
+        entry: zizmor --config zizmor.yaml
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+
+  # ===========================================================================
+  # Infrastructure / IaC security scan — config: .checkov.yaml
+  # Replaces: checkov in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: checkov
+        name: Infrastructure security scan
+        entry: checkov --config-file .checkov.yaml -d .
+        language: system
+        pass_filenames: false
+        files: ^(\.github/|Dockerfile|.*\.tf|.*\.yaml|.*\.yml)
+
+  # ===========================================================================
+  # Secrets detection
+  # Replaces: gitleaks in super-linter
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: gitleaks
+        name: Secrets detection
+        entry: gitleaks protect --staged --redact
         language: system
         pass_filenames: false
 
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
-  skip: [local-hooks, super-linter]
+  # All language: system hooks require tools installed in the runner —
+  # skip them in pre-commit.ci (cloud) since the environment lacks these binaries.
+  # They run locally and in GitHub Actions CI where tools are pre-installed.
+  skip:
+    - local-hooks
+    - yamllint
+    - markdownlint
+    - shellcheck
+    - actionlint
+    - hadolint
+    - biome-check
+    - codespell
+    - editorconfig-checker
+    - zizmor
+    - checkov
+    - gitleaks


### PR DESCRIPTION
## Summary

- Removes the `docker run ghcr.io/super-linter/super-linter:v8` pre-commit hook which requires Docker-in-Docker (unavailable inside the devcontainer)
- Replaces it with 11 individual `language: system` hooks that call binaries already installed in the container and on macOS
- All system hooks added to `ci: skip:` list so pre-commit.ci (cloud) doesn't fail on missing binaries

**Hooks added** (each uses its existing config file in the repo):

| Hook | Config file | Replaces |
|------|-------------|---------|
| yamllint | `.yamllint.yaml` | VALIDATE_YAML in super-linter |
| markdownlint-cli2 | `.markdownlint.json` | VALIDATE_MARKDOWN |
| shellcheck | `.shellcheckrc` | VALIDATE_BASH (with SC2016 disabled) |
| actionlint | — | VALIDATE_GITHUB_ACTIONS |
| hadolint | — | VALIDATE_DOCKERFILE_HADOLINT |
| biome check | `biome.json` | VALIDATE_JSON, VALIDATE_JAVASCRIPT |
| codespell | `.codespellrc` | VALIDATE_SPELL |
| editorconfig-checker | `.editorconfig-checker.json` | VALIDATE_EDITORCONFIG |
| zizmor | `zizmor.yaml` | VALIDATE_GITHUB_ACTIONS_ZIZMOR |
| checkov | `.checkov.yaml` | VALIDATE_CHECKOV |
| gitleaks | — | VALIDATE_GITLEAKS |

## Test plan

- [ ] Pre-commit hooks run successfully inside the devcontainer without Docker
- [ ] `pre-commit run --all-files` produces no Docker-related errors
- [ ] Each individual hook triggers only on its relevant file types

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)