### PR TITLE
feat: onboard oh-my-xcsh into governance ecosystem

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -118,5 +118,10 @@
     "label": "Marketplace",
     "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
+  },
+  {
+    "label": "Oh My XCSh",
+    "url": "https://f5xc-salesdemos.github.io/oh-my-xcsh/llms-full.txt",
+    "description": "Multi-model agent orchestration plugin for OpenCode"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -22,5 +22,6 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
-  "f5xc-salesdemos/marketplace"
+  "f5xc-salesdemos/marketplace",
+  "f5xc-salesdemos/oh-my-xcsh"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -44,7 +44,11 @@
       "allow_fork_syncing": false
     }
   ],
-  "repo_overrides": {},
+  "repo_overrides": {
+    "oh-my-xcsh": {
+      "additional_contexts": ["CI / Tests", "CI / Typecheck", "CI / Build"]
+    }
+  },
   "topics": [],
   "pages": {
     "enabled": true,

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,22 @@ cache/
 src/generated/
 out/
 
+# Bun
+*.bun-build
+
+# OpenCode plugin
+.sisyphus/*
+!.sisyphus/rules/
+packages/*/bin/
+test-injection/
+notepad.md
+oauth-success.html
+.omx/
+
+# Lock file preferences (Bun-based repos)
+package-lock.json
+yarn.lock
+
 # Documentation build artifacts
 docs/_data/
 


### PR DESCRIPTION
## Summary
- Add `f5xc-salesdemos/oh-my-xcsh` to `downstream-repos.json` for dispatch enrollment
- Add docs-sites.json metadata entry for README generation
- Add `repo_overrides` for oh-my-xcsh CI check contexts (Tests, Typecheck, Build)
- Merge 12 unique .gitignore entries from oh-my-xcsh (Bun builds, .sisyphus, platform binaries, .omx, lock file preferences)

## Test plan
- [ ] Verify JSON files are valid
- [ ] After merge, trigger enforcement: `gh workflow run enforce-repo-settings.yml --repo f5xc-salesdemos/oh-my-xcsh`
- [ ] Verify sync PR is created in oh-my-xcsh

Closes #281

Generated with [Claude Code](https://claude.com/claude-code)