### PR TITLE
feat: add .prettierignore as governance-managed file

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -29,6 +29,7 @@
     "zizmor.yaml",
     ".shellcheckrc",
     ".codespellrc",
+    ".prettierignore",
     ".trivyignore",
     ".claude/settings.json",
     ".claude/governance.json",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -81,6 +81,7 @@
       { "src": "zizmor.yaml", "dest": "zizmor.yaml" },
       { "src": ".shellcheckrc", "dest": ".shellcheckrc" },
       { "src": ".codespellrc", "dest": ".codespellrc" },
+      { "src": ".prettierignore", "dest": ".prettierignore" },
 
       { "src": ".claude/governance.json", "dest": ".claude/governance.json" },
       { "src": ".claude/settings.json", "dest": ".claude/settings.json" },

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+# Auto-generated files -- do not reformat
+**/src/gen/
+**/src/v2/gen/
+**/src/generated/
+**/*.gen.ts
+**/*.gen.js
+**/*.gen.d.ts


### PR DESCRIPTION
## Summary

- Add governed `.prettierignore` with universal codegen patterns (`src/gen/`, `src/generated/`, `*.gen.ts/js/d.ts`) to prevent Prettier from corrupting auto-generated files
- Register `.prettierignore` in `governance.json` and `repo-settings.json` for downstream sync

Closes #276

## Test plan

- [ ] CI checks pass
- [ ] Governance sync validates `.prettierignore` is distributed to downstream repos
- [ ] Verify codegen output directories are excluded from Prettier formatting