### PR TITLE
chore: remove deprecated xcsh repos from automation

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -118,15 +118,5 @@
     "label": "Marketplace",
     "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
-  },
-  {
-    "label": "Oh My XCSh",
-    "url": "https://f5xc-salesdemos.github.io/oh-my-xcsh/llms-full.txt",
-    "description": "Multi-model agent orchestration plugin for OpenCode"
-  },
-  {
-    "label": "XCSh",
-    "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
-    "description": "AI-powered development environment and CLI tool"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -22,7 +22,5 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
-  "f5xc-salesdemos/marketplace",
-  "f5xc-salesdemos/oh-my-xcsh",
-  "f5xc-salesdemos/xcsh"
+  "f5xc-salesdemos/marketplace"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -44,14 +44,7 @@
       "allow_fork_syncing": false
     }
   ],
-  "repo_overrides": {
-    "oh-my-xcsh": {
-      "additional_contexts": ["CI / Tests", "CI / Typecheck", "CI / Build"]
-    },
-    "xcsh": {
-      "additional_contexts": ["typecheck", "unit (linux)", "unit (macos)", "e2e (linux)"]
-    }
-  },
+  "repo_overrides": {},
   "topics": [],
   "pages": {
     "enabled": true,


### PR DESCRIPTION
## Summary
- Removed `oh-my-xcsh` and `xcsh` from `downstream-repos.json`
- Emptied `repo_overrides` in `repo-settings.json` (removed CI check overrides)
- Removed doc site entries from `docs-sites.json`

These repos are being deprecated and renamed. Removing them from docs-control prevents automation from targeting non-existent repos.

## Test plan
- [ ] Verify JSON files are valid
- [ ] Confirm enforce-repo-settings workflow no longer targets xcsh/oh-my-xcsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)