### PR TITLE
chore: remove oh-my-xcsh from ecosystem configuration

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -120,11 +120,6 @@
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
   },
   {
-    "label": "Oh My XCSh",
-    "url": "https://f5xc-salesdemos.github.io/oh-my-xcsh/llms-full.txt",
-    "description": "Multi-model agent orchestration plugin for OpenCode"
-  },
-  {
     "label": "XCSh",
     "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
     "description": "AI-powered development environment and CLI tool"

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -23,6 +23,5 @@
   "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
   "f5xc-salesdemos/marketplace",
-  "f5xc-salesdemos/oh-my-xcsh",
   "f5xc-salesdemos/xcsh"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -45,9 +45,6 @@
     }
   ],
   "repo_overrides": {
-    "oh-my-xcsh": {
-      "additional_contexts": ["CI / Tests", "CI / Typecheck", "CI / Build"]
-    },
     "xcsh": {
       "additional_contexts": ["typecheck", "unit (linux)", "unit (macos)", "e2e (linux)"]
     }


### PR DESCRIPTION
## Summary

- Remove oh-my-xcsh override block from `repo-settings.json`
- Remove oh-my-xcsh from the downstream repos list in `downstream-repos.json`
- Remove Oh My XCSh docs site entry from `docs-sites.json`

Closes #301

## Test plan

- [ ] CI checks pass
- [ ] Verify oh-my-xcsh no longer appears in any ecosystem config file
- [ ] Confirm remaining repo entries are unaffected