### PR TITLE
feat: add .trivyignore as governance-managed file

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -29,6 +29,7 @@
     "zizmor.yaml",
     ".shellcheckrc",
     ".codespellrc",
+    ".trivyignore",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# Governance-managed Trivy ignore list
+# Review quarterly — remove entries when upstream fixes are released
+#
+# Format: one CVE/ID per line
+# Lines starting with # are comments
+
+# CVE-2026-4539 — Low severity (CVSS 3.3) ReDoS in pygments AdlLexer
+# Transitive dependency: rich -> pygments
+# Affected: pygments <= 2.19.2 — no fix released to PyPI
+# Fix merged upstream: pygments/pygments#3064 (2026-03-25)
+# Pygments maintainers dispute this as a security issue per their security policy
+# Impact: Zero — AdlLexer handles openEHR archetype definitions, unused in this context
+# Expiry: 2026-05-31 — re-evaluate after pygments releases fix
+# Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-4539
+CVE-2026-4539


### PR DESCRIPTION
## Summary

- Add `.trivyignore` as a centrally-managed governance file for audited CVE suppressions
- Add CVE-2026-4539 suppression with 60-day expiry (2026-05-31)
- Register `.trivyignore` in `governance.json` protected_files for downstream sync

## CVE-2026-4539 Justification

| Attribute | Value |
|---|---|
| Severity | CVSS 3.3 Low (v3.1) / 4.8 Medium (v4.0) |
| Vulnerability | ReDoS in pygments AdlLexer (archetype.py) |
| Dependency chain | rich → pygments ≤2.19.2 |
| Fix status | Merged upstream (pygments/pygments#3064), not yet released to PyPI |
| Upstream stance | Pygments maintainers dispute this as a security issue per their security policy |
| Impact | Zero — AdlLexer handles openEHR archetype definitions, unused in docs/CI context |

## Checklist

- [x] Linked to issue
- [x] Branch follows naming convention
- [x] Conventional commit message
- [x] CI-relevant changes only

Closes #273