### PR TITLE
fix: add workflow directory argument to zizmor pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,7 +154,7 @@ repos:
     hooks:
       - id: zizmor
         name: GitHub Actions security
-        entry: zizmor --config zizmor.yaml
+        entry: zizmor --config zizmor.yaml .github/workflows/
         language: system
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false


### PR DESCRIPTION
## Summary

- Added `.github/workflows/` directory argument to the zizmor pre-commit hook entry command
- zizmor v1.23.1 requires at least one positional `<INPUTS>` argument; the hook had `pass_filenames: false` without a directory, causing failures
- This fix propagates to all content repos via managed file sync

Closes #245

## Test plan

- [ ] CI checks pass
- [ ] Verify zizmor hook runs successfully with the directory argument
- [ ] Confirm managed file sync distributes the fix to content repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)