### PR TITLE
feat(.gitignore): add worktrees/ and .wt/ patterns for worktree workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,8 +128,10 @@ tsconfig.tsbuildinfo
 .direnv/
 /result
 
-# Workspace
+# Workspace (includes git worktree dirs for AI agents and bare-repo workflows)
 .worktrees/
+worktrees/
+.wt/
 .codex/
 playground/
 


### PR DESCRIPTION
## Summary

- Add `worktrees/` pattern (bare-repo workflows without dot prefix)
- Add `.wt/` pattern (shorthand worktree alias convention)
- Update section comment to clarify worktree directory purpose

Developers across the ecosystem are adopting git worktrees for parallel development with AI coding tools (Claude Code, Codex, parallel-code). The ecosystem `.gitignore` already covers `.worktrees/` and `.claude/worktrees/` but misses these two additional conventions. This additive 3-line change propagates to all 25 downstream repos via the sync-managed-files workflow.

Closes #398

## Test plan

- [ ] CI checks pass (lint, governance)
- [ ] Verify `.gitignore` patterns are syntactically correct
- [ ] Confirm no existing tracked files match the new patterns