### PR TITLE
fix(governance): Layer A hotfix — trigger Pages on every push + retry in API fallback

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -94,7 +94,7 @@ jobs:
           PAGES_BASE="https://f5xc-salesdemos.github.io/docs-control"
 
           fetch_governed() {
-            local key="$1" fallback="$2" body
+            local key="$1" fallback="$2" body err_file
             local url="${PAGES_BASE}/api/${key}"
 
             body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
@@ -104,9 +104,16 @@ jobs:
             fi
 
             echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
-            body=$(gh api "$fallback" 2>/dev/null || true)
+            err_file=$(mktemp)
+            if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+              echo "[ERROR] gh api failed for ${key}:" >&2
+              cat "$err_file" >&2
+              rm -f "$err_file"
+              return 1
+            fi
+            rm -f "$err_file"
             if [ -z "$body" ]; then
-              echo "[ERROR] Both Pages and API failed for ${key}" >&2
+              echo "[ERROR] gh api returned empty body for ${key}" >&2
               return 1
             fi
 

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -3,10 +3,6 @@ name: Build and Deploy Docs
 on:
   push:
     branches: [main]
-    paths:
-      - 'docs/**'
-      - '.github/config/**'
-      - 'workflows/**'
   workflow_call:
     inputs:
       content-path:

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -84,7 +84,7 @@ jobs:
           PAGES_BASE="https://f5xc-salesdemos.github.io/docs-control"
 
           fetch_governed() {
-            local key="$1" fallback="$2" body
+            local key="$1" fallback="$2" body err_file
             local url="${PAGES_BASE}/api/${key}"
 
             body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
@@ -94,9 +94,16 @@ jobs:
             fi
 
             echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
-            body=$(gh api "$fallback" 2>/dev/null || true)
+            err_file=$(mktemp)
+            if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+              echo "[ERROR] gh api failed for ${key}:" >&2
+              cat "$err_file" >&2
+              rm -f "$err_file"
+              return 1
+            fi
+            rm -f "$err_file"
             if [ -z "$body" ]; then
-              echo "[ERROR] Both Pages and API failed for ${key}" >&2
+              echo "[ERROR] gh api returned empty body for ${key}" >&2
               return 1
             fi
 

--- a/tests/fixtures/fetch-governed.sh
+++ b/tests/fixtures/fetch-governed.sh
@@ -22,8 +22,8 @@
 # Minimal retry stub for standalone testing. Workflows define a richer
 # retry that shadows this one; the declare -F guard prevents redefinition.
 declare -F retry >/dev/null 2>&1 || retry() {
-	shift # drop max-attempts
-	"$@"
+  shift # drop max-attempts
+  "$@"
 }
 
 # fetch_governed <pages-key> <api-fallback-path>
@@ -33,32 +33,32 @@ declare -F retry >/dev/null 2>&1 || retry() {
 # Prints: raw file content to stdout.
 # Returns: 0 on success (via Pages or API), non-zero if both fail.
 fetch_governed() {
-	local key="$1" fallback="$2" body err_file
-	local url="${PAGES_BASE}/api/${key}"
+  local key="$1" fallback="$2" body err_file
+  local url="${PAGES_BASE}/api/${key}"
 
-	body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
-	if [ -n "$body" ]; then
-		printf '%s' "$body"
-		return 0
-	fi
+  body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
+  if [ -n "$body" ]; then
+    printf '%s' "$body"
+    return 0
+  fi
 
-	echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
-	err_file=$(mktemp)
-	if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
-		echo "[ERROR] gh api failed for ${key}:" >&2
-		cat "$err_file" >&2
-		rm -f "$err_file"
-		return 1
-	fi
-	rm -f "$err_file"
-	if [ -z "$body" ]; then
-		echo "[ERROR] gh api returned empty body for ${key}" >&2
-		return 1
-	fi
+  echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
+  err_file=$(mktemp)
+  if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+    echo "[ERROR] gh api failed for ${key}:" >&2
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    return 1
+  fi
+  rm -f "$err_file"
+  if [ -z "$body" ]; then
+    echo "[ERROR] gh api returned empty body for ${key}" >&2
+    return 1
+  fi
 
-	# API returns {"content": "<base64>", "encoding": "base64"} envelope.
-	# Unwrap to raw bytes.
-	printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
+  # API returns {"content": "<base64>", "encoding": "base64"} envelope.
+  # Unwrap to raw bytes.
+  printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
 }
 
 # revision_is_fresh <source-sha>
@@ -68,13 +68,13 @@ fetch_governed() {
 #          non-zero when Pages is stale or unreachable or when
 #          source-sha is empty.
 revision_is_fresh() {
-	local source_sha="${1:-}" rev pages_sha
-	[ -z "$source_sha" ] && return 1
+  local source_sha="${1:-}" rev pages_sha
+  [ -z "$source_sha" ] && return 1
 
-	rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
-		"${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
-	[ -z "$rev" ] && return 1
+  rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
+    "${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
+  [ -z "$rev" ] && return 1
 
-	pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
-	[ "$pages_sha" = "$source_sha" ]
+  pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
+  [ "$pages_sha" = "$source_sha" ]
 }

--- a/tests/fixtures/fetch-governed.sh
+++ b/tests/fixtures/fetch-governed.sh
@@ -10,7 +10,21 @@
 #   PAGES_BASE   e.g. "https://f5xc-salesdemos.github.io/docs-control"
 #   GH_TOKEN     used by fallback `gh api` path
 #
+# Dependencies:
+#   retry(max_attempts, cmd...)   consumer workflows define a richer
+#                                 retry with rate-limit sleep-to-reset.
+#                                 Fixture provides a minimal pass-through
+#                                 stub below so the file works standalone
+#                                 in unit tests.
+#
 # All functions are safe to source multiple times.
+
+# Minimal retry stub for standalone testing. Workflows define a richer
+# retry that shadows this one; the declare -F guard prevents redefinition.
+declare -F retry >/dev/null 2>&1 || retry() {
+	shift # drop max-attempts
+	"$@"
+}
 
 # fetch_governed <pages-key> <api-fallback-path>
 #   pages-key          : relative path under ${PAGES_BASE}/api/ (e.g. "repo-settings.json")
@@ -19,25 +33,32 @@
 # Prints: raw file content to stdout.
 # Returns: 0 on success (via Pages or API), non-zero if both fail.
 fetch_governed() {
-  local key="$1" fallback="$2" body
-  local url="${PAGES_BASE}/api/${key}"
+	local key="$1" fallback="$2" body err_file
+	local url="${PAGES_BASE}/api/${key}"
 
-  body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
-  if [ -n "$body" ]; then
-    printf '%s' "$body"
-    return 0
-  fi
+	body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
+	if [ -n "$body" ]; then
+		printf '%s' "$body"
+		return 0
+	fi
 
-  echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
-  body=$(gh api "$fallback" 2>/dev/null || true)
-  if [ -z "$body" ]; then
-    echo "[ERROR] Both Pages and API failed for ${key}" >&2
-    return 1
-  fi
+	echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
+	err_file=$(mktemp)
+	if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+		echo "[ERROR] gh api failed for ${key}:" >&2
+		cat "$err_file" >&2
+		rm -f "$err_file"
+		return 1
+	fi
+	rm -f "$err_file"
+	if [ -z "$body" ]; then
+		echo "[ERROR] gh api returned empty body for ${key}" >&2
+		return 1
+	fi
 
-  # API returns {"content": "<base64>", "encoding": "base64"} envelope.
-  # Unwrap to raw bytes.
-  printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
+	# API returns {"content": "<base64>", "encoding": "base64"} envelope.
+	# Unwrap to raw bytes.
+	printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
 }
 
 # revision_is_fresh <source-sha>
@@ -47,13 +68,13 @@ fetch_governed() {
 #          non-zero when Pages is stale or unreachable or when
 #          source-sha is empty.
 revision_is_fresh() {
-  local source_sha="${1:-}" rev pages_sha
-  [ -z "$source_sha" ] && return 1
+	local source_sha="${1:-}" rev pages_sha
+	[ -z "$source_sha" ] && return 1
 
-  rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
-    "${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
-  [ -z "$rev" ] && return 1
+	rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
+		"${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
+	[ -z "$rev" ] && return 1
 
-  pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
-  [ "$pages_sha" = "$source_sha" ]
+	pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
+	[ "$pages_sha" = "$source_sha" ]
 }


### PR DESCRIPTION
## Summary

Two regressions from PR #363 (merged as `498570e`) are fixed:

1. **Pages deploy never ran for the merge commit.** The `paths:` filter in `github-pages-deploy.yml` listed `docs/**`, `.github/config/**`, `workflows/**` — but PR #363's changes were under `.github/workflows/**`, which matches none of those. Result: `/api/revision.json` has been 404 since the merge. **Fix:** drop the `paths:` filter so every push to main redeploys Pages. The deploy step is idempotent and cheap; it must always republish governance assets even when the filter-matching files are unchanged.

2. **The canonical helper's `gh api` fallback swallowed stderr and lacked `retry 3`.** Before PR #363, governed reads used `retry 3 gh api …` with rate-limit-aware sleep-to-reset. After PR #363, the fallback called `gh api` directly. When Pages 404'd AND the PAT budget drained from the fleet-sync storm, **19/25 downstream `Enforce Repository Settings` runs failed** at `[ERROR] Failed to fetch or parse config from f5xc-salesdemos/docs-control`. **Fix:** wrap fallback in `retry 3`, capture stderr to a tempfile, and surface real errors on failure. Fixture adds a standalone `retry` stub so unit tests still work.

Closes #365

## Files changed

- `.github/workflows/github-pages-deploy.yml` — removed `paths:` filter
- `.github/workflows/sync-managed-files.yml` — inlined helper updated
- `.github/workflows/enforce-repo-settings.yml` — inlined helper updated
- `tests/fixtures/fetch-governed.sh` — canonical: retry + stderr capture + standalone stub

## Post-merge acceptance

- [ ] `github-pages-deploy` runs on the hotfix merge commit
- [ ] `curl -fsSL https://f5xc-salesdemos.github.io/docs-control/api/revision.json` returns JSON with the hotfix merge SHA (within ~5 min)
- [ ] `dispatch-downstream` re-runs the 25 downstreams; the `retry 3` wrapper with rate-limit backoff handles any lingering PAT pressure

## Test plan

- [x] `bash tests/test-fetch-governed.sh` → 9 passed, 0 failed (locally)
- [x] `bash tests/test-inlined-helpers-match.sh` → both [OK] (locally)
- [x] `yamllint` on all three workflows — clean
- [x] `actionlint` on all three — clean
- [x] `shellcheck` on canonical + both test scripts — clean
- [ ] CI green on PR
- [ ] Pages deploy succeeds and `/api/revision.json` reports the new merge SHA