### PR TITLE
feat: add Python indent override and scoped checkov secret skip

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -2,3 +2,4 @@
 skip-check:
   - CKV_GHA_7
   - CKV2_GHA_1
+  - "CKV_SECRET_4:.*specifications/api/.*\\.json$"

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ indent_size = unset
 [*.mdx]
 indent_size = unset
 
+[*.py]
+indent_size = 4
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
Closes #270

## Summary

- **`.editorconfig`**: Add `[*.py] indent_size = 4` override per PEP 8 standard
- **`.checkov.yaml`**: Add scoped `CKV_SECRET_4` skip targeting only API spec JSON files (`specifications/api/`) instead of a global skip

## Why scoped instead of global skip

The original request asked to skip `CKV_SECRET_4` globally. Since this `.checkov.yaml` is governance-managed and distributed to all 24 downstream repos, a global skip would disable Basic Auth credential detection everywhere.

Checkov supports per-check-per-path regex skips: `CKV_SECRET_4:.*specifications/api/.*\.json$` — this suppresses the false positive on auto-generated API spec files while keeping credential detection active on all other files (Terraform, Dockerfiles, configs, etc.) across every repo.

## Changes

| File | Change |
|------|--------|
| `.editorconfig` | Added `[*.py]` section with `indent_size = 4` |
| `.checkov.yaml` | Added `CKV_SECRET_4:.*specifications/api/.*\.json$` to skip-check |

## Checklist

- [x] Linked to issue (#270)
- [x] Changes follow existing patterns
- [x] No secrets or credentials included