### PR TITLE
fix(lint): editorconfig-checker pre-commit hook must honor --files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,7 +145,6 @@ repos:
         name: EditorConfig check
         entry: editorconfig-checker
         language: system
-        pass_filenames: false
 
   # ===========================================================================
   # GitHub Actions security scan — config: zizmor.yaml

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -376,6 +376,39 @@ for phrase in 'skip_files' 'excluded_required_contexts' 'Fork-fidelity' 'Linter-
 done
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 9: .pre-commit-config.yaml — editorconfig-checker must honor
+#            --files so pre-existing unrelated violations do not block
+#            developer commits
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 9: pre-commit editorconfig-checker scope ==="
+
+# When editorconfig-checker was ported out of super-linter into
+# .pre-commit-config.yaml it was written with pass_filenames: false,
+# causing the hook to receive no file args and scan the entire repo.
+# Any governed repo carrying even one pre-existing violation then
+# blocks every developer commit regardless of what the commit actually
+# touches. pass_filenames must be true (or absent, since pre-commit's
+# default is true) so the hook scrubs only the changed files.
+ECC_PASS=$(python3 -c "
+import sys, yaml
+cfg = yaml.safe_load(open('$REPO_ROOT/.pre-commit-config.yaml'))
+for repo in cfg.get('repos', []):
+    for hook in repo.get('hooks', []):
+        if hook.get('id') == 'editorconfig-checker':
+            print(hook.get('pass_filenames', True))
+            sys.exit(0)
+print('HOOK_MISSING')
+")
+
+if [ "$ECC_PASS" = "True" ]; then
+  pass "9.1 editorconfig-checker hook honors --files (pass_filenames: true)"
+else
+  fail "9.1 editorconfig-checker hook honors --files (pass_filenames: true)" \
+    "expected pass_filenames=True (or absent), got '$ECC_PASS'"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 8: Idempotence (running this script twice yields identical output)
 # ════════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
## Summary

`.pre-commit-config.yaml` had `pass_filenames: false` on the `editorconfig-checker` hook. With that flag, `pre-commit` calls the tool with no file arguments and `editorconfig-checker` falls back to scanning the entire repository — so a single pre-existing editorconfig violation anywhere in the repo blocks every developer commit regardless of what that commit actually changed.

Removing the explicit `pass_filenames: false` line restores pre-commit's default (`true`), so the hook is handed only the files the developer staged. Pre-existing violations in untouched / vendored / generated code no longer derail unrelated commits while editorconfig enforcement on new and modified files is preserved.

Closes #345

## How this surfaced

Onboarding the `xcsh` repository hit this exact failure mode: xcsh carries ~61 pre-existing editorconfig violations in vendored and generated sources, and every attempted governance-survey commit there was blocked because the hook was scanning the whole repo rather than just the file(s) being staged.

## TDD harness

New Section 9 in `tests/test-linter-configs.sh` (assertion 9.1): parses `.pre-commit-config.yaml` and fails the suite if the `editorconfig-checker` hook has `pass_filenames` explicitly set to `false`. Assertion confirmed RED before the config change, then GREEN after.

Local test results:

- `tests/test-linter-configs.sh` — 101/101
- `tests/test-protect-managed-files.sh` — 122/122

## Downstream effect

`.pre-commit-config.yaml` is a managed file (src → dest mapping in `repo-settings.json`). After merge, the standard `sync-managed-files` cascade propagates the fix to every governed repo (including xcsh, which caught the bug).

## Test plan

- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] `tests/test-linter-configs.sh` Section 9 executes in CI
- [ ] After merge, confirm `sync-managed-files` cascade propagates the updated config to downstream governed repos