### PR TITLE
fix: remove README.md from static managed files list

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -83,7 +83,6 @@
       { "src": ".github/ISSUE_TEMPLATE/config.yml", "dest": ".github/ISSUE_TEMPLATE/config.yml" },
 
       { "src": "CONTRIBUTING.md", "dest": "CONTRIBUTING.md" },
-      { "src": "README.md", "dest": "README.md" },
       { "src": "CLAUDE.md", "dest": "CLAUDE.md" },
       { "src": ".editorconfig", "dest": ".editorconfig" },
       { "src": ".gitignore", "dest": ".gitignore" },


### PR DESCRIPTION
## Summary

- Remove `README.md` from the static `managed_files.files[]` list in `repo-settings.json`
- README.md is already handled by the dynamic `README.md.tpl` generation path in the sync workflow
- The duplicate listing caused every scheduled Enforce Repository Settings run to fail with "No commits between main and governance/sync-managed-files" across all downstream repos

Closes #434

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify the next scheduled Enforce Repository Settings run completes without the "No commits" error on downstream repos