### PR TITLE
feat: add native Spectral OpenAPI lint step to CI workflow

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -80,5 +80,13 @@ jobs:
           PYTHON_PYLINT_CONFIG_FILE: .python-lint
           PYTHON_MYPY_CONFIG_FILE: .mypy.ini
           # ── OpenAPI / Spectral ──────────────────────────────
-          # Repos provide their own .spectral.yaml for custom rules.
-          OPENAPI_SPECTRAL_CONFIG_FILE: .spectral.yaml
+          # Disabled — super-linter's Docker container can't resolve
+          # repo-specific .spectral.yaml paths. Handled by the
+          # dedicated Spectral step below (runs natively on runner).
+          VALIDATE_OPENAPI: false
+
+      - name: Spectral OpenAPI lint
+        if: hashFiles('.spectral.yaml', '.spectral.yml') != ''
+        uses: stoplightio/spectral-action@latest
+        with:
+          file_glob: "**/*.json **/*.yaml"


### PR DESCRIPTION
## Summary

Super-linter's Docker container can't resolve repo-specific `.spectral.yaml` paths — the `OPENAPI_SPECTRAL_CONFIG_FILE` env var doesn't work with `LINTER_RULES_PATH: "."` inside the container. This was the last remaining linter failure in downstream repos with OpenAPI specs.

## Fix

- Disable super-linter's `VALIDATE_OPENAPI` (broken Docker path resolution)
- Add a dedicated `stoplightio/spectral-action` step that runs natively on the runner
- Conditional: `if: hashFiles('.spectral.yaml', '.spectral.yml') != ''` — only runs when the repo has a Spectral config
- The native action auto-discovers `.spectral.yaml` from the repo root

## Impact

Downstream repos with `.spectral.yaml` (e.g., `api-specs`) get proper Spectral validation in CI with their custom rules. Repos without OpenAPI specs skip the step entirely.

Closes #323

## Test plan

- [ ] Super-linter CI passes (OPENAPI disabled, no regression)
- [ ] Downstream repos with .spectral.yaml get Spectral validation in CI