### PR TITLE
feat: enroll xcsh in downstream repo inventory

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -118,5 +118,10 @@
     "label": "Marketplace",
     "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
+  },
+  {
+    "label": "xcsh",
+    "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
+    "description": "AI-powered coding agent CLI and LLM tools"
   }
 ]

--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -118,15 +118,5 @@
     "label": "Marketplace",
     "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
-  },
-  {
-    "label": "Oh My XCSh",
-    "url": "https://f5xc-salesdemos.github.io/oh-my-xcsh/llms-full.txt",
-    "description": "Multi-model agent orchestration plugin for OpenCode"
-  },
-  {
-    "label": "XCSh",
-    "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
-    "description": "AI-powered development environment and CLI tool"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -22,5 +22,6 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
-  "f5xc-salesdemos/marketplace"
+  "f5xc-salesdemos/marketplace",
+  "f5xc-salesdemos/xcsh"
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -22,7 +22,5 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
-  "f5xc-salesdemos/marketplace",
-  "f5xc-salesdemos/oh-my-xcsh",
-  "f5xc-salesdemos/xcsh"
+  "f5xc-salesdemos/marketplace"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -44,14 +44,7 @@
       "allow_fork_syncing": false
     }
   ],
-  "repo_overrides": {
-    "oh-my-xcsh": {
-      "additional_contexts": ["CI / Tests", "CI / Typecheck", "CI / Build"]
-    },
-    "xcsh": {
-      "additional_contexts": ["typecheck", "unit (linux)", "unit (macos)", "e2e (linux)"]
-    }
-  },
+  "repo_overrides": {},
   "topics": [],
   "pages": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Re-enrolls `f5xc-salesdemos/xcsh` in `downstream-repos.json` with updated description
- Removes deprecated `oh-my-xcsh` from all config files
- Cleans up `repo_overrides` in `repo-settings.json` (removed stale CI check overrides)
- Updates xcsh docs-site entry in `docs-sites.json` for LLM docs aggregation

The newly forked xcsh repo is being added back to the governance ecosystem so it receives managed files and settings enforcement, while the deprecated oh-my-xcsh is removed.

## Test plan

- [ ] Verify all JSON files are valid
- [ ] Confirm enforce-repo-settings workflow no longer targets oh-my-xcsh
- [ ] Confirm downstream sync workflows pick up xcsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)