### PR TITLE
fix(governance): excluded_required_contexts uses qualified 'workflow / job' name

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -47,7 +47,7 @@
   "repo_overrides": {
     "xcsh": {
       "additional_contexts": ["typecheck", "unit (linux)", "unit (macos)", "e2e (linux)"],
-      "excluded_required_contexts": ["Lint Code Base"]
+      "excluded_required_contexts": ["lint / Lint Code Base"]
     }
   },
   "topics": [],

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -141,6 +141,41 @@ for word in doesnt forin invokable takin deine doub cros defaul ser anc runn; do
 done
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 7c: excluded_required_contexts entries must use the fully-
+#             qualified "workflow / job" form that matches the actual
+#             `contexts` list in branch protection
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 7c: excluded_required_contexts uses qualified names ==="
+
+# GitHub reports required status checks as "<workflow>/<job>", e.g.
+# "lint / Lint Code Base" (not "Lint Code Base"). Set subtraction in
+# enforce-repo-settings.yml is exact-match, so bare job names never match
+# the `contexts` array and the exclusion silently no-ops.
+# Every entry in excluded_required_contexts MUST therefore appear in the
+# base `required_status_checks.contexts` list verbatim, OR in
+# `additional_contexts` (the only other source of contexts).
+BASE_CTX=$(jq -c '.branch_protection[0].required_status_checks.contexts // []' "$REPO_SETTINGS")
+MISSING=""
+while IFS= read -r entry; do
+  [ -z "$entry" ] && continue
+  if ! echo "$BASE_CTX" | jq -e --arg e "$entry" 'index($e) != null' >/dev/null; then
+    REPO=$(jq -r --arg e "$entry" '.repo_overrides | to_entries[] | select(.value.excluded_required_contexts // [] | index($e)) | .key' "$REPO_SETTINGS" | head -1)
+    ADDITIONAL=$(jq -c --arg r "$REPO" '.repo_overrides[$r].additional_contexts // []' "$REPO_SETTINGS")
+    if ! echo "$ADDITIONAL" | jq -e --arg e "$entry" 'index($e) != null' >/dev/null; then
+      MISSING="${MISSING}  - ${entry} (in repo_overrides.${REPO})\n"
+    fi
+  fi
+done < <(jq -r '.repo_overrides | to_entries[] | .value.excluded_required_contexts // [] | .[]' "$REPO_SETTINGS")
+
+if [ -z "$MISSING" ]; then
+  pass "7c.1 every excluded_required_contexts entry matches a real context"
+else
+  fail "7c.1 every excluded_required_contexts entry matches a real context" \
+    "unmatched:\n$MISSING"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 5e: super-linter disables validators not applicable to the
 #             ecosystem's language mix (TS/Rust/Python/Markdown/Astro)
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Single-line fix: \`repo_overrides.xcsh.excluded_required_contexts\` now uses the fully-qualified \`"lint / Lint Code Base"\` form that matches GitHub's actual context reporting. Without this, every enforce run re-applied \`lint / Lint Code Base\` as a required context on xcsh and blocked all xcsh PRs on super-linter — defeating the whole purpose of the Phase 1 \`excluded_required_contexts\` schema.

Plus a regression-net assertion in \`tests/test-linter-configs.sh\` (Section 7c) that iterates every \`excluded_required_contexts\` entry and verifies it matches a real context (either the base \`contexts\` list or the repo's \`additional_contexts\`).

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)