### PR TITLE
fix(ci): per-step hashFiles guards for shell-unit-tests job

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -132,16 +132,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Run shell unit tests
-        # These tests guard docs-control's own fleet-sync machinery. They
-        # live only in docs-control; consumer repos that pin this workflow
-        # via `workflow_call` do not carry the scripts. Skip cleanly there
-        # so the overall job still exits green and satisfies branch-protection
-        # required checks (a skipped JOB is "neutral" and fails required
-        # checks; a skipped STEP is fine).
-        if: hashFiles('tests/test-fetch-governed.sh', 'tests/test-inlined-helpers-match.sh', 'tests/test-dispatch-matrix.sh') != ''
-        run: |
-          set -e
-          bash tests/test-fetch-governed.sh
-          bash tests/test-inlined-helpers-match.sh
-          bash tests/test-dispatch-matrix.sh
+      # These tests guard docs-control's own fleet-sync machinery. They
+      # live only in docs-control; consumer repos that pin this workflow
+      # via `workflow_call` do not carry the scripts. Each step has its
+      # OWN hashFiles guard so partial file presence (e.g. a consumer
+      # that inherited one script via an older governance sync) doesn't
+      # admit the step and fail on the missing sibling. A multi-file
+      # hashFiles('a','b','c') is OR, not AND — hence per-step guards.
+      - name: Run fetch-governed test
+        if: hashFiles('tests/test-fetch-governed.sh') != ''
+        run: bash tests/test-fetch-governed.sh
+
+      - name: Run inlined-helpers-match test
+        if: hashFiles('tests/test-inlined-helpers-match.sh') != ''
+        run: bash tests/test-inlined-helpers-match.sh
+
+      - name: Run dispatch-matrix test
+        if: hashFiles('tests/test-dispatch-matrix.sh') != ''
+        run: bash tests/test-dispatch-matrix.sh


### PR DESCRIPTION
## Summary

Follow-up to #364 / PR #371 (merge 48560da). PR #371's single multi-file guard was an **OR** check, not AND — it admitted the step whenever any listed file existed. Downstream consumers with a partial subset (e.g. `f5xc-salesdemos/devcontainer` has the first two scripts from an older governance sync but not `test-dispatch-matrix.sh`) still ran the step and failed on the missing sibling. Verified post-merge on devcontainer run [24690992009](https://github.com/f5xc-salesdemos/devcontainer/actions/runs/24690992009).

## Fix

Split the single guarded step into three separate steps, each with its own single-file `hashFiles(...)` guard:

```yaml
- name: Run fetch-governed test
  if: hashFiles('tests/test-fetch-governed.sh') != ''
  run: bash tests/test-fetch-governed.sh

- name: Run inlined-helpers-match test
  if: hashFiles('tests/test-inlined-helpers-match.sh') != ''
  run: bash tests/test-inlined-helpers-match.sh

- name: Run dispatch-matrix test
  if: hashFiles('tests/test-dispatch-matrix.sh') != ''
  run: bash tests/test-dispatch-matrix.sh
```

Each guard now sees exactly one file. Partial presence on consumers cleanly skips the individual step without leaking past the guard. Skipped STEPs keep the enclosing JOB green, satisfying branch-protection required checks (skipped JOBs are "neutral" and would fail).

Closes #372
Refs #364

## Test plan

- [x] `yamllint` + `actionlint` clean locally
- [x] All three test scripts pass in docs-control locally
- [ ] CI green on this PR (all three steps execute because docs-control has all three files)
- [ ] After merge, spot-check one downstream consumer (e.g. devcontainer) to confirm the Shell Unit Tests job is now green