### PR TITLE
feat: register vscode-f5xc-tools in governance skip_files

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -69,7 +69,8 @@
         ".github/workflows/super-linter.yml"
       ],
       "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-      "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+      "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+      "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
     },
     "files": [
       { "src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml" },


### PR DESCRIPTION
## Summary

- Add `vscode-f5xc-tools` to `managed_files.skip_files` in repo-settings.json, skipping Python linting configs (`ruff.toml`, `.ruff.toml`, `.python-lint`, `.mypy.ini`, `.isort.cfg`) that are not applicable to a TypeScript/Node.js project.

Closes #442

## Test plan

- [ ] CI checks pass (Biome lint, governance check, super-linter)
- [ ] Verify `vscode-f5xc-tools` entry appears correctly in `skip_files` object
- [ ] Confirm governance sync excludes Python configs for this repo