### PR TITLE
fix(governance): xcsh additional_contexts match real ci.yml job names

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -46,7 +46,7 @@
   ],
   "repo_overrides": {
     "xcsh": {
-      "additional_contexts": ["typecheck", "unit (linux)", "unit (macos)", "e2e (linux)"],
+      "additional_contexts": ["check", "test"],
       "excluded_required_contexts": ["lint / Lint Code Base"]
     }
   },


### PR DESCRIPTION
## Summary

One-line fix: xcsh's \`additional_contexts\` listed 4 job names that don't exist in xcsh's \`ci.yml\`, blocking every xcsh PR on "4 of 5 required status checks are expected". Replaces with the two that actually exist as PR gates.

Surfaced while trying to merge xcsh sync PR #133.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)