### PR TITLE
feat: add vscode-f5xc-tools to downstream repos and docs sites

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -128,5 +128,10 @@
     "label": "Demo Resources",
     "url": "https://f5xc-salesdemos.github.io/demo-resources/llms-full.txt",
     "description": "Catalog of pre-configured Azure VM components for F5 XC demo environments"
+  },
+  {
+    "label": "VS Code Extension",
+    "url": "https://f5xc-salesdemos.github.io/vscode-f5xc-tools/llms-full.txt",
+    "description": "VS Code extension for managing F5 Distributed Cloud resources with IntelliSense and xcsh chat"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -26,5 +26,6 @@
   "f5xc-salesdemos/origin-server",
   "f5xc-salesdemos/traffic-generator",
   "f5xc-salesdemos/demo-resources",
-  "f5xc-salesdemos/demo-resource-template"
+  "f5xc-salesdemos/demo-resource-template",
+  "f5xc-salesdemos/vscode-f5xc-tools"
 ]


### PR DESCRIPTION
## Summary

- Add `f5xc-salesdemos/vscode-f5xc-tools` to `downstream-repos.json` for automatic settings enforcement and managed file sync
- Add VS Code extension docs site entry to `docs-sites.json` for documentation catalog inclusion

Closes #455

## Test plan

- [ ] CI checks pass (linked issues check + linter)
- [ ] Verify vscode-f5xc-tools appears in downstream-repos.json
- [ ] Verify VS Code extension entry appears in docs-sites.json with correct URL