### PR TITLE
fix: restrict checkov frameworks and skip non-IaC paths

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,10 +1,29 @@
 ---
+# ── Path exclusions ──────────────────────────────────────────────────────────
+# Directories that never contain IaC. Avoids parsing large generated/vendored
+# files that cause memory exhaustion (e.g. 88 MB of OpenAPI spec JSON).
 skip-path:
   - dist
   - build
   - release
   - vendor
+  - node_modules
+  - docs/specifications
+  - specs/discovered
+  - specs/raw
+
+# ── Framework restriction ────────────────────────────────────────────────────
+# Only run frameworks relevant to this org's repos. Eliminates ~35 frameworks
+# that parse every file looking for CloudFormation/ARM/Kubernetes/etc. patterns
+# in repos that contain none of those.
+framework:
+  - github_actions
+  - github_configuration
+  - secrets
+  - terraform
+
+# ── Check exclusions ─────────────────────────────────────────────────────────
 skip-check:
-  - CKV_GHA_7
-  - CKV2_GHA_1
+  - CKV_GHA_7    # GitHub Actions — allow pinning to branch refs
+  - CKV2_GHA_1   # GitHub Actions — immutable actions (covered by Dependabot)
   - "CKV_SECRET_4:.*specifications/api/.*\\.json$"


### PR DESCRIPTION
Closes #327
Closes #325

## Problem

Checkov was parsing ~113 MB of OpenAPI spec JSON through ~40 frameworks, causing:
- **Local pre-commit**: OOM kills at 10+ GB RSS (4 kills in 24h on a 16 GB VM)
- **GitHub Actions super-linter**: crash with zero output on 7 GB runner

The `.checkov.yaml` distributed to all org repos lacked path exclusions for generated spec directories and ran every framework by default.

## Changes

### Path exclusions (`skip-path`)
Added directories that never contain IaC:
- `docs/specifications` — generated OpenAPI spec JSON (88 MB in api-specs-enriched)
- `specs/discovered` — raw downloaded OpenAPI specs (25 MB)
- `specs/raw` — raw spec variants
- `node_modules` — NPM dependencies (checkov ignores .gitignore)

### Framework restriction (`framework`)
Restricted to the 4 frameworks relevant to this org:
- `github_actions` — workflow security checks
- `github_configuration` — .github/ config checks
- `secrets` — hardcoded secret detection
- `terraform` — for terraform-provider-f5xc

Eliminates ~35 irrelevant frameworks (CloudFormation, ARM, Kubernetes, Ansible, etc.) that were parsing every JSON and YAML file for patterns that don't exist in this org.

## Expected Impact

| Metric | Before | After |
|---|---|---|
| Files parsed | Every JSON/YAML (~113 MB) | Only .github/, .tf, text |
| Frameworks | ~40 | 4 |
| Peak memory | 10+ GB → OOM | <500 MB |
| Scan time | 8+ min (crash) | Seconds |

## Deployment

After merge, `sync-managed-files` distributes updated `.checkov.yaml` to all downstream repos. Both pre-commit and super-linter pick up the change automatically via `--config-file .checkov.yaml`.
