### PR TITLE
feat: add secrets governance manifest and enforcement workflow

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -118,5 +118,51 @@
       { "src": ".claude/hooks/protect-managed-files.sh", "dest": ".claude/hooks/protect-managed-files.sh" },
       { "src": ".claude/hooks/enforce-git-delegation.sh", "dest": ".claude/hooks/enforce-git-delegation.sh" }
     ]
+  },
+  "secrets_manifest": {
+    "roles": {
+      "governance": ["REPO_SETTINGS_TOKEN", "REPO_SYNC_TOKEN"],
+      "npm_publish": ["NPM_TOKEN", "RELEASE_TOKEN"],
+      "release": ["RELEASE_TOKEN"],
+      "vscode_extension": ["VS_MARKETPLACE_TOKEN", "RELEASE_PAT", "RELEASE_TOKEN"],
+      "terraform_provider": ["GPG_PRIVATE_KEY", "PASSPHRASE", "AUTO_MERGE_TOKEN"],
+      "api_enrichment": [
+        "DOWNSTREAM_DISPATCH_TOKEN",
+        "F5XC_API_TOKEN",
+        "F5XC_API_URL",
+        "F5XC_NAMESPACE",
+        "VERSION_BUMP_PAT"
+      ],
+      "apple_signing": [
+        "APPLE_CERTIFICATE_BASE64",
+        "APPLE_CERTIFICATE_PASSWORD",
+        "APPLE_ID",
+        "APPLE_PASSWORD",
+        "APPLE_TEAM_ID"
+      ]
+    },
+    "repo_roles": {
+      "_default": ["governance"],
+      "docs-icons": ["governance", "npm_publish"],
+      "docs-theme": ["governance", "npm_publish"],
+      "docs-builder": ["governance", "release"],
+      "origin-server": ["governance", "release"],
+      "starlight-llms-txt": ["governance", "npm_publish"],
+      "xcsh": ["governance", "npm_publish", "apple_signing"],
+      "vscode-f5xc-tools": ["governance", "vscode_extension"],
+      "terraform-provider-f5xc": ["governance", "terraform_provider"],
+      "api-specs": ["governance"],
+      "api-specs-enriched": ["governance", "api_enrichment"],
+      "apt-repo": ["governance"]
+    },
+    "org_secret_source": {
+      "REPO_SETTINGS_TOKEN": "REPO_SETTINGS_TOKEN",
+      "REPO_SYNC_TOKEN": "REPO_SYNC_TOKEN",
+      "NPM_TOKEN": "NPM_TOKEN",
+      "RELEASE_TOKEN": "RELEASE_TOKEN"
+    },
+    "canonical_env_vars": {
+      "NPM_TOKEN": "NODE_AUTH_TOKEN"
+    }
   }
 }

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -27,6 +27,15 @@ on:
       REPO_SETTINGS_TOKEN:
         description: 'Repo-level fallback used by push trigger context'
         required: false
+      ORG_NPM_TOKEN:
+        description: 'Org-level NPM token for auto-provisioning'
+        required: false
+      ORG_RELEASE_TOKEN:
+        description: 'Org-level release token for auto-provisioning'
+        required: false
+      ORG_REPO_SYNC_TOKEN:
+        description: 'Org-level repo sync token for auto-provisioning'
+        required: false
 
 permissions:
   contents: read
@@ -46,6 +55,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
           SOURCE_SHA: ${{ inputs.source_sha }}
+          ORG_REPO_SETTINGS_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
+          ORG_REPO_SYNC_TOKEN: ${{ secrets.ORG_REPO_SYNC_TOKEN || '' }}
+          ORG_NPM_TOKEN: ${{ secrets.ORG_NPM_TOKEN || '' }}
+          ORG_RELEASE_TOKEN: ${{ secrets.ORG_RELEASE_TOKEN || '' }}
         run: |
           set -euo pipefail
 
@@ -451,9 +464,97 @@ jobs:
             echo "[SKIP] Pages not enabled in config"
           fi
 
-          # --- Phase 7: Verify --------------------------------------------------
+          # --- Phase 7: Enforce secrets -----------------------------------------
           echo ""
-          echo "=== Phase 7: Verify ==="
+          echo "=== Phase 7: Enforce secrets ==="
+
+          SECRETS_MANIFEST=$(echo "$CONFIG" | jq -c '.secrets_manifest // empty')
+
+          if [ -z "$SECRETS_MANIFEST" ] || [ "$SECRETS_MANIFEST" = "null" ]; then
+            echo "[SKIP] No secrets_manifest in config"
+          else
+            # Resolve roles for this repo
+            REPO_ROLES=$(echo "$SECRETS_MANIFEST" | jq -r \
+              --arg repo "$REPO" \
+              'if .repo_roles[$repo] then .repo_roles[$repo][]
+               else .repo_roles["_default"][]
+               end')
+
+            # Build expected secrets set from roles
+            EXPECTED_SECRETS=""
+            for role in $REPO_ROLES; do
+              ROLE_SECRETS=$(echo "$SECRETS_MANIFEST" | jq -r \
+                --arg r "$role" '.roles[$r] // [] | .[]')
+              EXPECTED_SECRETS=$(printf '%s\n%s' "$EXPECTED_SECRETS" "$ROLE_SECRETS")
+            done
+            EXPECTED_SECRETS=$(echo "$EXPECTED_SECRETS" | sort -u | grep -v '^$')
+
+            if [ -z "$EXPECTED_SECRETS" ]; then
+              echo "[SKIP] No secrets expected for ${REPO}"
+            else
+              echo "[INFO] Expected secrets for ${REPO}: $(echo "$EXPECTED_SECRETS" | tr '\n' ', ' | sed 's/,$//')"
+
+              # List current secrets
+              CURRENT_SECRETS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/secrets" \
+                --jq '.secrets[].name' 2>/dev/null | sort) || true
+
+              # Detect missing and auto-create where possible
+              CREATED=0
+              MANUAL_NEEDED=0
+              while IFS= read -r secret; do
+                [ -z "$secret" ] && continue
+                if ! echo "$CURRENT_SECRETS" | grep -qxF "$secret"; then
+                  ORG_SOURCE=$(echo "$SECRETS_MANIFEST" | jq -r \
+                    --arg s "$secret" '.org_secret_source[$s] // empty')
+                  if [ -n "$ORG_SOURCE" ]; then
+                    # Map org_secret_source name to the workflow env var
+                    ORG_ENV_VAR=""
+                    case "$ORG_SOURCE" in
+                      REPO_SETTINGS_TOKEN) ORG_ENV_VAR="ORG_REPO_SETTINGS_TOKEN" ;;
+                      REPO_SYNC_TOKEN)     ORG_ENV_VAR="ORG_REPO_SYNC_TOKEN" ;;
+                      NPM_TOKEN)           ORG_ENV_VAR="ORG_NPM_TOKEN" ;;
+                      RELEASE_TOKEN)       ORG_ENV_VAR="ORG_RELEASE_TOKEN" ;;
+                    esac
+                    # Indirect variable expansion: get the value of the env var
+                    ORG_VALUE="${!ORG_ENV_VAR:-}"
+                    if [ -n "$ORG_VALUE" ]; then
+                      echo "[INFO] Creating ${secret} from org source ${ORG_SOURCE}..."
+                      if echo "$ORG_VALUE" | gh secret set "$secret" \
+                        --repo "${OWNER}/${REPO}" 2>/dev/null; then
+                        echo "[OK] Created ${secret}"
+                        CREATED=$((CREATED + 1))
+                      else
+                        echo "[WARN] Failed to create ${secret} -- manual creation required"
+                        MANUAL_NEEDED=$((MANUAL_NEEDED + 1))
+                      fi
+                    else
+                      echo "[WARN] Missing ${secret} -- org value for ${ORG_SOURCE} not available in workflow secrets"
+                      MANUAL_NEEDED=$((MANUAL_NEEDED + 1))
+                    fi
+                  else
+                    echo "[WARN] Missing ${secret} -- no org source, manual creation required"
+                    MANUAL_NEEDED=$((MANUAL_NEEDED + 1))
+                  fi
+                fi
+              done <<< "$EXPECTED_SECRETS"
+
+              # Detect unexpected
+              UNEXPECTED=0
+              while IFS= read -r secret; do
+                [ -z "$secret" ] && continue
+                if ! echo "$EXPECTED_SECRETS" | grep -qxF "$secret"; then
+                  echo "[INFO] Unexpected secret: ${secret} (not in assigned roles)"
+                  UNEXPECTED=$((UNEXPECTED + 1))
+                fi
+              done <<< "$CURRENT_SECRETS"
+
+              echo "[OK] Secrets audit: created=${CREATED}, manual_needed=${MANUAL_NEEDED}, unexpected=${UNEXPECTED}"
+            fi
+          fi
+
+          # --- Phase 8: Verify --------------------------------------------------
+          echo ""
+          echo "=== Phase 8: Verify ==="
 
           VERIFY_FAILED=false
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -408,6 +408,93 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 10: secrets_manifest schema validity
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 10: secrets_manifest schema validity ==="
+
+MANIFEST=$(jq -c '.secrets_manifest // empty' "$REPO_SETTINGS")
+
+if [ -z "$MANIFEST" ] || [ "$MANIFEST" = "null" ]; then
+  fail "10.1 secrets_manifest exists in repo-settings.json" "key not found"
+else
+  pass "10.1 secrets_manifest exists in repo-settings.json"
+
+  # 10.2: every role referenced in repo_roles must exist in roles
+  ROLE_CHECK=$(echo "$MANIFEST" | jq -r '
+    . as $m |
+    [.repo_roles | to_entries[] | .value[]] | unique | .[] |
+    select(. as $r | $m.roles | has($r) | not)
+  ')
+  if [ -z "$ROLE_CHECK" ]; then
+    pass "10.2 all repo_roles reference valid roles"
+  else
+    fail "10.2 all repo_roles reference valid roles" "undefined roles: $ROLE_CHECK"
+  fi
+
+  # 10.3: every org_secret_source key must appear in at least one role
+  ALL_ROLE_SECRETS=$(echo "$MANIFEST" | jq -r '[.roles[][]] | unique | .[]')
+  ORG_CHECK=""
+  for secret in $(echo "$MANIFEST" | jq -r '.org_secret_source | keys[]'); do
+    if ! echo "$ALL_ROLE_SECRETS" | grep -qxF "$secret"; then
+      ORG_CHECK="${ORG_CHECK} ${secret}"
+    fi
+  done
+  if [ -z "$ORG_CHECK" ]; then
+    pass "10.3 all org_secret_source keys exist in a role"
+  else
+    fail "10.3 all org_secret_source keys exist in a role" "orphaned:$ORG_CHECK"
+  fi
+
+  # 10.4: canonical_env_vars keys must all appear in a role
+  CANONICAL_CHECK=""
+  for secret in $(echo "$MANIFEST" | jq -r '.canonical_env_vars | keys[]'); do
+    if ! echo "$ALL_ROLE_SECRETS" | grep -qxF "$secret"; then
+      CANONICAL_CHECK="${CANONICAL_CHECK} ${secret}"
+    fi
+  done
+  if [ -z "$CANONICAL_CHECK" ]; then
+    pass "10.4 all canonical_env_vars keys exist in a role"
+  else
+    fail "10.4 all canonical_env_vars keys exist in a role" "orphaned:$CANONICAL_CHECK"
+  fi
+fi
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 10b: canonical_env_vars workflow lint
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 10b: canonical_env_vars workflow lint ==="
+
+# For each secret in canonical_env_vars, scan managed workflow files
+# and assert the env var name matches the canonical name.
+# Pattern matched: ENV_VAR_NAME: ${{ secrets.SECRET_NAME }}
+CANONICAL_LINT_FAIL=""
+if [ -n "$MANIFEST" ] && [ "$MANIFEST" != "null" ]; then
+  while IFS='=' read -r secret_name canonical_var; do
+    [ -z "$secret_name" ] && continue
+    # Find all env var assignments referencing this secret in managed workflows
+    while IFS=: read -r wf_file wf_line; do
+      [ -z "$wf_file" ] && continue
+      # Extract the env var name (left side of the colon)
+      env_var=$(echo "$wf_line" | sed -n 's/^[[:space:]]*\([A-Z_][A-Z0-9_]*\)[[:space:]]*:.*/\1/p')
+      if [ -n "$env_var" ] && [ "$env_var" != "$canonical_var" ]; then
+        CANONICAL_LINT_FAIL="${CANONICAL_LINT_FAIL}  ${wf_file}: ${env_var} should be ${canonical_var} (for secrets.${secret_name})\n"
+      fi
+    done < <(grep -rn "secrets\.${secret_name}" "$REPO_ROOT/workflows/" 2>/dev/null || true)
+  done < <(echo "$MANIFEST" | jq -r '.canonical_env_vars | to_entries[] | "\(.key)=\(.value)"')
+
+  if [ -z "$CANONICAL_LINT_FAIL" ]; then
+    pass "10b.1 managed workflows use canonical env var names"
+  else
+    fail "10b.1 managed workflows use canonical env var names" \
+      "non-canonical references found:\n$CANONICAL_LINT_FAIL"
+  fi
+else
+  echo "  SKIP: no secrets_manifest to lint against"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 8: Idempotence (running this script twice yields identical output)
 # ════════════════════════════════════════════════════════════════════
 echo ""

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -30,6 +30,9 @@ jobs:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
+      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main


### PR DESCRIPTION
## Summary

- Adds `secrets_manifest` to `repo-settings.json` declaring role-based secret bundles and repo-to-role mappings
- Adds Phase 7 (Secrets enforcement) to `enforce-repo-settings.yml` that audits repo secrets against the manifest and auto-creates missing ones from org-level sources
- Adds 5 new test assertions: manifest schema validity (Section 10) and canonical env var lint (Section 10b)
- Updates local caller workflow to forward org secrets (`NPM_TOKEN`, `RELEASE_TOKEN`, `REPO_SYNC_TOKEN`)

Closes #459

## Test plan

- [ ] `bash tests/test-linter-configs.sh` passes 106/106 (verified locally)
- [ ] `jq empty .github/config/repo-settings.json` validates JSON
- [ ] `python3 -c "import yaml; yaml.safe_load(...)"` validates both workflow YAMLs
- [ ] CI lint passes on PR