### PR TITLE
fix: add per-file-ignores to ruff.toml for test code compatibility

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -31,6 +31,32 @@ ignore = [
     "PLR0915",
 ]
 
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
 [lint.isort]
 split-on-trailing-comma = true
 combine-as-imports = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,32 @@ ignore = [
     "PLR0915",
 ]
 
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",
+    "SLF001",
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+    "PLR2004",
+    "TCH",
+]
+"**/conftest.py" = [
+    "ARG001",
+    "ARG002",
+    "ANN",
+    "D",
+]
+"**/__init__.py" = [
+    "F401",
+    "D104",
+]
+"scripts/**" = [
+    "T201",
+    "INP001",
+]
+
 [lint.isort]
 split-on-trailing-comma = true
 combine-as-imports = true


### PR DESCRIPTION
## Summary

- Adds `[lint.per-file-ignores]` to `ruff.toml` and `.ruff.toml` to exempt standard test code patterns from the governance rule floor
- Fixes 442 lint errors in downstream repos caused by rules that conflict with pytest, private method testing, and fixture injection patterns

Closes #306

## Per-file exemptions added

| Pattern | Rules exempted | Reason |
|---------|---------------|--------|
| `tests/**` | S101, SLF001, ARG001/2, ANN, D, PLR2004, TCH | Standard pytest patterns |
| `**/conftest.py` | ARG001/2, ANN, D | Fixture definitions |
| `**/__init__.py` | F401, D104 | Re-export pattern |
| `scripts/**` | T201, INP001 | CLI print statements, namespace packages |

## Test plan
- [ ] Downstream repos with Python test suites pass ruff lint in CI
- [ ] Assert statements in tests no longer flagged as S101