### PR TITLE
feat: register cdn-simulator in governance ecosystem

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -113,5 +113,10 @@
     "label": "XCSh",
     "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
     "description": "AI-powered development environment and CLI tool"
+  },
+  {
+    "label": "CDN Simulator",
+    "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms-full.txt",
+    "description": "NGINX-based CDN edge node simulator on Azure for multi-vendor lab environments"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -21,5 +21,6 @@
   "f5xc-salesdemos/terraform-provider-f5xc",
   "f5xc-salesdemos/devcontainer",
   "f5xc-salesdemos/marketplace",
-  "f5xc-salesdemos/xcsh"
+  "f5xc-salesdemos/xcsh",
+  "f5xc-salesdemos/cdn-simulator"
 ]


### PR DESCRIPTION
## Summary

- Add `f5xc-salesdemos/cdn-simulator` to `downstream-repos.json` for governance enforcement (repo settings, managed file sync, workflow dispatch)
- Add CDN Simulator entry to `docs-sites.json` with label, LLM endpoint URL, and description for README generation and LLM federation

Closes #400

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify `downstream-repos.json` is valid JSON with cdn-simulator entry
- [ ] Verify `docs-sites.json` is valid JSON with CDN Simulator entry