### PR TITLE
fix: restore mode="bypassPermissions" in github-ops dispatch example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,13 @@ Never run `git commit`, `git push`, `gh pr create` directly.
 ```
 Agent(
   subagent_type="f5xc-github-ops:github-ops",
+  mode="bypassPermissions",
   prompt="<type>: <desc>\n\nFiles:\n- <list>\n\nWhy: <reason>"
 )
 ```
+
+`mode="bypassPermissions"` is required — without it, plan mode can
+re-engage mid-workflow and strip the agent's Bash access, leaving
+it stuck after the first step.
 
 See `CONTRIBUTING.md` for project rules.


### PR DESCRIPTION
## Summary

- Adds `mode="bypassPermissions"` to the `Agent(...)` dispatch example
  in the Git Operations section of this template's `CLAUDE.md`.
- Documents, in one sentence, why the mode is required: without it,
  plan mode can re-engage mid-workflow and strip the github-ops
  subagent's `Bash` access, stranding the workflow after the first step.
- Locks the fix in the canonical template so downstream repos pick it
  up on the next managed-files sync (no per-repo patching).

Closes #381

## Context

Downstream incident trail in `f5xc-salesdemos/marketplace`:

- marketplace#155 (2026-03-28) — stop-gap added `mode="bypassPermissions"`
  to its local `CLAUDE.md`, closing marketplace#154.
- marketplace#151 (2026-03-28) — managed-files sync from this template
  reverted the stop-gap because the template lacked the fix.
- marketplace#286 / marketplace#287 (today) — while fixing a separate
  github-ops zsh bug, the dispatch-mode regression resurfaced.

This PR fixes the regression at its source.

## Test plan

- [x] Pre-commit gate passed locally (markdown lint, spell check,
      EditorConfig, secrets, governance).
- [ ] `Check linked issues` CI passes (PR body contains `Closes #381`).
- [ ] `Lint Code Base` CI passes.
- [ ] After merge, next managed-files sync run propagates the updated
      template to downstream repos.