### PR TITLE
chore: decommission api-mcp and terraform-provider-mcp from governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -75,11 +75,6 @@
     "description": "F5 XC API security"
   },
   {
-    "label": "API MCP",
-    "url": "https://f5xc-salesdemos.github.io/api-mcp/llms-full.txt",
-    "description": "MCP server for F5 Distributed Cloud API"
-  },
-  {
     "label": "API Specs",
     "url": "https://f5xc-salesdemos.github.io/api-specs/llms-full.txt",
     "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud"
@@ -108,11 +103,6 @@
     "label": "Dev Container",
     "url": "https://f5xc-salesdemos.github.io/devcontainer/llms-full.txt",
     "description": "Isolated development environment with AI coding tools"
-  },
-  {
-    "label": "Terraform Provider MCP",
-    "url": "https://f5xc-salesdemos.github.io/terraform-provider-mcp/llms-full.txt",
-    "description": "MCP server exposing Terraform provider schemas"
   },
   {
     "label": "Marketplace",

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -14,13 +14,11 @@
   "f5xc-salesdemos/ddos",
   "f5xc-salesdemos/waf",
   "f5xc-salesdemos/api-protection",
-  "f5xc-salesdemos/api-mcp",
   "f5xc-salesdemos/api-specs",
   "f5xc-salesdemos/api-specs-enriched",
   "f5xc-salesdemos/csd",
   "f5xc-salesdemos/docs-icons",
   "f5xc-salesdemos/terraform-provider-f5xc",
-  "f5xc-salesdemos/terraform-provider-mcp",
   "f5xc-salesdemos/devcontainer",
   "f5xc-salesdemos/marketplace",
   "f5xc-salesdemos/xcsh"


### PR DESCRIPTION
## Summary

- Remove both MCP repos from `.github/config/downstream-repos.json` (stops fleet-sync dispatch)
- Remove both MCP repos from `.github/config/docs-sites.json` (drops from canonical llms aggregator)

Part of the MCP decommission. Both repos have been archived (read-only) as of 2026-04-22 — this PR cleans up the governance-layer references.

## Verification

- JSON syntax validated with `jq empty`.
- Entry counts: 25 → 23 in each config file (2 removed from each).
- No remaining references to `api-mcp` or `terraform-provider-mcp` in either file.
- Follow-up PRs in docs-theme and docs will remove the UI references (megamenu, landing page LinkCard). Those reference this issue but do not close it.

Closes #393