### PR TITLE
fix: explicitly configure yamllint brackets rule for consistency

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -6,6 +6,11 @@ ignore: |
   docs/specifications/
 rules:
   line-length: disable
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 0
+    max-spaces-inside-empty: 0
   truthy:
     allowed-values: ["true", "false", "on"]
   comments:


### PR DESCRIPTION
## Summary

Adds explicit `brackets` rule configuration to `.yamllint.yaml` to prevent warnings caused by yamllint version differences in super-linter. Does NOT disable `document-start` — governance enforces best practices, downstream maintainers must add `---` to their own YAML files.

## Change

```yaml
brackets:
  min-spaces-inside: 0
  max-spaces-inside: 0
  min-spaces-inside-empty: 0
  max-spaces-inside-empty: 0
```

Closes #320

## Test plan
- [ ] All governed YAML files pass yamllint cleanly
- [ ] Empty brackets `[]` no longer produce warnings in super-linter