### PR TITLE
feat: add governed-file content check to enforce-git-delegation hook

### DIFF
--- a/.claude/hooks/enforce-git-delegation.sh
+++ b/.claude/hooks/enforce-git-delegation.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# PreToolUse hook: blocks git commit/push and gh pr create from the main
-# session, so all git/GitHub operations are delegated to the
-# f5xc-github-ops:github-ops subagent (per CLAUDE.md).
-# Allows the delegated subagent through via the agent_type stdin field.
+# PreToolUse hook: enforces the docs-control delegation policy.
+# In docs-control itself: everything is allowed (source-of-truth).
+# In downstream repos:
+#   - main session and non-delegated subagents are blocked from running
+#     git commit / git push / gh pr create (must delegate to github-ops).
+#   - the f5xc-github-ops:github-ops subagent may run those operations,
+#     UNLESS the changeset touches a file listed in governance.json.
 # Distributed by docs-control via managed_files sync.
 # Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
 set -euo pipefail
@@ -15,16 +18,8 @@ fi
 INPUT=$(cat)
 
 # ── Self-exclusion: allow all git/GitHub operations in docs-control ─
-# docs-control IS the source of truth; delegation policy applies only
-# to downstream repos that consume it via managed_files sync.
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
 if echo "$REMOTE_URL" | grep -q "docs-control"; then
-  exit 0
-fi
-
-# ── Allow the trusted delegated subagent ────────────────────────────
-AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null || echo "")
-if [ "$AGENT_TYPE" = "f5xc-github-ops:github-ops" ]; then
   exit 0
 fi
 
@@ -34,16 +29,82 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
-# ── Block delegated git/gh operations ───────────────────────────────
-BLOCK_REGEX='(^|[^A-Za-z0-9_])(git[[:space:]]+(commit|push)|gh[[:space:]]+pr[[:space:]]+create)([^A-Za-z0-9_]|$)'
+# ── Detect operation type ───────────────────────────────────────────
+IS_COMMIT=0
+IS_PUSH=0
+IS_PR=0
+if [[ "$COMMAND" =~ (^|[^A-Za-z0-9_])git[[:space:]]+commit([^A-Za-z0-9_]|$) ]]; then
+  IS_COMMIT=1
+fi
+if [[ "$COMMAND" =~ (^|[^A-Za-z0-9_])git[[:space:]]+push([^A-Za-z0-9_]|$) ]]; then
+  IS_PUSH=1
+fi
+if [[ "$COMMAND" =~ (^|[^A-Za-z0-9_])gh[[:space:]]+pr[[:space:]]+create([^A-Za-z0-9_]|$) ]]; then
+  IS_PR=1
+fi
 
-if [[ "$COMMAND" =~ $BLOCK_REGEX ]]; then
+# Not a delegated operation — no policy applies
+if [ "$IS_COMMIT" = 0 ] && [ "$IS_PUSH" = 0 ] && [ "$IS_PR" = 0 ]; then
+  exit 0
+fi
+
+# ── Delegation check: only github-ops may run delegated operations ──
+AGENT_TYPE=$(echo "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null || echo "")
+if [ "$AGENT_TYPE" != "f5xc-github-ops:github-ops" ]; then
   cat >&2 <<EOF
 BLOCKED: "${COMMAND}" is a delegated git/GitHub operation.
 
 CLAUDE.md requires all git commit, git push, and gh pr create calls to
 go through the f5xc-github-ops:github-ops subagent. Dispatch that agent
 with a clear task description instead of running the command directly.
+EOF
+  exit 2
+fi
+
+# ── Content check: governed files cannot leave a downstream repo ────
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GOVERNANCE_FILE="${SCRIPT_DIR}/../governance.json"
+if [ ! -f "$GOVERNANCE_FILE" ]; then
+  exit 0
+fi
+
+# Compute the set of file paths this operation would affect
+CHANGED=""
+if [ "$IS_COMMIT" = 1 ]; then
+  # Files staged for this commit
+  CHANGED=$(git diff --cached --name-only 2>/dev/null || echo "")
+  # -a / --all flag includes modified-but-unstaged tracked files
+  if [[ " $COMMAND " =~ [[:space:]]-[a-zA-Z]*a[a-zA-Z]*[[:space:]] ]] ||
+    [[ " $COMMAND " =~ [[:space:]]--all[[:space:]] ]]; then
+    CHANGED=$(printf '%s\n%s\n' "$CHANGED" "$(git diff --name-only 2>/dev/null || echo "")")
+  fi
+else
+  # push or pr create: files changed between upstream and HEAD
+  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+  if [ -z "$UPSTREAM" ]; then
+    UPSTREAM=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || echo "origin/main")
+  fi
+  CHANGED=$(git diff --name-only "${UPSTREAM}..HEAD" 2>/dev/null || echo "")
+fi
+
+CHANGED_SORTED=$(printf '%s\n' "$CHANGED" | awk 'NF' | sort -u)
+GOVERNED_SORTED=$(jq -r '.protected_files[]' "$GOVERNANCE_FILE" 2>/dev/null | awk 'NF' | sort -u)
+
+if [ -z "$CHANGED_SORTED" ] || [ -z "$GOVERNED_SORTED" ]; then
+  exit 0
+fi
+
+VIOLATIONS=$(comm -12 <(printf '%s' "$CHANGED_SORTED") <(printf '%s' "$GOVERNED_SORTED"))
+
+if [ -n "$VIOLATIONS" ]; then
+  SOURCE_REPO=$(jq -r '.source_repo' "$GOVERNANCE_FILE")
+  cat >&2 <<EOF
+BLOCKED: "${COMMAND}" would affect governed file(s) managed by ${SOURCE_REPO}:
+$(printf '%s\n' "$VIOLATIONS" | sed 's/^/  - /')
+
+Governed files cannot be committed, pushed, or PR-submitted from
+downstream repos. To change them, open an issue/PR in ${SOURCE_REPO} —
+changes sync automatically to downstream repos.
 EOF
   exit 2
 fi


### PR DESCRIPTION
## Summary

Stacked on top of #332. Adds a file-level content check to
`.claude/hooks/enforce-git-delegation.sh`, appended after the existing
delegation gate, so that the `f5xc-github-ops:github-ops` subagent
cannot push files listed in `.claude/governance.json`'s `protected_files`
out of a downstream repo.

- **Base branch:** `feature/331-subagent-aware-git-delegation-hook`
  (PR #332) — do NOT retarget to `main`.
- **Additive only:** the docs-control self-exclusion and the
  main-session / non-github-ops blocks from #332 are preserved exactly.

## Behavior

- `git commit`: inspects `git diff --cached --name-only`, plus
  `git diff --name-only` if `-a` / `--all` is set (covers
  modified-but-unstaged tracked files pulled in by `-a`).
- `git push` / `gh pr create`: inspects
  `git diff --name-only <upstream>..HEAD`, falling back to
  `origin/HEAD` or `origin/main` when the branch has no upstream yet.
- Intersects the changeset with `.claude/governance.json`'s
  `protected_files` array and exits 2 with a governance-aware BLOCKED
  message listing the violating files and pointing at `source_repo`.

## Why

Operator feedback after #332 shipped: github-ops was being allowed any
delegated operation unconditionally, which left a real path for
governed files to accidentally leave a downstream repo — exactly what
docs-control's governance model is supposed to prevent. Governed files
are owned by docs-control and propagate downstream via managed-files
sync; the only supported way to edit them is a PR in docs-control
itself.

## Still allowed

- docs-control self-exclusion (every op permitted here; docs-control
  IS the source of truth).
- github-ops `commit` / `push` / `pr create` in downstream repos when
  the changeset contains only non-governed files.

## Still blocked

- Main session and non-github-ops subagents running `git commit`,
  `git push`, or `gh pr create` in downstream repos.

## Local verification

- `shellcheck .claude/hooks/enforce-git-delegation.sh` → clean.
- `pre-commit run` (governance, repo-hooks, shellcheck, spellcheck,
  editorconfig, secrets) → green.
- 26/26 unit-test cases pass covering: docs-control self-exclusion,
  main-session/Explore blocks on commit/push/pr-create, benign reads
  allowed, github-ops commit with non-governed staged allowed,
  github-ops commit with governed staged blocked (including
  `--amend`), mixed-staged blocked, `-a` / `-am` / `-a -m` / `--all`
  pulling in unstaged governed tracked files (blocked), `--amend` and
  `-m "add feature"` correctly NOT matched by the `-a` regex,
  `push` / `gh pr create` blocked when outgoing diff contains a
  governed file, empty stdin and missing command field handled.

Closes #336

## Test plan

- [ ] CI checks pass
- [ ] Reviewer sanity-checks the diff is additive (docs-control
      self-exclusion and non-github-ops blocks intact)
- [ ] Reviewer confirms PR base is
      `feature/331-subagent-aware-git-delegation-hook`, not `main`