### PR TITLE
fix(ci): pin dependabot/fetch-metadata to v3.1.0 SHA to clear zizmor ref-version-mismatch

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Approve PR


### PR DESCRIPTION
## Summary

`Lint Code Base` / `GITHUB_ACTIONS_ZIZMOR` is failing on `main` with a medium-severity `ref-version-mismatch`. In `.github/workflows/dependabot-auto-merge.yml`, the `dependabot/fetch-metadata` action was pinned at SHA `ffa630c65fa7e0ecfa0625b5ceda64399aea1b36` with comment `# v3`. That SHA actually points to tag `v3.0.0`, while the moving `v3` tag currently points to `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` (`v3.1.0`).

This PR updates the pin to that v3.1.0 commit and aligns the comment to `# v3.1.0`, matching the true tag of the SHA while honoring what the original `# v3` comment implied (always the current v3 head).

Closes #357

## Impact

- Unblocks `Lint Code Base` on `main`.
- Unblocks PR #355 (follow-up to issue #354), which is red only because of the same finding on a file the PR does not touch.

## Test plan

- [ ] `Lint Code Base` passes (specifically the `GITHUB_ACTIONS_ZIZMOR` sub-linter).
- [ ] All other required checks remain green.