### PR TITLE
fix: add .trivyignore to managed_files sync list

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -82,6 +82,7 @@
       { "src": ".shellcheckrc", "dest": ".shellcheckrc" },
       { "src": ".codespellrc", "dest": ".codespellrc" },
       { "src": ".prettierignore", "dest": ".prettierignore" },
+      { "src": ".trivyignore", "dest": ".trivyignore" },
 
       { "src": ".claude/governance.json", "dest": ".claude/governance.json" },
       { "src": ".claude/settings.json", "dest": ".claude/settings.json" },


### PR DESCRIPTION
## Summary

- Add `.trivyignore` to `repo-settings.json` `managed_files.files` array so the sync workflow propagates the file to downstream repos

## Problem

PR #274 added `.trivyignore` to `governance.json` `protected_files` and created the file, but missed adding it to `repo-settings.json` `managed_files`. The sync workflow only syncs files listed in `managed_files.files`, so downstream repos received the updated `governance.json` (which references `.trivyignore`) but not the actual `.trivyignore` file.

## Checklist

- [x] Linked to issue
- [x] Branch follows naming convention
- [x] Conventional commit message

Closes #273