### PR TITLE
fix: revert to PAT for governance workflows

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -27,11 +27,9 @@ jobs:
 
       - name: Enforce repository settings
         env:
-          GH_TOKEN: ${{ github.token }}
-          ADMIN_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
+          GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
         run: |
           set -euo pipefail
-          export GH_TOKEN
 
           # ─── Retry helpers ─────────────────────────────────────────────────
           # Retry with exponential backoff (for commands without stdin)
@@ -140,7 +138,7 @@ jobs:
 
           if [ "$REPO_DRIFT" = true ]; then
             echo "[INFO] Patching repository settings..."
-            GH_TOKEN="$ADMIN_TOKEN" retry_json 3 "$REPO_PATCH" "repos/${OWNER}/${REPO}" --method PATCH >/dev/null
+            retry_json 3 "$REPO_PATCH" "repos/${OWNER}/${REPO}" --method PATCH >/dev/null
             echo "[OK] Repository settings updated"
           else
             echo "[OK] Repository settings match — no changes needed"
@@ -167,7 +165,7 @@ jobs:
 
             if [ "$ACTIONS_DRIFT" = true ]; then
               echo "[INFO] Updating Actions workflow permissions..."
-              GH_TOKEN="$ADMIN_TOKEN" retry_json 3 "$DESIRED_ACTIONS" "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
+              retry_json 3 "$DESIRED_ACTIONS" "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
                 --method PUT >/dev/null
               echo "[OK] Actions permissions updated"
             else
@@ -313,7 +311,7 @@ jobs:
                   allow_fork_syncing: $desired.allow_fork_syncing
                 }')
 
-              GH_TOKEN="$ADMIN_TOKEN" retry_json 3 "$PUT_PAYLOAD" "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+              retry_json 3 "$PUT_PAYLOAD" "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
                 --method PUT >/dev/null
               echo "[OK] Branch protection updated for $BRANCH"
             else
@@ -332,7 +330,7 @@ jobs:
               echo "[WARN] Drift in topics: current=$CURRENT_TOPICS desired=$DESIRED_TOPICS"
               echo "[INFO] Updating topics..."
               TOPICS_JSON=$(jq -n --argjson names "$DESIRED_TOPICS" '{"names": $names}')
-              GH_TOKEN="$ADMIN_TOKEN" retry_json 3 "$TOPICS_JSON" "repos/${OWNER}/${REPO}/topics" --method PUT >/dev/null
+              retry_json 3 "$TOPICS_JSON" "repos/${OWNER}/${REPO}/topics" --method PUT >/dev/null
               echo "[OK] Topics updated"
             else
               echo "[OK] Topics match — no changes needed"
@@ -352,7 +350,7 @@ jobs:
             PAGES_JSON=$(jq -n --arg bt "$DESIRED_BUILD_TYPE" '{"build_type": $bt, "source": {"branch": "main", "path": "/"}}')
             if [ "$PAGES_HTTP_CODE" = "404" ]; then
               echo "[INFO] Enabling GitHub Pages with ${DESIRED_BUILD_TYPE} source..."
-              GH_TOKEN="$ADMIN_TOKEN" retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1 || true
+              retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1 || true
               echo "[OK] Pages enabled with build_type=${DESIRED_BUILD_TYPE}"
             else
               PAGES_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
@@ -360,7 +358,7 @@ jobs:
               if [ "$CURRENT_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
                 echo "[WARN] Drift in pages.build_type: current=$CURRENT_BUILD_TYPE desired=$DESIRED_BUILD_TYPE"
                 echo "[INFO] Updating Pages build_type to ${DESIRED_BUILD_TYPE}..."
-                GH_TOKEN="$ADMIN_TOKEN" retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method PUT >/dev/null 2>&1
+                retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method PUT >/dev/null 2>&1
                 echo "[OK] Pages build_type updated to ${DESIRED_BUILD_TYPE}"
               else
                 echo "[OK] Pages build_type matches (${CURRENT_BUILD_TYPE}) — no changes needed"

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -17,11 +17,9 @@ jobs:
 
       - name: Sync managed files
         env:
-          GH_TOKEN: ${{ github.token }}
-          SYNC_TOKEN: ${{ secrets.repo-sync-token }}
+          GH_TOKEN: ${{ secrets.repo-sync-token }}
         run: |
           set -euo pipefail
-          export GH_TOKEN
 
           # ─── Retry helpers ─────────────────────────────────────────────────
           # Retry with exponential backoff (for commands without stdin)
@@ -107,7 +105,7 @@ jobs:
                   echo "[INFO] CI passed — merging PR #${pr_num}..."
                   local merge_attempts=0
                   while [ "$merge_attempts" -lt 3 ]; do
-                    if GH_TOKEN="$SYNC_TOKEN" gh pr merge "${pr_num}" --repo "${repo_slug}" --squash --delete-branch; then
+                    if gh pr merge "${pr_num}" --repo "${repo_slug}" --squash --delete-branch; then
                       echo "[OK] Merged sync PR #${pr_num}"
                       return 0
                     fi
@@ -340,7 +338,7 @@ jobs:
                   # Force-update the PR branch to main's HEAD so it stays rebased
                   MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
                   BRANCH_UPDATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}')
-                  GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$BRANCH_UPDATE_JSON" \
+                  retry_json 3 "$BRANCH_UPDATE_JSON" \
                     "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" --method PATCH >/dev/null
                   echo "[OK] Rebased PR branch onto main HEAD"
 
@@ -363,7 +361,7 @@ jobs:
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"branch":$branch}')
                     fi
-                    GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
+                    retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
                     echo "[OK] Updated ${dest_file} on PR branch"
                   done
 
@@ -382,7 +380,7 @@ jobs:
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"branch":$branch}')
                     fi
-                    GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
+                    retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
                     echo "[OK] Updated .github/dependabot.yml on PR branch"
                   fi
 
@@ -401,7 +399,7 @@ jobs:
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"branch":$branch}')
                     fi
-                    GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
+                    retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
                     echo "[OK] Updated README.md on PR branch"
                   fi
 
@@ -431,9 +429,9 @@ jobs:
                   # Create branch from main HEAD (try create, fall back to update if concurrent run created it)
                   MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
                   BRANCH_CREATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"ref":"refs/heads/governance/sync-managed-files","sha":$sha}')
-                  if ! GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$BRANCH_CREATE_JSON" "repos/${OWNER}/${REPO}/git/refs" --method POST >/dev/null 2>&1; then
+                  if ! retry_json 3 "$BRANCH_CREATE_JSON" "repos/${OWNER}/${REPO}/git/refs" --method POST >/dev/null 2>&1; then
                     BRANCH_UPDATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}')
-                    GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$BRANCH_UPDATE_JSON" "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" --method PATCH >/dev/null
+                    retry_json 3 "$BRANCH_UPDATE_JSON" "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" --method PATCH >/dev/null
                   fi
                   echo "[OK] Created or updated branch governance/sync-managed-files"
 
@@ -460,14 +458,14 @@ jobs:
                             --arg sha "$FILE_SHA" \
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}')
-                      GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
+                      retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
                     else
                       # Create new file
                       COMMIT_JSON=$(jq -n --arg msg "chore: sync ${dest_file}" \
                             --arg content "$B64" \
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"branch":$branch}')
-                      GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
+                      retry_json 3 "$COMMIT_JSON" "repos/${OWNER}/${REPO}/contents/${dest_file}" --method PUT >/dev/null
                     fi
                     echo "[OK] Synced ${dest_file}"
                   done
@@ -483,13 +481,13 @@ jobs:
                             --arg sha "$DEPBOT_SHA" \
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}')
-                      GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
+                      retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
                     else
                       DEPBOT_COMMIT=$(jq -n --arg msg "chore: create .github/dependabot.yml" \
                             --arg content "$DEPBOT_B64" \
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"branch":$branch}')
-                      GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
+                      retry_json 3 "$DEPBOT_COMMIT" "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT >/dev/null
                     fi
                     echo "[OK] Synced .github/dependabot.yml (dynamic)"
                   fi
@@ -505,13 +503,13 @@ jobs:
                             --arg sha "$README_SHA" \
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}')
-                      GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
+                      retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
                     else
                       README_COMMIT=$(jq -n --arg msg "chore: create README.md" \
                             --arg content "$README_B64" \
                             --arg branch "governance/sync-managed-files" \
                         '{"message":$msg,"content":$content,"branch":$branch}')
-                      GH_TOKEN="$SYNC_TOKEN" retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
+                      retry_json 3 "$README_COMMIT" "repos/${OWNER}/${REPO}/contents/README.md" --method PUT >/dev/null
                     fi
                     echo "[OK] Synced README.md (dynamic)"
                   fi
@@ -519,7 +517,7 @@ jobs:
                   # Create PR
                   PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \
                     "$ISSUE_NUM" "$SOURCE_REPO" "$DRIFT_LIST")
-                  GH_TOKEN="$SYNC_TOKEN" PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
+                  PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
                     --head governance/sync-managed-files \
                     --title "chore: sync managed files from governance template" \
                     --body "$PR_BODY")


### PR DESCRIPTION
## Summary

Reverts PR #313's GITHUB_TOKEN optimization. `github.token` doesn't have admin-level permissions needed for Actions permissions reads, branch protection reads, and issue creation — all of which are required by the governance workflows.

## Evidence

https://github.com/f5xc-salesdemos/api-specs/actions/runs/24590252339 — both enforce-settings and sync-files failed with `Resource not accessible by integration (HTTP 403)`.

## Changes

- `enforce-repo-settings.yml`: GH_TOKEN reverted to `${{ secrets.repo-settings-token }}`
- `sync-managed-files.yml`: GH_TOKEN reverted to `${{ secrets.repo-sync-token }}`
- Removed ADMIN_TOKEN/SYNC_TOKEN split and inline overrides

Closes #317

## Test plan

- [ ] CI checks pass
- [ ] Governance workflows succeed in downstream repos after merge