### PR TITLE
feat: enroll origin-server in governance ecosystem

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -118,5 +118,10 @@
     "label": "CDN Simulator",
     "url": "https://f5xc-salesdemos.github.io/cdn-simulator/llms-full.txt",
     "description": "NGINX-based CDN edge node simulator on Azure for multi-vendor lab environments"
+  },
+  {
+    "label": "Origin Server",
+    "url": "https://f5xc-salesdemos.github.io/origin-server/llms-full.txt",
+    "description": "Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -22,5 +22,6 @@
   "f5xc-salesdemos/devcontainer",
   "f5xc-salesdemos/marketplace",
   "f5xc-salesdemos/xcsh",
-  "f5xc-salesdemos/cdn-simulator"
+  "f5xc-salesdemos/cdn-simulator",
+  "f5xc-salesdemos/origin-server"
 ]


### PR DESCRIPTION
## Summary

- Register `f5xc-salesdemos/origin-server` as the 26th downstream repository in `downstream-repos.json` for automated settings enforcement and managed file sync
- Add Origin Server entry to `docs-sites.json` with correct `llms-full.txt` URL for docs site generation

Closes #402

## Test plan

- [ ] CI checks pass (linked issue check, linter)
- [ ] Verify `downstream-repos.json` is valid JSON with origin-server as last entry
- [ ] Verify `docs-sites.json` is valid JSON with correct Origin Server URL