### PR TITLE
fix(ci): skip shell-unit-tests step in consumer repos via hashFiles guard

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -133,6 +133,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run shell unit tests
+        # These tests guard docs-control's own fleet-sync machinery. They
+        # live only in docs-control; consumer repos that pin this workflow
+        # via `workflow_call` do not carry the scripts. Skip cleanly there
+        # so the overall job still exits green and satisfies branch-protection
+        # required checks (a skipped JOB is "neutral" and fails required
+        # checks; a skipped STEP is fine).
+        if: hashFiles('tests/test-fetch-governed.sh', 'tests/test-inlined-helpers-match.sh', 'tests/test-dispatch-matrix.sh') != ''
         run: |
           set -e
           bash tests/test-fetch-governed.sh


### PR DESCRIPTION
## Summary

PR #363 added a `shell-unit-tests` job to `super-linter.yml` that runs
`tests/test-fetch-governed.sh`, `tests/test-inlined-helpers-match.sh`,
and `tests/test-dispatch-matrix.sh`. These scripts live only in
docs-control, but consumer repos pin this workflow via `workflow_call`
(`uses: f5xc-salesdemos/docs-control/.github/workflows/super-linter.yml@main`),
so the job now runs in every downstream and fails with:

```
bash: tests/test-fetch-governed.sh: No such file or directory
exit 127
```

That turns the required Super-Linter check red on every downstream PR
across the fleet (~25 consumer repos). First observed on
`f5xc-salesdemos/devcontainer#1039`.

## Fix

Add a step-level `if: hashFiles(...)` guard so the step runs when the
scripts exist (docs-control) and is cleanly skipped when they do not
(every consumer).

```yaml
- name: Run shell unit tests
  if: hashFiles('tests/test-fetch-governed.sh', 'tests/test-inlined-helpers-match.sh', 'tests/test-dispatch-matrix.sh') != ''
```

The guard is at **step level**, not job level, on purpose: a skipped
STEP keeps the enclosing JOB green, which satisfies branch-protection
required checks. A skipped JOB reports `neutral` and would fail the
required check — which is exactly the bug we are fixing.

Closes #364

## Test plan

- [x] `yamllint -c .yamllint.yaml .github/workflows/super-linter.yml` clean
- [x] `actionlint .github/workflows/super-linter.yml` clean
- [x] `bash tests/test-fetch-governed.sh` passes 9/9 locally (step still runs in docs-control)
- [ ] CI green on this PR (Super-Linter, shell-unit-tests step runs here because scripts exist)
- [ ] Post-merge: representative downstream (`f5xc-salesdemos/devcontainer`) passes Super-Linter required check after fleet sync