### PR TITLE
fix: add stdin guard to hook script for BASH_EXEC linter compatibility

### DIFF
--- a/.claude/hooks/protect-managed-files.sh
+++ b/.claude/hooks/protect-managed-files.sh
@@ -4,6 +4,11 @@
 # Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
 set -euo pipefail
 
+# ── Guard: exit if no stdin (e.g., linter running script directly) ──
+if [ -t 0 ] && [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  exit 0
+fi
+
 # ── Self-exclusion: allow edits in docs-control itself ──────────────
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
 if echo "$REMOTE_URL" | grep -q "docs-control"; then


### PR DESCRIPTION
## Summary

- Add stdin detection guard to `protect-managed-files.sh` that exits 0 when the script is run without a stdin pipe and without `CLAUDE_PROJECT_DIR` set
- Prevents the hook from hanging when super-linter's BASH_EXEC check runs it directly
- Unblocks 10 downstream sync PRs that were failing the lint check

Closes #255

## Test plan

- [ ] CI checks pass (including super-linter BASH_EXEC)
- [ ] Hook still blocks managed file edits when invoked by Claude Code (stdin piped, CLAUDE_PROJECT_DIR set)
- [ ] Hook exits cleanly when run directly by a linter (no stdin, no CLAUDE_PROJECT_DIR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)