### PR TITLE
fix(codespellrc): add aNULL to ignore-words-list

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+ignore-words-list = afterall,aks,anull,datas,edn,hcl,ists,iterm,nd,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine


### PR DESCRIPTION
## Summary

- Add `anull` to the codespell `ignore-words-list` in `.codespellrc`
- The OpenSSL cipher suite identifier `aNULL` (used in TLS configs like `HIGH:!aNULL:!MD5`) is incorrectly flagged as a misspelling of "annul"
- Since `.codespellrc` is a managed file synced to all downstream repos, this fix propagates automatically

Closes #406

## Test plan

- [ ] CI checks pass (codespell no longer flags aNULL)
- [ ] Verify the ignore-words-list remains alphabetically sorted