### PR TITLE
feat: add .claude/scheduled_tasks.lock to governed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ projects/
 .claude/settings.local.json
 .claude/todos/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 .playwright-mcp/
 .serena/
 .auto-claude/


### PR DESCRIPTION
## Summary

- Add `.claude/scheduled_tasks.lock` to the governed `.gitignore` template
- Claude Code's durable CronCreate feature writes this runtime lock file, which shows up as untracked in `git status`
- Follows the existing explicit-naming convention used for other ephemeral `.claude/` artifacts (`settings.local.json`, `todos/`, `worktrees/`)

Closes #277

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] Verify `.claude/scheduled_tasks.lock` is listed in `.gitignore` after governance sync