### PR TITLE
fix: add nd and edn to codespell ignore list

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = aks,datas,hcl,iterm,uncomplete,ves
+ignore-words-list = aks,datas,edn,hcl,iterm,nd,uncomplete,ves


### PR DESCRIPTION
## Summary

Add `nd` and `edn` to `.codespellrc` ignore list. Both are false positives from the marketplace tool catalog:

- `nd` — nodriver Python import alias (`import nodriver as nd`)
- `edn` — Clojure Extensible Data Notation file format

Closes #265

Ref: f5xc-salesdemos/marketplace#160

## Test plan

- [x] `codespell` passes locally
- [ ] CI passes