### PR TITLE
fix: add bun.lock to codespell skip list

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*/tools/generated/*,vendor/*
+skip = *.json,*/tools/generated/*,vendor/*,bun.lock
 ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,preceeding,uncomplete,ves


### PR DESCRIPTION
Lockfiles are generated content that shouldn't be spell-checked. Codespell flags minified fragments like 'vEw' as errors.

Closes #290

Generated with [Claude Code](https://claude.com/claude-code)