### PR TITLE
fix: exclude specs/original from canonical Checkov skip-path

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -11,6 +11,7 @@ skip-path:
   - docs/specifications
   - specs/discovered
   - specs/raw
+  - specs/original
   # Install-verification dockerfiles are test harnesses, not production
   # images — CKV_DOCKER_2 (HEALTHCHECK) and CKV_DOCKER_3 (non-root user)
   # are not meaningful for ephemeral CI validation containers.


### PR DESCRIPTION
Closes #360.

## Summary

Adds `specs/original` to the canonical `.checkov.yaml` `skip-path:` list, alongside the existing `specs/discovered` and `specs/raw` entries.

## Context

During issue triage for #360, I discovered the sync-manifest premise in the initial report was partially outdated:

- `.checkov.yaml` **is already listed** in `repo-settings.json` `managed_files.files` (line 88, added in PR #134). So the governance bot **does** push it — no manifest edit needed.
- What was still actionable: `specs/original` is absent from canonical `skip-path:`. This PR adds it.

## Why this unblocks api-specs-enriched#142

api-specs-enriched's local `.checkov.yaml` has drifted — it's missing `framework:` and `skip-path:` entirely. Once this canonical update is in place and the governance bot re-syncs, the downstream repo's `.checkov.yaml` will regain:

1. The `framework:` restriction (which alone prevents the openapi framework from scanning `specs/original/`)
2. The full canonical `skip-path:` list including the new `specs/original` entry (defense-in-depth)

Either protection alone is sufficient; both together are belt-and-suspenders.

## Test plan

- [x] Pre-commit gate passes locally (YAML lint, Checkov self-scan, secrets detection)
- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] Manual verification after merge: governance bot sync run propagates updated `.checkov.yaml` to api-specs-enriched

See issue #360 for the full root-cause analysis and evidence links.