### PR TITLE
fix(governance): move SOURCE_SHA to step env to unbreak fleet + sed-based drift filter

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Sync managed files
         env:
           GH_TOKEN: ${{ secrets.repo-sync-token }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
 
@@ -128,8 +129,10 @@ jobs:
             [ "$pages_sha" = "$source_sha" ]
           }
 
-          SOURCE_SHA="${{ inputs.source_sha }}"
-          if [ -n "$SOURCE_SHA" ] && ! revision_is_fresh "$SOURCE_SHA"; then
+          # SOURCE_SHA is set via step env: above; empty when dispatch
+          # doesn't pass --field source_sha (current default until the
+          # downstream shim update propagates to all 25 repos).
+          if [ -n "${SOURCE_SHA:-}" ] && ! revision_is_fresh "$SOURCE_SHA"; then
             echo "[WARN] Pages revision lags source ${SOURCE_SHA:0:8} — this run will fall back to API for governed reads" >&2
             # Force fallback by making Pages calls error.
             PAGES_BASE="https://invalid.pages.local"

--- a/tests/test-inlined-helpers-match.sh
+++ b/tests/test-inlined-helpers-match.sh
@@ -14,7 +14,7 @@ SOURCE="${REPO_ROOT}/tests/fixtures/fetch-governed.sh"
 canonical=$(awk '
   /^fetch_governed\(\)/,/^}$/ { print; next }
   /^revision_is_fresh\(\)/,/^}$/ { print }
-' "$SOURCE" | sed 's/^[[:space:]]*//' | grep -v '^$' | grep -v '^#')
+' "$SOURCE" | sed -e 's/^[[:space:]]*//' -e '/^$/d' -e '/^#/d')
 
 FAIL=0
 for wf in \
@@ -23,7 +23,7 @@ for wf in \
   inlined=$(awk '
     /fetch_governed\(\)/,/^[[:space:]]*}[[:space:]]*$/ { print; next }
     /revision_is_fresh\(\)/,/^[[:space:]]*}[[:space:]]*$/ { print }
-  ' "$wf" | sed 's/^[[:space:]]*//' | grep -v '^$' | grep -v '^#')
+  ' "$wf" | sed -e 's/^[[:space:]]*//' -e '/^$/d' -e '/^#/d')
   if [ "$inlined" = "$canonical" ]; then
     echo "[OK] $(basename "$wf") helper matches canonical"
   else


### PR DESCRIPTION
## Summary

Two-part hotfix restoring the managed-file fleet.

### 1. Restore sync-managed-files.yml under the 21KB template-expression limit

PR #368 (Layer B) added `SOURCE_SHA=\"\${{ inputs.source_sha }}\"` inline
in the `run:` block of `.github/workflows/sync-managed-files.yml`. That
`\${{ }}` expansion is evaluated at workflow parse time and pushed the
surrounding expression past GitHub's **21,000-byte limit** — the exact
invariant PR #352 was written to guard.

Effect: every reusable-workflow call via
`f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main`
started failing with:

```
HTTP 422: failed to parse workflow … Exceeded max expression length 21000
```

All 25 `dispatch-downstream` matrix cells went red.

**Fix:** move `SOURCE_SHA: \${{ inputs.source_sha }}` into the step-level
`env:` map so the template expression is expanded once at step level; the
`run:` body references `\$SOURCE_SHA` as a plain bash var. The run-block
shrinks, staying safely under 21KB. Also uses `\${SOURCE_SHA:-}` defensive
expansion to handle older downstream shims that don't yet pass
`source_sha` via `with:`.

### 2. Robust drift-test filter (sed, not grep -v)

`tests/test-inlined-helpers-match.sh` used
`awk … | grep -v '^\$' | grep -v '^#'`. If `awk` produces no output
(indicating a broken extraction), `grep -v` returns exit 1 and
`set -euo pipefail` kills the script with a confusing failure mode
that masks the real bug.

**Fix:** replace both `grep -v` pipelines with
`sed -e '/^\$/d' -e '/^#/d'` folded into the existing `sed`
invocation. Behavior is identical when `awk` produces output; `sed`
exits 0 on empty input, so extraction bugs surface as honest
mismatch reports instead of pipefail crashes.

## Local verification

- `bash tests/test-fetch-governed.sh` → 9 passed
- `bash tests/test-inlined-helpers-match.sh` → both [OK]
- `bash tests/test-dispatch-matrix.sh` → 7 [OK]
- `yamllint -c .yamllint.yaml .github/workflows/sync-managed-files.yml` → clean
- `actionlint .github/workflows/sync-managed-files.yml` → clean

## Expected post-merge behavior

- `dispatch-downstream` fires the 25-cell matrix with `max-parallel: 5`
  (Layer B config intact).
- Each cell calls the downstream shim → the fixed
  `sync-managed-files.yml` reusable workflow parses cleanly → downstream
  sync runs to completion.
- First fully-working end-to-end fleet cycle with Layer A + Layer B
  both in effect.

Closes #369

## Test plan

- [ ] CI checks pass on this PR (yamllint, actionlint, shellcheck, drift test)
- [ ] Post-merge: `dispatch-downstream` run on `main` fires 25 cells
- [ ] Post-merge: all 25 downstream `sync-managed-files` runs parse
  (no HTTP 422) and complete green