### PR TITLE
fix(lint): disable Go linters in super-linter and exclude generated provider paths from JSCPD

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -155,6 +155,12 @@ jobs:
           # (e.g., xcsh's Cursor protobuf imports under packages/ai/src/
           # providers/cursor/proto/) whose layout is fork-faithful.
           VALIDATE_PROTOBUF: false
+          # GO: super-linter runs golangci-lint per-file, but Go's type
+          # checker requires all files in a package. Repos with Go code
+          # run golangci-lint correctly in their own CI jobs.
+          VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
+          VALIDATE_GO_REVIVE: false
 
       - name: Spectral OpenAPI lint
         if: hashFiles('.spectral.yaml', '.spectral.yml') != ''

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -11,6 +11,10 @@
     "**/.git/**",
     "**/vendor/**",
     "**/internal/client/**",
-    "**/templates/**"
+    "**/internal/provider/**",
+    "**/templates/**",
+    "**/docs/resources/**",
+    "**/docs/data-sources/**",
+    "**/docs/functions/**"
   ]
 }


### PR DESCRIPTION
## Summary

- Disables `VALIDATE_GO`, `VALIDATE_GO_MODULES`, and `VALIDATE_GO_REVIVE` in super-linter workflow — super-linter runs golangci-lint per-file, but Go's type checker requires all package files, fundamentally breaking Go linting in repos like terraform-provider-f5xc
- Adds `internal/provider/**`, `docs/resources/**`, `docs/data-sources/**`, and `docs/functions/**` to `.jscpd.json` ignore list — these are code-generated files from generate-all-schemas.go and tfplugindocs where duplication is inherent and intentional (37.71% over the 10% threshold)
- Repos with Go code already run golangci-lint correctly in their own CI jobs, so disabling in super-linter removes redundant broken checks

Closes #425

## Test plan

- [ ] CI checks pass
- [ ] Verify super-linter no longer fails on Go files in terraform-provider-f5xc
- [ ] Verify JSCPD no longer reports false positives on generated provider files