### PR TITLE
feat: add subagent-aware git-delegation PreToolUse hook

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -38,6 +38,7 @@
     ".mypy.ini",
     ".claude/settings.json",
     ".claude/governance.json",
-    ".claude/hooks/protect-managed-files.sh"
+    ".claude/hooks/protect-managed-files.sh",
+    ".claude/hooks/enforce-git-delegation.sh"
   ]
 }

--- a/.claude/hooks/enforce-git-delegation.sh
+++ b/.claude/hooks/enforce-git-delegation.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# PreToolUse hook: blocks git commit/push and gh pr create from the main
+# session, so all git/GitHub operations are delegated to the
+# f5xc-github-ops:github-ops subagent (per CLAUDE.md).
+# Allows the delegated subagent through via the agent_type stdin field.
+# Distributed by docs-control via managed_files sync.
+# Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
+set -euo pipefail
+
+# ── Guard: exit if no stdin data (e.g., linter running script) ───────
+if ! read -t 0 2>/dev/null; then
+  exit 0
+fi
+
+INPUT=$(cat)
+
+# ── Self-exclusion: allow all git/GitHub operations in docs-control ─
+# docs-control IS the source of truth; delegation policy applies only
+# to downstream repos that consume it via managed_files sync.
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
+if echo "$REMOTE_URL" | grep -q "docs-control"; then
+  exit 0
+fi
+
+# ── Allow the trusted delegated subagent ────────────────────────────
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null || echo "")
+if [ "$AGENT_TYPE" = "f5xc-github-ops:github-ops" ]; then
+  exit 0
+fi
+
+# ── Extract the Bash command ────────────────────────────────────────
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# ── Block delegated git/gh operations ───────────────────────────────
+BLOCK_REGEX='(^|[^A-Za-z0-9_])(git[[:space:]]+(commit|push)|gh[[:space:]]+pr[[:space:]]+create)([^A-Za-z0-9_]|$)'
+
+if [[ "$COMMAND" =~ $BLOCK_REGEX ]]; then
+  cat >&2 <<EOF
+BLOCKED: "${COMMAND}" is a delegated git/GitHub operation.
+
+CLAUDE.md requires all git commit, git push, and gh pr create calls to
+go through the f5xc-github-ops:github-ops subagent. Dispatch that agent
+with a clear task description instead of running the command directly.
+EOF
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,15 @@
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-managed-files.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/enforce-git-delegation.sh\""
+          }
+        ]
       }
     ]
   }

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -95,7 +95,8 @@
 
       { "src": ".claude/governance.json", "dest": ".claude/governance.json" },
       { "src": ".claude/settings.json", "dest": ".claude/settings.json" },
-      { "src": ".claude/hooks/protect-managed-files.sh", "dest": ".claude/hooks/protect-managed-files.sh" }
+      { "src": ".claude/hooks/protect-managed-files.sh", "dest": ".claude/hooks/protect-managed-files.sh" },
+      { "src": ".claude/hooks/enforce-git-delegation.sh", "dest": ".claude/hooks/enforce-git-delegation.sh" }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Enforces the project `CLAUDE.md` policy that all `git commit`, `git push`, and `gh pr create` operations must go through the `f5xc-github-ops:github-ops` subagent in downstream repos. Previously the policy existed only in prose and was not enforced by any hook, so the main session could silently bypass it.

The new `.claude/hooks/enforce-git-delegation.sh` hook runs on `PreToolUse` for `Bash` tools. It uses a three-layer allow/deny chain:

1. **docs-control self-exclusion** — if `git remote get-url origin` contains `docs-control`, exit 0. This mirrors the existing pattern in `protect-managed-files.sh`: docs-control is the source of truth where managed files live, and the delegation policy applies only to downstream repos that consume it via `managed_files` sync.
2. **Delegated subagent passthrough** — if the `PreToolUse` stdin JSON has `agent_type == "f5xc-github-ops:github-ops"`, exit 0 so the delegated agent can actually perform its job. The `agent_type` field is part of Claude Code's documented hook schema.
3. **Regex block** — otherwise, block commands matching `(git[[:space:]]+(commit|push)|gh[[:space:]]+pr[[:space:]]+create)` with word-boundary guards so `git add`, `git status`, `gh issue create`, and reads of `.git/COMMIT_EDITMSG` are correctly NOT blocked. On block, print a clear message pointing at `CLAUDE.md`.

### Governance sync

- `.claude/settings.json` registers a second `PreToolUse` matcher for `Bash` that runs the new hook.
- `.claude/governance.json` adds the hook to `protected_files` so downstream repos cannot locally edit it.
- `.github/config/repo-settings.json` adds the hook to `managed_files.files[]` so `sync-managed-files.yml` distributes it to every downstream repo on its next run.

The existing `Edit|Write` `protect-managed-files.sh` hook is untouched — governed files must remain uneditable in downstream repos (even by subagents), and only docs-control itself (via self-exclusion) allows edits. This new hook mirrors that pattern for `git`/`gh` operations.

Closes #331

## Test plan

- [x] 19/19 unit test cases pass locally
  - docs-control self-exclusion allows `git commit`, `git push`, `gh pr create`
  - Downstream context enforces, with `f5xc-github-ops:github-ops` `agent_type` passthrough working
  - Non-git dirs enforce (no remote → no match → proceeds to regex block)
  - Chained commands (`&&`, `;`, `|`) caught by word-boundary regex
  - `git add`, `git status`, `gh issue create`, `.git/COMMIT_EDITMSG` reads correctly NOT blocked
  - Empty/missing stdin fields handled (exit 0 — fail open)
- [x] `shellcheck` exit 0
- [x] `pre-commit run --files` green across shellcheck, biome, editorconfig, secrets, checkov, etc.
- [x] The self-exclusion block successfully allowed this very commit/push in docs-control (dogfooded)
- [ ] CI: `Check linked issues` passes
- [ ] CI: `Lint Code Base` passes
- [ ] CI: any other required checks pass