### PR TITLE
feat(governance): add traffic-generator to downstream repos list

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -23,5 +23,6 @@
   "f5xc-salesdemos/marketplace",
   "f5xc-salesdemos/xcsh",
   "f5xc-salesdemos/cdn-simulator",
-  "f5xc-salesdemos/origin-server"
+  "f5xc-salesdemos/origin-server",
+  "f5xc-salesdemos/traffic-generator"
 ]


### PR DESCRIPTION
## Summary

- Add `f5xc-salesdemos/traffic-generator` to the downstream repos list in `.github/config/downstream-repos.json`
- Ensures governance-managed files will sync to the traffic-generator repo once it exists
- Part of resolving the llms.txt federation gap identified in f5xc-salesdemos/docs#359

Closes #415

## Test plan

- [ ] CI checks pass
- [ ] JSON syntax is valid (Biome lint)
- [ ] Governance sync workflow will pick up the new repo on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)