### PR TITLE
fix(lint): disable step summary and biome schema to unblock Go repos

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -106,7 +106,8 @@ jobs:
           # .mypy_cache, .ruff_cache, .pytest_cache so the fs walker
           # doesn't hit dangling symlinks mid-run). See issue #377.
           TRIVY_CONFIG_FILE: trivy.yaml
-          SAVE_SUPER_LINTER_SUMMARY: true
+          SAVE_SUPER_LINTER_SUMMARY: false
+          VALIDATE_ALL_CODEBASE: false
           # No commitlint config exists in managed repos
           VALIDATE_GIT_COMMITLINT: false
           # ── Python linters ─────────────────────────────────

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "formatter": {
     "indentStyle": "space",
     "indentWidth": 2,


### PR DESCRIPTION
## Summary

- Set `SAVE_SUPER_LINTER_SUMMARY=false` to prevent exceeding GitHub's 1MB step summary limit in repos with 100+ generated Go files, docs, and examples
- Set `VALIDATE_ALL_CODEBASE=false` to only lint changed files, reducing summary size and improving CI performance
- Removed `$schema` line from `biome.json` to prevent version mismatch errors when super-linter uses `version:latest`

Closes #425

## Test plan

- [ ] CI checks pass on this PR
- [ ] Downstream Go repos (terraform-provider-f5xc) no longer fail super-linter due to step summary size
- [ ] Biome no longer reports schema version mismatch errors