### PR TITLE
fix(biome): bump $schema in biome.json from 2.4.10 to 2.4.12

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,


### PR DESCRIPTION
## Summary

Bumps `biome.json` `$schema` from 2.4.10 to 2.4.12 to match the Biome version that `super-linter.yml` runs via `biomejs/setup-biome@<SHA>` with `version: latest`.

Schema URLs are advisory — no formatter or linter behavior changes.

## Impact

Unblocks `lint / Lint Code Base` on all fleet consumer PRs. Currently observed failing on:
- f5xc-salesdemos/api-specs-enriched PR #200 (release v2.1.62)

## Test plan

- [x] Diff is single-line schema URL bump
- [x] Local `biome ci .` clean on updated config (Biome 2.4.12)
- [ ] docs-control CI green

Closes #395
