### PR TITLE
feat: lint config cleanup — codespell, prettierignore, Spectral

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = *.json,*/tools/generated/*,vendor/*
-ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,preceeding,uncomplete,ves
+skip = *.json,*.lock,*/tools/generated/*,vendor/*
+ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -79,3 +79,6 @@ jobs:
           PYTHON_RUFF_FORMAT_CONFIG_FILE: ruff.toml
           PYTHON_PYLINT_CONFIG_FILE: .python-lint
           PYTHON_MYPY_CONFIG_FILE: .mypy.ini
+          # ── OpenAPI / Spectral ──────────────────────────────
+          # Repos provide their own .spectral.yaml for custom rules.
+          OPENAPI_SPECTRAL_CONFIG_FILE: .spectral.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,9 @@
 **/*.gen.ts
 **/*.gen.js
 **/*.gen.d.ts
+
+# Build and release output
+dist/
+build/
+release/
+vendor/


### PR DESCRIPTION
## Summary

Batch fix for four open lint config issues.

Closes #272
Closes #290
Closes #291
Closes #314

## Changes

| File | Change | Issues |
|------|--------|--------|
| `.codespellrc` | Add `*.lock` to skip list; add `observ`, `pre-select`, `pre-selected`, `pre-selects` to ignore-words-list | #272, #290, #291 |
| `.prettierignore` | Add `dist/`, `build/`, `release/`, `vendor/` directories | #291 |
| `.github/workflows/super-linter.yml` | Add `OPENAPI_SPECTRAL_CONFIG_FILE: .spectral.yaml` | #314 |

## Test plan

- [ ] Super-linter CI passes
- [ ] Downstream repos with `.spectral.yaml` have Spectral use their custom rules
- [ ] codespell no longer flags `observ`, `pre-select*`, or lock file contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)