### PR TITLE
fix: replace [ -t 0 ] stdin guard with read -t 0 for BASH_EXEC compatibility

### DIFF
--- a/.claude/hooks/protect-managed-files.sh
+++ b/.claude/hooks/protect-managed-files.sh
@@ -4,8 +4,10 @@
 # Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
 set -euo pipefail
 
-# ── Guard: exit if no stdin (e.g., linter running script directly) ──
-if [ -t 0 ] && [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+# ── Guard: exit if no stdin data (e.g., linter running script) ───────
+# read -t 0 checks if stdin has data without consuming it.
+# BASH_EXEC and other linters run scripts without piped input.
+if ! read -t 0 2>/dev/null; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Replace `[ -t 0 ] && [ -z "${CLAUDE_PROJECT_DIR:-}" ]` stdin guard with `read -t 0` in the protect-managed-files hook
- `read -t 0` correctly detects whether stdin has data regardless of terminal vs pipe vs /dev/null
- Fixes BASH_EXEC super-linter failures across all 21 downstream sync PRs

Closes #258

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] BASH_EXEC linter no longer fails on this script
- [ ] Hook still correctly exits when run outside Claude Code context
- [ ] Hook still correctly blocks managed file edits when piped input is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)