### PR TITLE
fix: ignore ARG002 globally — interface-contract method signatures

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -29,6 +29,7 @@ ignore = [
     "PLR0913",
     "PLR0912",
     "PLR0915",
+    "ARG002",
 ]
 
 [lint.per-file-ignores]

--- a/ruff.toml
+++ b/ruff.toml
@@ -29,6 +29,7 @@ ignore = [
     "PLR0913",
     "PLR0912",
     "PLR0915",
+    "ARG002",
 ]
 
 [lint.per-file-ignores]


### PR DESCRIPTION
## Summary

Adds `ARG002` to the global `ignore` list in `ruff.toml` and `.ruff.toml`.

Closes #308

## Rationale

`ARG002` (unused method argument) produces systematic false positives for standard OOP patterns where a method must match a shared interface signature even if a specific implementation doesn't use every parameter — dispatcher, strategy, template method, visitor. Downstream `api-specs` required 18 `# noqa: ARG002` suppressions across production code using these patterns.

`ARG001` (unused function argument) remains enabled — standalone functions have no interface contract obligation and genuine unused params there are bugs worth catching.

## Change

```toml
ignore = [
    ...
    "ARG002",   # ← added
]
```

Applied to both `ruff.toml` and `.ruff.toml` (kept identical).

## Related
- #306 — test-code exemptions (merged #307)
- #304 — ruff.toml governance distribution (resolved)

## Test plan

- [ ] CI checks pass
- [ ] Both `ruff.toml` and `.ruff.toml` contain `ARG002` in the ignore list
- [ ] Downstream repos receiving these configs via governance will no longer flag unused method arguments