### PR TITLE
chore: onboard api-specs-enriched repository to governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -85,6 +85,11 @@
     "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud"
   },
   {
+    "label": "API Specs Enriched",
+    "url": "https://f5xc-salesdemos.github.io/api-specs-enriched/llms-full.txt",
+    "description": "Enriched OpenAPI specifications for F5 Distributed Cloud"
+  },
+  {
     "label": "Client-Side Defense",
     "url": "https://f5xc-salesdemos.github.io/csd/llms-full.txt",
     "description": "F5 XC client-side defense"

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -16,6 +16,7 @@
   "f5xc-salesdemos/api-protection",
   "f5xc-salesdemos/api-mcp",
   "f5xc-salesdemos/api-specs",
+  "f5xc-salesdemos/api-specs-enriched",
   "f5xc-salesdemos/csd",
   "f5xc-salesdemos/docs-icons",
   "f5xc-salesdemos/terraform-provider-f5xc",


### PR DESCRIPTION
## Summary

Register `f5xc-salesdemos/api-specs-enriched` with the docs-control governance system:

- Add to `downstream-repos.json` so it receives governance configurations
- Add to `docs-sites.json` so its docs site is indexed

Closes #268

## Test plan

- [ ] CI checks pass
- [ ] Verify `downstream-repos.json` has the new entry after `api-specs`
- [ ] Verify `docs-sites.json` has the new entry after API Specs