### PR TITLE
feat: onboard demo-resources repository into governance

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -123,5 +123,10 @@
     "label": "Origin Server",
     "url": "https://f5xc-salesdemos.github.io/origin-server/llms-full.txt",
     "description": "Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments"
+  },
+  {
+    "label": "Demo Resources",
+    "url": "https://f5xc-salesdemos.github.io/demo-resources/llms-full.txt",
+    "description": "Catalog of pre-configured Azure VM components for F5 XC demo environments"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -24,5 +24,6 @@
   "f5xc-salesdemos/xcsh",
   "f5xc-salesdemos/cdn-simulator",
   "f5xc-salesdemos/origin-server",
-  "f5xc-salesdemos/traffic-generator"
+  "f5xc-salesdemos/traffic-generator",
+  "f5xc-salesdemos/demo-resources"
 ]


### PR DESCRIPTION
## Summary

- Add `f5xc-salesdemos/demo-resources` to `downstream-repos.json` to enable managed file sync, settings enforcement, and CI governance
- Add Demo Resources entry to `docs-sites.json` to register documentation metadata with `llms-full.txt` URL

Closes #417

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify `downstream-repos.json` is valid JSON with the new entry
- [ ] Verify `docs-sites.json` is valid JSON with the new entry