### PR TITLE
feat(governance): exclude api-specs and api-specs-enriched from Python-lint config sync

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -58,7 +58,9 @@
   "managed_files": {
     "source_repo": "f5xc-salesdemos/docs-control",
     "skip_files": {
-      "xcsh": ["biome.json", "LICENSE", "CONTRIBUTING.md", "ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+      "xcsh": ["biome.json", "LICENSE", "CONTRIBUTING.md", "ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+      "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+      "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
     },
     "files": [
       { "src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml" },


### PR DESCRIPTION
## Summary

Add `api-specs` and `api-specs-enriched` to `managed_files.skip_files` in
`.github/config/repo-settings.json` so the canonical `ruff.toml`,
`.ruff.toml`, `.python-lint`, and `.mypy.ini` are no longer synced to
those two repos.

Both repos carry a `[tool.ruff]` section in their own `pyproject.toml`
(including the intentionally-tuned `[tool.ruff.lint.per-file-ignores]`
flagged in #359). That config was being shadowed by the synced
`ruff.toml`. This change lets each repo own its Python lint config
entirely via `pyproject.toml`.

### Why not a fleet-wide redesign?

A fleet audit found that only 2 of 25 downstream repos have
`pyproject.toml` (`api-specs` and `api-specs-enriched`). The other 23
have none. A fleet-wide `extend = "pyproject.toml"` redesign would
require either shipping `pyproject.toml` to 23 more repos or adding
23 entries to `skip_files`. Targeted skip on the two affected repos is
the minimal, surgical fix. Follows the `xcsh` precedent in the same
file.

### Change

```diff
     "skip_files": {
-      "xcsh": [...]
+      "xcsh": [...],
+      "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+      "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
     }
```

Closes #359

## Test plan

- [ ] CI checks pass (Biome + jq schema validation of the config file)
- [ ] On merge, dispatch-downstream sync skips the four lint files
      for `api-specs` and `api-specs-enriched`
- [ ] Issue #359 auto-closes via the `Closes #359` trailer