### PR TITLE
fix: skip biome ci when no eligible files exist in repo

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -35,7 +35,12 @@ jobs:
           version: latest
 
       - name: Run Biome
-        run: biome ci .
+        run: |
+          if find . -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' -o -name '*.json' -o -name '*.jsonc' -o -name '*.css' -o -name '*.vue' \) -not -path './node_modules/*' -not -path './.terraform/*' -not -path './dist/*' -not -path './build/*' -not -path './vendor/*' | grep -q .; then
+            biome ci .
+          else
+            echo "No biome-eligible files found — skipping"
+          fi
 
       - name: Run Super-Linter
         uses: super-linter/super-linter@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0


### PR DESCRIPTION
## Summary

- Add file-existence check before running `biome ci` in the super-linter workflow
- When no biome-eligible files (`.js`, `.jsx`, `.ts`, `.tsx`, `.json`, `.jsonc`, `.css`, `.vue`) are found, the step prints a skip message and exits successfully
- Prevents the **Lint Code Base** required check from failing in docs-only repos (e.g., origin-server, cdn-simulator) where biome has nothing to lint

Closes #404

## Test plan

- [ ] CI checks pass on this PR
- [ ] Verify that repos with biome-eligible files still run `biome ci` normally
- [ ] Verify that docs-only repos (origin-server, cdn-simulator) no longer fail the lint check