### PR TITLE
docs: add frontmatter descriptions and llms-config for llms.txt hierarchy

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Architecture
+description: Three-repository documentation pipeline architecture spanning docs-control, docs-builder, and docs-theme.
 sidebar:
   order: 2
 ---

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration Reference
+description: Central repo-settings.json configuration reference for enforcement, sync, and dispatch behavior.
 sidebar:
   order: 3
 ---

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -1,5 +1,6 @@
 ---
 title: Downstream Dispatch
+description: Downstream dispatch workflow that triggers enforcement across all enrolled repositories.
 sidebar:
   order: 6
 ---

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -1,5 +1,6 @@
 ---
 title: File Synchronization
+description: Managed file synchronization, dynamic dependabot.yml generation, and README templating.
 sidebar:
   order: 5
 ---

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,11 @@
+{
+  "customSets": [
+    {
+      "label": "Workflows",
+      "description": "Enforcement, sync, and dispatch workflow documentation",
+      "paths": ["dispatch*", "file-sync*", "settings-enforcement*"]
+    }
+  ],
+  "promote": ["index*", "architecture*", "onboarding*"],
+  "demote": ["configuration*"]
+}

--- a/docs/settings-enforcement.mdx
+++ b/docs/settings-enforcement.mdx
@@ -1,5 +1,6 @@
 ---
 title: Settings Enforcement
+description: Seven-phase idempotent repository settings enforcement workflow for branch protection, labels, and pages.
 sidebar:
   order: 4
 ---


### PR DESCRIPTION
## Summary

Refs f5xc-salesdemos/xcsh#223

Step 5 of the cascading llms.txt knowledge hierarchy — adds `description:` to 5 workflow documentation pages and creates `llms-config.json` with custom sets for Workflows, promote, and demote lists.

### Changes

- **docs/architecture.mdx** — added `description:` field to frontmatter
- **docs/configuration.mdx** — added `description:` field to frontmatter
- **docs/dispatch.mdx** — added `description:` field to frontmatter
- **docs/file-sync.mdx** — added `description:` field to frontmatter
- **docs/settings-enforcement.mdx** — added `description:` field to frontmatter
- **docs/llms-config.json** — new file with customSets for Workflows topic, promote list, and demote list

Closes #412

## Test plan

- [ ] CI checks pass
- [ ] Frontmatter descriptions render correctly in docs site
- [ ] llms-config.json is valid JSON and matches expected schema