### PR TITLE
fix(ruff): restore target-version = "py313" in managed ruff configs

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,5 @@
 line-length = 88
+target-version = "py313"
 
 [format]
 quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,5 @@
 line-length = 88
+target-version = "py313"
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
## Summary

Restore an explicit `target-version = "py313"` in the two governed ruff
configuration files (`.ruff.toml` and `ruff.toml`).

### Symptom

Downstream repos consuming the governed ruff configs (e.g.
`f5xc-salesdemos/api-specs` PR #127) failed Super-Linter with a
false-positive `F821 Undefined name 'BaseExceptionGroup'`. That name
is a Python 3.11+ builtin.

### Root Cause

A prior change dropped the `extend = "pyproject.toml"` line from both
governed files without replacing it with an explicit `target-version`.
Ruff then fell back to its default (py37/py38 era), which does not
recognize `BaseExceptionGroup`, triggering the false positive.

### Fix

Add `target-version = "py313"` immediately after `line-length = 88` in
both files. Both governed files remain byte-identical.

### Why py313 (not py311)

The fleet is standardizing on Python 3.13. Repos still on 3.11/3.12
lint fine under a py313 target — ruff simply will not apply 3.13-only
auto-rewrites to their code.

### Downstream Effect

Governance sync will propagate these configs to consumer repos.
`f5xc-salesdemos/api-specs` PR #127 can re-sync and the Super-Linter
F821 failure will clear.

Closes #344

## Test plan

- [ ] `Check linked issues` CI check passes
- [ ] `Lint Code Base` CI check passes
- [ ] Governance pre-commit hooks passed locally on the feature branch
- [ ] Manual review per CONTRIBUTING.md before merge