### PR TITLE
fix: standardize xcsh label casing to lowercase

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -110,7 +110,7 @@
     "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
   },
   {
-    "label": "XCSh",
+    "label": "xcsh",
     "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
     "description": "AI-powered development environment and CLI tool"
   },


### PR DESCRIPTION
## Summary

- Standardize the xcsh label in `.github/config/docs-sites.json` from `XCSh` to `xcsh` to comply with the ecosystem-wide codespell audit requiring lowercase product naming

Closes #410

## Test plan

- [x] Pre-commit hooks pass (Biome JSON lint, spelling check, secrets detection)
- [ ] CI checks pass (Check linked issues, Lint Code Base)