### PR TITLE
feat: add demo-resource-template to downstream repos list

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -25,5 +25,6 @@
   "f5xc-salesdemos/cdn-simulator",
   "f5xc-salesdemos/origin-server",
   "f5xc-salesdemos/traffic-generator",
-  "f5xc-salesdemos/demo-resources"
+  "f5xc-salesdemos/demo-resources",
+  "f5xc-salesdemos/demo-resource-template"
 ]


### PR DESCRIPTION
## Summary

- Add `f5xc-salesdemos/demo-resource-template` to the downstream repos configuration
- The template repo was created during demo resources standardization but was never onboarded into the docs-control governance ecosystem
- Once merged, the Enforce Repository Settings workflow will detect the missing managed files and create a sync PR to add all standard governance files to the template repo

Closes #436

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Verify JSON is valid and properly formatted
- [ ] After merge, confirm Enforce Repository Settings workflow runs and creates a sync PR in demo-resource-template