### PR TITLE
fix: resolve linter conflicts and YAML line-length warnings

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,19 +29,28 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: "."
-          # Disable prettier formatters — biome handles formatting, yamllint
-          # handles YAML, markdownlint handles MD, eslint-plugin-jsonc handles JSON
+          # Disable Prettier — Biome handles formatting for
+          # JS/TS/JSON/CSS/HTML/GraphQL/JSX/Vue; yamllint handles
+          # YAML; markdownlint handles Markdown.
+          VALIDATE_CSS_PRETTIER: false
+          VALIDATE_GRAPHQL_PRETTIER: false
+          VALIDATE_HTML_PRETTIER: false
           VALIDATE_JSON_PRETTIER: false
-          VALIDATE_MARKDOWN_PRETTIER: false
-          VALIDATE_YAML_PRETTIER: false
+          VALIDATE_JSONC_PRETTIER: false
+          VALIDATE_JSX_PRETTIER: false
           VALIDATE_JAVASCRIPT_PRETTIER: false
+          VALIDATE_MARKDOWN_PRETTIER: false
           VALIDATE_TYPESCRIPT_PRETTIER: false
-          # Disable ESLint validators — super-linter cannot run type-aware
-          # ESLint rules (no npm ci, no tsconfig resolution). Repos with
-          # TypeScript run ESLint in their own CI with proper dependencies.
+          VALIDATE_VUE_PRETTIER: false
+          VALIDATE_YAML_PRETTIER: false
+          # Disable ESLint — Biome handles linting for
+          # JS/TS/JSON/JSX/Vue; super-linter cannot run
+          # type-aware ESLint (no npm ci / tsconfig).
           VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_TYPESCRIPT_ES: false
           VALIDATE_TSX: false
+          # Disable Stylelint — Biome handles CSS linting
+          VALIDATE_CSS: false
           # Disable pre-commit — cannot execute inside super-linter container
           VALIDATE_PRE_COMMIT: false
           # Pass SC2016 exclusion to shellcheck via env so actionlint's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,8 @@ repos:
 
   # ===========================================================================
   # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)
-  # Replaces: shellcheck in super-linter (was passing SHELLCHECK_OPTS="-e SC2016")
+  # Replaces: shellcheck in super-linter
+  # (was passing SHELLCHECK_OPTS="-e SC2016")
   # ===========================================================================
   - repo: local
     hooks:
@@ -187,8 +188,9 @@ repos:
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
-  # All language: system hooks require tools installed in the runner —
-  # skip them in pre-commit.ci (cloud) since the environment lacks these binaries.
+  # All language: system hooks require tools installed
+  # in the runner — skip them in pre-commit.ci (cloud)
+  # since the environment lacks these binaries.
   # They run locally and in GitHub Actions CI where tools are pre-installed.
   skip:
     - local-hooks


### PR DESCRIPTION
## Summary

- Disable Prettier for CSS/GraphQL/HTML/JSONC/JSX/Vue in super-linter — Biome handles formatting for these file types
- Disable Stylelint for CSS — Biome handles CSS linting
- Wrap two comments in `.pre-commit-config.yaml` that exceeded 80 characters

Eliminates 11 Super-Linter warnings about conflicting linters on every CI run.

Closes #260
Closes #261

## Test plan

- [ ] CI checks pass with no linter conflict warnings
- [ ] No regressions in linting coverage