### PR TITLE
docs: document release PR pattern for auto-release refactor

### DIFF
--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -411,6 +411,33 @@ gh api repos/f5xc-salesdemos/<repo-name>/git/refs/heads/governance/sync-managed-
   --method DELETE
 ```
 
+### Release automation: release PR pattern
+
+Governed repos that auto-publish releases (npm, Homebrew, GitHub Releases)
+must not push directly to `main`. With `enforce_admins: true` plus required
+status checks, any direct push from a CI token is rejected by GitHub with
+`GH006: Protected branch update failed`. The governance-compatible flow --
+the **release PR pattern** -- is two decoupled workflows:
+
+1. **Version-bump PR.** On `fix:` / `feat:` merges to `main`, a job runs
+   the repo's release script, which creates a `release/v<X.Y.Z>` branch,
+   commits `chore: bump version to v<X.Y.Z>`, pushes the branch, opens a
+   PR, and enables auto-merge. The PR name falls under the `release/**`
+   branch exemption already listed in
+   `.github/workflows/require-linked-issue.yml` `exclude-branches`, so no
+   linked-issue friction.
+
+2. **Tag on merge.** A separate workflow fires on `main` pushes whose head
+   commit starts with `chore: bump version to v`, extracts the version,
+   and pushes the git tag. Tag pushes are not subject to branch
+   protection, so this step always succeeds.
+
+The downstream release chain (build, sign, publish) remains triggered by
+the tag push -- no changes needed there. See xcsh's
+`scripts/release.ts` `cmdAutoRelease` and
+`.github/workflows/tag-on-version-bump.yml` for the reference
+implementation.
+
 ## Further reading
 
 - [Content authoring guide](https://f5xc-salesdemos.github.io/docs-builder/content-authors/) from docs-builder for page content and MDX conventions

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -367,7 +367,7 @@ echo ""
 echo "=== Section 7b: onboarding.mdx regression net ==="
 
 ONBOARDING="$REPO_ROOT/docs/onboarding.mdx"
-for phrase in 'skip_files' 'excluded_required_contexts' 'Fork-fidelity' 'Linter-compatibility audit cadence' 'frontmatter titles containing colons'; do
+for phrase in 'skip_files' 'excluded_required_contexts' 'Fork-fidelity' 'Linter-compatibility audit cadence' 'frontmatter titles containing colons' 'release PR pattern'; do
   if grep -qF "$phrase" "$ONBOARDING"; then
     pass "7b.x onboarding.mdx references '$phrase'"
   else


### PR DESCRIPTION
## Summary

- Add an 8-line governance note to `docs/onboarding.mdx` describing
  the two-workflow **release PR pattern** (version-bump PR, then
  tag-on-merge) that governed repos must use to publish releases
  under `enforce_admins: true` with required status checks.
- Extend the Section 7b phrase regression-net in
  `tests/test-linter-configs.sh` with `'release PR pattern'` so the
  new note is protected against accidental deletion (the same way
  other critical phrases in onboarding.mdx are protected).

Closes #349

## Context

xcsh's current auto-release job pushes directly to `main` and is
rejected by GitHub with `GH006: Protected branch update failed`. The
approved fix in xcsh is a two-decoupled-workflow release pattern:

1. A version-bump PR (created by `cmdAutoRelease`, goes through normal
   branch-protection like any other PR, lives under `release/**` so it
   is already exempt from the require-linked-issue workflow).
2. A tag-on-merge workflow that detects `chore: bump version to v*`
   commits on `main` and pushes the git tag.

That pattern is general governance guidance, so it belongs in the
fleet onboarding doc.

## Files

- `docs/onboarding.mdx` — +27 lines: new "Release automation: release
  PR pattern" subsection placed next to the existing release-automation
  material.
- `tests/test-linter-configs.sh` — +1 phrase in the Section 7b
  regression-net.

## Test plan

- [x] `tests/test-linter-configs.sh` locally: 102/102 (was 101 before
      this change — the new assertion contributes the delta).
- [x] `tests/test-protect-managed-files.sh` locally: 122/122
      (unchanged).
- [x] Pre-commit hooks green on staged files (`SKIP=super-linter`).
- [ ] CI `Check linked issues` passes.
- [ ] CI `Lint Code Base` passes.

## Non-goals

- No xcsh changes (tracked in a separate xcsh PR).
- No runtime changes in docs-control — this is documentation only.