### PR TITLE
fix: exclude .mdx files from Python linters

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.11
 ignore_missing_imports = True
+exclude = (?x)(\.mdx$)
 check_untyped_defs = True
 warn_return_any = False
 disallow_untyped_defs = False

--- a/.python-lint
+++ b/.python-lint
@@ -1,6 +1,7 @@
 [MAIN]
 py-version = 3.11
 jobs = 0
+ignore-paths = ^.*\.mdx$
 
 [FORMAT]
 max-line-length = 88

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,6 @@
 line-length = 88
 target-version = "py313"
+extend-exclude = ["*.mdx"]
 
 [format]
 quote-style = "double"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,6 @@
 line-length = 88
 target-version = "py313"
+extend-exclude = ["*.mdx"]
 
 [format]
 quote-style = "double"


### PR DESCRIPTION
## Summary

- Add `.mdx` exclusion patterns to ruff, mypy, and pylint configs to prevent false-positive syntax errors from embedded Python code blocks in MDX documentation files
- Triggered by origin-server's `03-deploy.mdx` which embeds the CSD demo `app.py` in a cloud-init code block

Closes #408

## Test plan

- [ ] CI checks pass
- [ ] Verify ruff does not scan `.mdx` files (`ruff check --extend-exclude` respects the config)
- [ ] Verify mypy excludes `.mdx` files
- [ ] Verify pylint ignores `.mdx` paths