### PR TITLE
feat(governance): opt xcsh out of super-linter.yml managed-files sync

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -1,7 +1,18 @@
 {
   "source_repo": "f5xc-salesdemos/docs-control",
   "skip_files": {
-    "xcsh": ["biome.json", "LICENSE", "CONTRIBUTING.md", "ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+    "xcsh": [
+      "biome.json",
+      "LICENSE",
+      "CONTRIBUTING.md",
+      "ruff.toml",
+      ".ruff.toml",
+      ".python-lint",
+      ".mypy.ini",
+      ".github/workflows/super-linter.yml"
+    ],
+    "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -58,7 +58,16 @@
   "managed_files": {
     "source_repo": "f5xc-salesdemos/docs-control",
     "skip_files": {
-      "xcsh": ["biome.json", "LICENSE", "CONTRIBUTING.md", "ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+      "xcsh": [
+        "biome.json",
+        "LICENSE",
+        "CONTRIBUTING.md",
+        "ruff.toml",
+        ".ruff.toml",
+        ".python-lint",
+        ".mypy.ini",
+        ".github/workflows/super-linter.yml"
+      ],
       "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
     },


### PR DESCRIPTION
## Summary

Super-Linter on xcsh is not ready for linting that codebase — runs very long and consistently fails. xcsh's branch protection already excludes the `lint / Lint Code Base` required status check (see `repo_overrides.xcsh.excluded_required_contexts`), but the `.github/workflows/super-linter.yml` workflow is still being synced into xcsh and executed on every PR.

## Change

Adds `.github/workflows/super-linter.yml` to `skip_files.xcsh` in both:

- `.github/config/repo-settings.json`
- `.claude/governance.json`

Both files must match per `tests/test-protect-managed-files.sh` test 3.5.

Also aligns `.claude/governance.json`'s `skip_files` with `repo-settings.json` by adding the `api-specs` and `api-specs-enriched` entries that were missed in #375 — this additionally fixes a pre-existing test 3.5 failure on main.

## Notes

- Test 3.1 (trivy.yaml missing from `protected_files`) is a separate pre-existing failure from #378/#380, not addressed here.
- After this lands, a follow-up PR in xcsh will delete the existing `.github/workflows/super-linter.yml` file. Without that follow-up the workflow keeps running — `skip_files` only prevents future re-sync, not existing files.

Closes #386

## Test plan

- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] `tests/test-protect-managed-files.sh` test 3.5 parity check passes for both config files