### PR TITLE
feat(lint): run Biome latest via biomejs/setup-biome, disable BIOME in Super-Linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,6 +23,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Biome runs OUTSIDE the Super-Linter container so we can track Biome
+      # `latest` instead of being gated on Super-Linter's container release
+      # cadence. Authority boundary: setup-biome owns JS/TS/JSON/JSX; the
+      # Super-Linter step below runs everything else with VALIDATE_BIOME_*
+      # disabled. Step order matters: if Biome fails, Super-Linter is skipped
+      # (default fail-fast, no `if: always()`) so developers get a focused log.
+      - name: Setup Biome
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51  # v2.7.1 — Dependabot-managed
+        with:
+          version: latest
+
+      - name: Run Biome
+        run: biome ci .
+
       - name: Run Super-Linter
         uses: super-linter/super-linter@v8
         env:
@@ -36,6 +50,12 @@ jobs:
           RUFF_CACHE_DIR: /tmp/ruff_cache
           PYTEST_ADDOPTS: --cache-dir=/tmp/pytest_cache
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Disable Biome in Super-Linter — handled by the biomejs/setup-biome
+          # step above, which runs Biome `latest` instead of the container's
+          # bundled version. Authority boundary: setup-biome owns JS/TS/JSON/JSX;
+          # Super-Linter retains everything else.
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
           LINTER_RULES_PATH: "."
           # tree-sitter-<grammar>/src/{parser,scanner}.c are either machine-
           # generated (parser.c from `tree-sitter generate`) or hand-written


### PR DESCRIPTION
## Summary

Move JS/TS/JSON/JSX linting from Super-Linter's bundled Biome to the official `biomejs/setup-biome` GitHub Marketplace action, pinned to a reviewed 40-char SHA with `version: latest`. Disable `VALIDATE_BIOME_FORMAT` and `VALIDATE_BIOME_LINT` in Super-Linter so no linter runs twice.

Closes #384

## Why

Super-Linter v8's container bundles a Biome version that lags upstream. Running Biome outside the Super-Linter container lets the fleet track Biome releases in real time (via Dependabot-managed SHA bumps of the setup-biome action) instead of waiting on Super-Linter's container release cadence.

**Authority boundary:** `setup-biome` owns JS/TS/JSON/JSX. Super-Linter retains every other validator (yamllint, markdownlint, shellcheck, actionlint, hadolint, checkov, gitleaks, codespell, Ruff, Pylint, Mypy, clang-format, Trivy).

**Step order:** Checkout → Setup Biome → Run Biome → Run Super-Linter. If Biome fails, Super-Linter is skipped (default fail-fast, no `if: always()`) so developers get a focused log.

## Pre-merge audit

Confirmed all **25/25** governed consumer repos in `.github/config/downstream-repos.json` have a `biome.json` at HEAD of default branch. `xcsh` owns its own `biome.json` (listed in `.claude/governance.json` `skip_files`), so no xcsh-side change is needed.

Check name `Lint Code Base` is unchanged — no consumer-repo branch-protection updates required.

## Pin data

- `biomejs/setup-biome` @ `4c91541eaada48f67d7dbd7833600ce162b68f51` (= release tag `v2.7.1`, published 2026-03-11)
- Dependabot-managed via `.github/dependabot.yml` action-ecosystem rules

## Test plan

- [ ] Step order in Actions log: Checkout → Setup Biome → Run Biome → Run Super-Linter → Spectral OpenAPI lint
- [ ] `biome ci .` passes against docs-control's own code
- [ ] Super-Linter log no longer shows BIOME_FORMAT or BIOME_LINT sections
- [ ] Single check name `Lint Code Base` reports the combined result
- [ ] `Check linked issues` passes (issue #384 linked via `Closes #384`)