### PR TITLE
fix: correct xcsh CI check names and add ruff.toml to managed files

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -49,7 +49,7 @@
       "additional_contexts": ["CI / Tests", "CI / Typecheck", "CI / Build"]
     },
     "xcsh": {
-      "additional_contexts": ["typecheck", "unit / unit (linux)", "unit / unit (macos)", "e2e / e2e (linux)"]
+      "additional_contexts": ["typecheck", "unit (linux)", "unit (macos)", "e2e (linux)"]
     }
   },
   "topics": [],
@@ -90,6 +90,8 @@
       { "src": ".codespellrc", "dest": ".codespellrc" },
       { "src": ".prettierignore", "dest": ".prettierignore" },
       { "src": ".trivyignore", "dest": ".trivyignore" },
+      { "src": ".ruff.toml", "dest": ".ruff.toml" },
+      { "src": "ruff.toml", "dest": "ruff.toml" },
 
       { "src": ".claude/governance.json", "dest": ".claude/governance.json" },
       { "src": ".claude/settings.json", "dest": ".claude/settings.json" },


### PR DESCRIPTION
## Summary

- Fix xcsh `repo_overrides.additional_contexts` CI check names: changed from `unit / unit (linux)` format to `unit (linux)` to match actual workflow check names
- Add `.ruff.toml` and `ruff.toml` to `managed_files` array so they sync to downstream repos alongside other linter configs

Closes #295

## Test plan

- [ ] CI checks pass
- [ ] Verify xcsh branch protection will reference correct check names after governance sync
- [ ] Verify ruff.toml files will sync to downstream repos on next governance run