### PR TITLE
fix(ci): add trivy.yaml with skip-dirs for Python tool caches

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -93,6 +93,7 @@
       { "src": ".codespellrc", "dest": ".codespellrc" },
       { "src": ".prettierignore", "dest": ".prettierignore" },
       { "src": ".trivyignore", "dest": ".trivyignore" },
+      { "src": "trivy.yaml", "dest": "trivy.yaml" },
       { "src": ".ruff.toml", "dest": ".ruff.toml" },
       { "src": "ruff.toml", "dest": "ruff.toml" },
       { "src": ".isort.cfg", "dest": ".isort.cfg" },

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -69,6 +69,10 @@ jobs:
           # Explicit config file name — super-linter v8 defaults to
           # .yamllint.yml but our managed config uses .yamllint.yaml
           YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml
+          # Point Trivy at our governance config (skip-dirs for
+          # .mypy_cache, .ruff_cache, .pytest_cache so the fs walker
+          # doesn't hit dangling symlinks mid-run). See issue #377.
+          TRIVY_CONFIG_FILE: trivy.yaml
           SAVE_SUPER_LINTER_SUMMARY: true
           # No commitlint config exists in managed repos
           VALIDATE_GIT_COMMITLINT: false

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,19 @@
+---
+# Governance-managed Trivy configuration.
+#
+# CVE suppressions live in .trivyignore (separate managed file).
+# This file configures filesystem-scan behavior — specifically,
+# directories that must never be walked.
+
+# Python tool caches create dangling symlinks during the same CI run
+# (mypy's missing_stubs/, ruff's, pytest's). Trivy's fs walker hits
+# those symlinks between mypy-populates and trivy-scans, producing a
+# FATAL "no such file or directory" and aborting the whole scan.
+# Skipping these directories is safe: they contain no production
+# artifacts — only scratch caches regenerated each run.
+#
+# See docs-control issue #377.
+skip-dirs:
+  - .mypy_cache
+  - .ruff_cache
+  - .pytest_cache


### PR DESCRIPTION
## Summary

Fixes Super-Linter TRIVY failures caused by dangling symlinks inside
Python tool caches that are created during the same CI run.

- Add repo-level `trivy.yaml` with `skip-dirs: [.mypy_cache, .ruff_cache, .pytest_cache]`
- Wire Super-Linter to the new config via `TRIVY_CONFIG_FILE` env
- Add `trivy.yaml` to `.managed_files.files` in `repo-settings.json` so the fix propagates to downstream repos during the next fleet sync

Closes #377

## Background

Super-Linter's TRIVY step (v0.69.3) runs a filesystem scan of the
checkout. In the same run, its PYTHON_MYPY step populates
`.mypy_cache/`, which can contain a dangling `missing_stubs` symlink.
TRIVY's fs walker follows the link, hits ENOENT, and aborts the scan
with FATAL — first observed in `api-specs-enriched` PR #148
(run 24695948367). Any repo with `.py` files is exposed.

The three caches skipped here (`.mypy_cache`, `.ruff_cache`,
`.pytest_cache`) are scratch directories regenerated on every run and
carry no security-relevant payload, so skipping them has no impact on
the scan surface.

## Why this fix vs. alternatives

- Option 1 (skip-dirs via config) — chosen. Lowest-risk, fleet-scoped.
- Option 2 (reorder MYPY after TRIVY) — Super-Linter doesn't guarantee
  step ordering between linters; fragile.
- Option 3 (bump TRIVY to 0.70) — broader change; may or may not fix.
  Better as a separate PR.
- Option 4 (add `.mypy_cache` to `.gitignore`) — doesn't affect CI
  filesystem state.

## Local verification

- `yamllint -c .yamllint.yaml trivy.yaml` — clean
- `yamllint -c .yamllint.yaml .github/workflows/super-linter.yml` — clean
- `actionlint .github/workflows/super-linter.yml` — clean
- `jq empty .github/config/repo-settings.json` — valid

## Test plan

- [ ] Super-Linter CI passes on this PR (TRIVY no longer FATALs)
- [ ] After merge, `dispatch-downstream` workflow fires
- [ ] Issue #377 auto-closes on merge
- [ ] Next `api-specs-enriched` fleet sync PR passes TRIVY cleanly