### PR TITLE
fix: add Go editorconfig override and biome formatter exclusion for generated JSON

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,5 +18,9 @@ indent_size = unset
 [*.py]
 indent_size = 4
 
+[*.go]
+indent_style = tab
+indent_size = 4
+
 [Makefile]
 indent_style = tab

--- a/biome.json
+++ b/biome.json
@@ -36,6 +36,12 @@
       }
     },
     {
+      "includes": ["docs/specifications/api/**", "docs/api-reference/**"],
+      "formatter": {
+        "enabled": false
+      }
+    },
+    {
       "includes": ["**/*.astro"],
       "linter": {
         "rules": {


### PR DESCRIPTION
## Summary

- Added `[*.go]` override in `.editorconfig` to set `indent_style=tab` for Go files, matching gofmt requirements. This prevents editorconfig-checker from rejecting Go file commits in downstream repos like terraform-provider-f5xc.
- Added biome formatter exclusion for machine-generated JSON directories (`docs/specifications/api/**`, `docs/api-reference/**`) to prevent chronic Super-Linter failures in api-specs-enriched releases.

Closes #419, closes #420

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify `.editorconfig` Go override is syntactically correct
- [ ] Verify `biome.json` formatter override follows existing pattern for disabled directories