### PR TITLE
fix: govern README.md as a managed file synced to all downstream repos

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -83,6 +83,7 @@
       { "src": ".github/ISSUE_TEMPLATE/config.yml", "dest": ".github/ISSUE_TEMPLATE/config.yml" },
 
       { "src": "CONTRIBUTING.md", "dest": "CONTRIBUTING.md" },
+      { "src": "README.md", "dest": "README.md" },
       { "src": "CLAUDE.md", "dest": "CLAUDE.md" },
       { "src": ".editorconfig", "dest": ".editorconfig" },
       { "src": ".gitignore", "dest": ".gitignore" },

--- a/.github/workflows/build-managed-files-manifest.yml
+++ b/.github/workflows/build-managed-files-manifest.yml
@@ -19,7 +19,7 @@ on:
       - 'workflows/**'
       - 'CONTRIBUTING.md'
       - 'CLAUDE.md'
-      - 'README.md.tpl'
+      - 'README.md'
       - 'LICENSE'
       - '.editorconfig'
       - '.gitignore'

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -6,7 +6,6 @@ on:
     branches: [main]
     paths-ignore:
       - 'docs/**'
-      - 'README.md'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,23 +1,6 @@
-# Docs Control
+# f5xc-salesdemos
 
-[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/github-pages-deploy.yml)
-[![Repository Settings](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/enforce-repo-settings.yml)
-[![License](https://img.shields.io/github/license/f5xc-salesdemos/docs-control)](LICENSE)
-
-Governance and CI workflow templates for the f5xc-salesdemos documentation pipeline.
-
-## Documentation
-
-Full documentation is available at **[https://f5xc-salesdemos.github.io/docs-control/](https://f5xc-salesdemos.github.io/docs-control/)**.
-
-## Getting Started
-
-```bash
-git clone https://github.com/f5xc-salesdemos/docs-control.git
-```
-
-See the [documentation](https://f5xc-salesdemos.github.io/docs-control/) for detailed setup
-and usage guides.
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Makes README.md a fully governed managed file that syncs to all downstream repos
- Replaces repo-specific content (docs-control badges, clone URLs) with a generic canonical template
- Removes README.md from dispatch-downstream paths-ignore so changes trigger downstream sync
- Updates the manifest build trigger path from the unused README.md.tpl to README.md

Closes #397

## Test plan

- [ ] CI checks pass
- [ ] Verify README.md appears in the managed files manifest after build
- [ ] Confirm downstream dispatch workflow triggers on README.md changes