### PR TITLE
feat(lint): close super-linter BIOME/CHECKOV/CLANG_FORMAT Phase 2 gaps

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -11,6 +11,10 @@ skip-path:
   - docs/specifications
   - specs/discovered
   - specs/raw
+  # Install-verification dockerfiles are test harnesses, not production
+  # images — CKV_DOCKER_2 (HEALTHCHECK) and CKV_DOCKER_3 (non-root user)
+  # are not meaningful for ephemeral CI validation containers.
+  - scripts/install-tests
 
 # ── Framework restriction ────────────────────────────────────────────────────
 # Only run frameworks relevant to this org's repos. Eliminates ~35 frameworks

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -29,7 +29,11 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: "."
-          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/)"
+          # tree-sitter-<grammar>/src/{parser,scanner}.c are either machine-
+          # generated (parser.c from `tree-sitter generate`) or hand-written
+          # to upstream tree-sitter conventions that do not match
+          # clang-format's default style; excluding preserves fork fidelity.
+          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/|tree-sitter-[^/]+/src/(parser|scanner)\\.(c|h)$)"
           # Disable Prettier — Biome handles formatting for
           # JS/TS/JSON/CSS/HTML/GraphQL/JSX/Vue; yamllint handles
           # YAML; markdownlint handles Markdown.

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -274,6 +274,38 @@ for cfg in ruff.toml .ruff.toml .python-lint .mypy.ini; do
 done
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 5c: .checkov.yaml skips the install-test harness dockerfiles
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 5c: .checkov.yaml skip-path covers install-test dockerfiles ==="
+
+CHECKOV_SKIP=$(python3 -c "import yaml; print(' '.join(yaml.safe_load(open('$REPO_ROOT/.checkov.yaml')).get('skip-path',[])))")
+for p in 'scripts/install-tests' 'node_modules' 'vendor'; do
+  if echo "$CHECKOV_SKIP" | grep -qFw "$p"; then
+    pass "5c.x .checkov.yaml skip-path contains '$p'"
+  else
+    fail "5c.x .checkov.yaml skip-path contains '$p'" "not in skip-path"
+  fi
+done
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 5d: super-linter.yml FILTER_REGEX_EXCLUDE covers tree-sitter
+#             generated / companion C sources (machine-generated or
+#             upstream-style; reformatting creates fork drift)
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 5d: super-linter FILTER_REGEX_EXCLUDE tree-sitter coverage ==="
+
+FILTER_REGEX=$(grep -E '^[[:space:]]*FILTER_REGEX_EXCLUDE:' "$REPO_ROOT/.github/workflows/super-linter.yml" | head -1)
+for pattern in 'tree-sitter-' 'parser|scanner' 'dist/' 'vendor/'; do
+  if echo "$FILTER_REGEX" | grep -qF "$pattern"; then
+    pass "5d.x super-linter FILTER_REGEX_EXCLUDE contains '$pattern'"
+  else
+    fail "5d.x super-linter FILTER_REGEX_EXCLUDE contains '$pattern'" "not in regex"
+  fi
+done
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 7b: Onboarding doc regression net — the key Phase 1+2
 #             concepts must stay documented for future onboarders
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Post-merge super-linter runs on xcsh revealed three validators the Phase 2 local audit missed. This PR lands the ecosystem-side decisions for CHECKOV and CLANG_FORMAT; paired xcsh PR handles BIOME_LINT warnings and ships \`.clang-format-ignore\`.

### Changes

- \`.checkov.yaml\`: add \`scripts/install-tests\` to \`skip-path\`. These are install-verification test harnesses, not production containers — \`CKV_DOCKER_2\` (HEALTHCHECK) and \`CKV_DOCKER_3\` (non-root USER) aren't meaningful for ephemeral CI images.
- \`.github/workflows/super-linter.yml\`: extend \`FILTER_REGEX_EXCLUDE\` with \`tree-sitter-<grammar>/src/(parser|scanner)\\.(c|h)$\`. parser.c is machine-generated; scanner.c follows upstream tree-sitter conventions, not clang-format defaults.
- \`tests/test-linter-configs.sh\`: new Sections 5c and 5d locking both decisions with 7 assertions. 91/91 green.

### Merge order

This PR is non-destructive (doesn't depend on xcsh). After merge, the next sync-managed-files run on xcsh will propagate the updated \`.checkov.yaml\` and super-linter.yml; next super-linter run on any xcsh PR reports 0 across BIOME_LINT / CHECKOV / CLANG_FORMAT.

Companion: \`f5xc-salesdemos/xcsh#??\` (super-linter-followup branch).

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)