### PR TITLE
chore: onboard api-specs repository to governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -80,6 +80,11 @@
     "description": "MCP server for F5 Distributed Cloud API"
   },
   {
+    "label": "API Specs",
+    "url": "https://f5xc-salesdemos.github.io/api-specs/llms-full.txt",
+    "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud"
+  },
+  {
     "label": "Client-Side Defense",
     "url": "https://f5xc-salesdemos.github.io/csd/llms-full.txt",
     "description": "F5 XC client-side defense"

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -15,6 +15,7 @@
   "f5xc-salesdemos/waf",
   "f5xc-salesdemos/api-protection",
   "f5xc-salesdemos/api-mcp",
+  "f5xc-salesdemos/api-specs",
   "f5xc-salesdemos/csd",
   "f5xc-salesdemos/docs-icons",
   "f5xc-salesdemos/terraform-provider-f5xc",


### PR DESCRIPTION
## Summary

Register `f5xc-salesdemos/api-specs` with the docs-control governance system by adding it to:

- `.github/config/downstream-repos.json` — enables governance enforcement and file sync
- `.github/config/docs-sites.json` — enables docs deployment tracking

Closes #266

## Test plan

- [ ] CI checks pass
- [ ] Verify api-specs appears in downstream-repos.json after api-mcp
- [ ] Verify API Specs entry appears in docs-sites.json after API MCP