### PR TITLE
fix: disable remaining ESLint validators that conflict with Biome

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -47,8 +47,12 @@ jobs:
           # JS/TS/JSON/JSX/Vue; super-linter cannot run
           # type-aware ESLint (no npm ci / tsconfig).
           VALIDATE_JAVASCRIPT_ES: false
+          VALIDATE_JSON: false
+          VALIDATE_JSONC: false
+          VALIDATE_JSX: false
           VALIDATE_TYPESCRIPT_ES: false
           VALIDATE_TSX: false
+          VALIDATE_VUE: false
           # Disable Stylelint — Biome handles CSS linting
           VALIDATE_CSS: false
           # Disable pre-commit — cannot execute inside super-linter container


### PR DESCRIPTION
## Summary

Add 4 missing `VALIDATE_*: false` flags to eliminate the remaining
Biome/ESLint conflict warnings in Super-Linter:

- `VALIDATE_JSON: false` — Biome handles JSON linting
- `VALIDATE_JSONC: false` — Biome handles JSONC linting
- `VALIDATE_JSX: false` — Biome handles JSX linting
- `VALIDATE_VUE: false` — Biome handles Vue linting

PR #262 disabled Prettier and Stylelint conflicts but missed these
4 ESLint validators. Verified by scanning post-sync Super-Linter
logs across nginx, devcontainer, and marketplace — all 4 warnings
still present.

Closes #261

## Test plan

- [ ] Super-Linter runs with zero conflict warnings