### PR TITLE
feat: add vscode-f5xc-tools branch protection overrides

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -48,6 +48,9 @@
     "xcsh": {
       "additional_contexts": ["check", "test"],
       "excluded_required_contexts": ["lint / Lint Code Base"]
+    },
+    "vscode-f5xc-tools": {
+      "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]
     }
   },
   "topics": [],


### PR DESCRIPTION
## Summary

- Add `vscode-f5xc-tools` to `repo_overrides` in `.github/config/repo-settings.json`
- Include repo-specific CI checks as required status checks: `Validate Generation`, `Test (ubuntu-latest)`, `Build VSIX`
- These are in addition to org-standard `Check linked issues` and `Lint Code Base` checks

Closes #453

## Test plan

- [ ] CI checks pass
- [ ] JSON syntax is valid
- [ ] Override structure matches existing entries (e.g., xcsh)