### PR TITLE
fix: add ruff.toml to governed files

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -31,6 +31,7 @@
     ".codespellrc",
     ".prettierignore",
     ".trivyignore",
+    "ruff.toml",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"


### PR DESCRIPTION
## Summary
- Adds `ruff.toml` to the `protected_files` array in `governance.json`
- The super-linter reusable workflow sets `PYTHON_RUFF_FORMAT_CONFIG_FILE: ruff.toml`, requiring this file at the repo root of all downstream repos
- Without governance, downstream repos fail CI until someone manually adds it (e.g., f5xc-salesdemos/devcontainer#858)
- All other linter configs are already governed — `ruff.toml` was the only one missing

Closes #297

## Test plan
- [ ] Verify `ruff.toml` appears in `governance.json` protected_files
- [ ] Confirm CI passes on this PR
- [ ] After merge, verify downstream repos receive `ruff.toml` on next governance sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)