### PR TITLE
fix(lint): exclude tools/** from biome formatter for generated JSON

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -36,7 +36,7 @@
       }
     },
     {
-      "includes": ["docs/specifications/api/**", "docs/api-reference/**"],
+      "includes": ["docs/specifications/api/**", "docs/api-reference/**", "tools/**"],
       "formatter": {
         "enabled": false
       }


### PR DESCRIPTION
## Summary

- Add `tools/**` to the Biome formatter exclusion override in `biome.json`
- Prevents Super-Linter from reformatting machine-generated JSON files under `tools/` and `tools/metadata/` in the terraform-provider-f5xc downstream repo
- Fixes the governance sync PR (#359) CI failure caused by Biome attempting to reformat provider code-gen output files (api-defaults.json, error-patterns.json, operations-metadata.json, resource-metadata.json)

Closes #424

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Verify `biome.json` formatter override now includes `tools/**` alongside existing `docs/specifications/api/**` and `docs/api-reference/**` exclusions