### PR TITLE
fix: suppress secrets-outside-env zizmor warnings for governance workflows

### DIFF
--- a/zizmor.yaml
+++ b/zizmor.yaml
@@ -46,3 +46,9 @@ rules:
   # for reusable workflows
   secrets-inherit:
     disable: true
+  # Governance workflows intentionally use
+  # secrets without dedicated environments;
+  # environment-based access control is not
+  # needed for org-internal automation tokens
+  secrets-outside-env:
+    disable: true


### PR DESCRIPTION
## Summary

- Add `secrets-outside-env: disable: true` to `zizmor.yaml` to suppress 4 medium-severity findings that are intentional
- Governance workflows use org-internal automation tokens (`REPO_SETTINGS_TOKEN`, `repo-sync-token`) without dedicated GitHub environments
- Environment-based access control is not needed for org-internal automation

Closes #247

## Test plan

- [x] Pre-commit hooks pass (YAML lint, spelling, infra security scan, secrets detection)
- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)


Generated with [Claude Code](https://claude.com/claude-code)