### PR TITLE
chore: promote lint / Lint Code Base to required status check

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -30,8 +30,8 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues"],
-        "self_contexts": ["Check linked issues"]
+        "contexts": ["check / Check linked issues", "lint / Lint Code Base"],
+        "self_contexts": ["Check linked issues", "Lint Code Base"]
       },
       "required_pull_request_reviews": null,
       "restrictions": null,


### PR DESCRIPTION
Closes #329

## Summary

Adds `lint / Lint Code Base` to `required_status_checks.contexts` and `Lint Code Base` to `self_contexts` in `.github/config/repo-settings.json`.

After the `Enforce Repository Settings` workflow runs, Super-Linter will be a required check across the whole fleet.

## Motivation

In `docs-theme` PR #465, the TRIVY stage of Super-Linter was failing (3 Vite CVEs) but the PR could still have been merged because `lint` was advisory. Promoting it closes that loophole.

## Blast-radius (pre-flight sweep 2026-04-19)

- 17 repos currently green — no disruption
- 6 repos currently red (api-mcp, api-specs-enriched, csd, terraform-provider-f5xc, terraform-provider-mcp, marketplace) — ~16 open PRs will be blocked until lint is fixed. Teams are expected to fix forward.
- 3 repos with no lint runs yet (docs-control, devcontainer, xcsh) — first-run result unknown.

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge, `Enforce Repository Settings` workflow propagates change to all 25 fleet repos
- [ ] Verify `docs-theme` branch protection contains both `check / Check linked issues` and `lint / Lint Code Base`