### PR TITLE
feat: exclude generated output directories from all linters

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,4 +1,9 @@
 ---
+skip-path:
+  - dist
+  - build
+  - release
+  - vendor
 skip-check:
   - CKV_GHA_7
   - CKV2_GHA_1

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,6 +29,7 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: "."
+          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/)"
           # Disable Prettier — Biome handles formatting for
           # JS/TS/JSON/CSS/HTML/GraphQL/JSX/Vue; yamllint handles
           # YAML; markdownlint handles Markdown.

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -7,6 +7,7 @@
     "**/node_modules/**",
     "**/dist/**",
     "**/build/**",
+    "**/release/**",
     "**/.git/**",
     "**/vendor/**",
     "**/internal/client/**",

--- a/biome.json
+++ b/biome.json
@@ -23,9 +23,18 @@
   },
   "files": {
     "maxSize": 5242880,
-    "includes": ["**", "!packages/*/icons.json", "!dist/**", "!build/**", "!release/**", "!vendor/**"]
+    "includes": ["**", "!packages/*/icons.json"]
   },
   "overrides": [
+    {
+      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "formatter": {
+        "enabled": false
+      },
+      "linter": {
+        "enabled": false
+      }
+    },
     {
       "includes": ["**/*.astro"],
       "linter": {

--- a/biome.json
+++ b/biome.json
@@ -23,7 +23,7 @@
   },
   "files": {
     "maxSize": 5242880,
-    "includes": ["**", "!packages/*/icons.json"]
+    "includes": ["**", "!packages/*/icons.json", "!dist/**", "!build/**", "!release/**", "!vendor/**"]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Summary

Excludes `dist/`, `build/`, `release/`, and `vendor/` from all linting — both in CI (super-linter) and locally (pre-commit configs). These are universally recognized generated output directories that produce false positives from format, duplication, security, and API spec linters.

Closes #310

## Changes

| File | Change |
|------|--------|
| `.github/workflows/super-linter.yml` | Add `FILTER_REGEX_EXCLUDE: "(dist/\|build/\|release/\|vendor/)"` — global exclusion for all linters |
| `biome.json` | Add `!dist/**`, `!build/**`, `!release/**`, `!vendor/**` to `files.includes` |
| `.jscpd.json` | Add `**/release/**` to ignore list (dist/build/vendor already present) |
| `.checkov.yaml` | Add `skip-path` for dist, build, release, vendor |

## Impact

Eliminates ~1,100+ false positives in downstream `api-specs` repo (228 BIOME_FORMAT, 9 JSCPD, 100+ OPENAPI, 779 CHECKOV — all from `release/specs/` generated OpenAPI spec files).

## Test plan
- [ ] Super-linter CI passes on this PR
- [ ] Downstream repos with generated output directories no longer fail on those files