### PR TITLE
feat(.gitignore): ignore build-info.generated.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,5 @@ out.jsonl
 out.html
 pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
+packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/


### PR DESCRIPTION
## Summary

Adds `packages/coding-agent/src/internal-urls/build-info.generated.ts` to `.gitignore`, immediately following the existing `docs-index.generated.ts` entry.

The file is regenerated by `packages/coding-agent/scripts/generate-build-info.ts` on nearly every npm script run (`prepare`, `check:types`, `test`, `fix`, `build`, `prepack`), and each regeneration updates `buildDate` plus the `dirty` git-state field. If a contributor accidentally commits it (for example via `git add .`), every subsequent script run would rewrite the tracked file and `resolveDirty()` would observe the tracked file as modified — binaries built from an otherwise clean checkout would then falsely advertise as `dirty: true`.

This was flagged during Codex review on xcsh PR #155. The fix is a single new line in this repo's managed `.gitignore` template.

Closes #354

## Test plan

- [ ] CI checks pass
- [ ] `Check linked issues` workflow recognises `Closes #354`
- [ ] `Lint Code Base` passes on the single-line `.gitignore` change
- [ ] Downstream repos picking up the managed `.gitignore` template get the new entry on next sync