### PR TITLE
fix: remove dead org-secret auto-provisioning code

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -154,15 +154,6 @@
       "api-specs": ["governance"],
       "api-specs-enriched": ["governance", "api_enrichment"],
       "apt-repo": ["governance"]
-    },
-    "org_secret_source": {
-      "REPO_SETTINGS_TOKEN": "REPO_SETTINGS_TOKEN",
-      "REPO_SYNC_TOKEN": "REPO_SYNC_TOKEN",
-      "NPM_TOKEN": "NPM_TOKEN",
-      "RELEASE_TOKEN": "RELEASE_TOKEN"
-    },
-    "canonical_env_vars": {
-      "NPM_TOKEN": "NODE_AUTH_TOKEN"
     }
   }
 }

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -27,15 +27,6 @@ on:
       REPO_SETTINGS_TOKEN:
         description: 'Repo-level fallback used by push trigger context'
         required: false
-      ORG_NPM_TOKEN:
-        description: 'Org-level NPM token for auto-provisioning'
-        required: false
-      ORG_RELEASE_TOKEN:
-        description: 'Org-level release token for auto-provisioning'
-        required: false
-      ORG_REPO_SYNC_TOKEN:
-        description: 'Org-level repo sync token for auto-provisioning'
-        required: false
 
 permissions:
   contents: read
@@ -55,10 +46,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
           SOURCE_SHA: ${{ inputs.source_sha }}
-          ORG_REPO_SETTINGS_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
-          ORG_REPO_SYNC_TOKEN: ${{ secrets.ORG_REPO_SYNC_TOKEN || '' }}
-          ORG_NPM_TOKEN: ${{ secrets.ORG_NPM_TOKEN || '' }}
-          ORG_RELEASE_TOKEN: ${{ secrets.ORG_RELEASE_TOKEN || '' }}
         run: |
           set -euo pipefail
 
@@ -498,43 +485,13 @@ jobs:
               CURRENT_SECRETS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/secrets" \
                 --jq '.secrets[].name' 2>/dev/null | sort) || true
 
-              # Detect missing and auto-create where possible
-              CREATED=0
-              MANUAL_NEEDED=0
+              # Detect missing
+              MISSING=0
               while IFS= read -r secret; do
                 [ -z "$secret" ] && continue
                 if ! echo "$CURRENT_SECRETS" | grep -qxF "$secret"; then
-                  ORG_SOURCE=$(echo "$SECRETS_MANIFEST" | jq -r \
-                    --arg s "$secret" '.org_secret_source[$s] // empty')
-                  if [ -n "$ORG_SOURCE" ]; then
-                    # Map org_secret_source name to the workflow env var
-                    ORG_ENV_VAR=""
-                    case "$ORG_SOURCE" in
-                      REPO_SETTINGS_TOKEN) ORG_ENV_VAR="ORG_REPO_SETTINGS_TOKEN" ;;
-                      REPO_SYNC_TOKEN)     ORG_ENV_VAR="ORG_REPO_SYNC_TOKEN" ;;
-                      NPM_TOKEN)           ORG_ENV_VAR="ORG_NPM_TOKEN" ;;
-                      RELEASE_TOKEN)       ORG_ENV_VAR="ORG_RELEASE_TOKEN" ;;
-                    esac
-                    # Indirect variable expansion: get the value of the env var
-                    ORG_VALUE="${!ORG_ENV_VAR:-}"
-                    if [ -n "$ORG_VALUE" ]; then
-                      echo "[INFO] Creating ${secret} from org source ${ORG_SOURCE}..."
-                      if echo "$ORG_VALUE" | gh secret set "$secret" \
-                        --repo "${OWNER}/${REPO}" 2>/dev/null; then
-                        echo "[OK] Created ${secret}"
-                        CREATED=$((CREATED + 1))
-                      else
-                        echo "[WARN] Failed to create ${secret} -- manual creation required"
-                        MANUAL_NEEDED=$((MANUAL_NEEDED + 1))
-                      fi
-                    else
-                      echo "[WARN] Missing ${secret} -- org value for ${ORG_SOURCE} not available in workflow secrets"
-                      MANUAL_NEEDED=$((MANUAL_NEEDED + 1))
-                    fi
-                  else
-                    echo "[WARN] Missing ${secret} -- no org source, manual creation required"
-                    MANUAL_NEEDED=$((MANUAL_NEEDED + 1))
-                  fi
+                  echo "[WARN] Missing ${secret}"
+                  MISSING=$((MISSING + 1))
                 fi
               done <<< "$EXPECTED_SECRETS"
 
@@ -548,7 +505,7 @@ jobs:
                 fi
               done <<< "$CURRENT_SECRETS"
 
-              echo "[OK] Secrets audit: created=${CREATED}, manual_needed=${MANUAL_NEEDED}, unexpected=${UNEXPECTED}"
+              echo "[OK] Secrets audit: missing=${MISSING}, unexpected=${UNEXPECTED}"
             fi
           fi
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -432,66 +432,6 @@ else
     fail "10.2 all repo_roles reference valid roles" "undefined roles: $ROLE_CHECK"
   fi
 
-  # 10.3: every org_secret_source key must appear in at least one role
-  ALL_ROLE_SECRETS=$(echo "$MANIFEST" | jq -r '[.roles[][]] | unique | .[]')
-  ORG_CHECK=""
-  for secret in $(echo "$MANIFEST" | jq -r '.org_secret_source | keys[]'); do
-    if ! echo "$ALL_ROLE_SECRETS" | grep -qxF "$secret"; then
-      ORG_CHECK="${ORG_CHECK} ${secret}"
-    fi
-  done
-  if [ -z "$ORG_CHECK" ]; then
-    pass "10.3 all org_secret_source keys exist in a role"
-  else
-    fail "10.3 all org_secret_source keys exist in a role" "orphaned:$ORG_CHECK"
-  fi
-
-  # 10.4: canonical_env_vars keys must all appear in a role
-  CANONICAL_CHECK=""
-  for secret in $(echo "$MANIFEST" | jq -r '.canonical_env_vars | keys[]'); do
-    if ! echo "$ALL_ROLE_SECRETS" | grep -qxF "$secret"; then
-      CANONICAL_CHECK="${CANONICAL_CHECK} ${secret}"
-    fi
-  done
-  if [ -z "$CANONICAL_CHECK" ]; then
-    pass "10.4 all canonical_env_vars keys exist in a role"
-  else
-    fail "10.4 all canonical_env_vars keys exist in a role" "orphaned:$CANONICAL_CHECK"
-  fi
-fi
-
-# ════════════════════════════════════════════════════════════════════
-# SECTION 10b: canonical_env_vars workflow lint
-# ════════════════════════════════════════════════════════════════════
-echo ""
-echo "=== Section 10b: canonical_env_vars workflow lint ==="
-
-# For each secret in canonical_env_vars, scan managed workflow files
-# and assert the env var name matches the canonical name.
-# Pattern matched: ENV_VAR_NAME: ${{ secrets.SECRET_NAME }}
-CANONICAL_LINT_FAIL=""
-if [ -n "$MANIFEST" ] && [ "$MANIFEST" != "null" ]; then
-  while IFS='=' read -r secret_name canonical_var; do
-    [ -z "$secret_name" ] && continue
-    # Find all env var assignments referencing this secret in managed workflows
-    while IFS=: read -r wf_file wf_line; do
-      [ -z "$wf_file" ] && continue
-      # Extract the env var name (left side of the colon)
-      env_var=$(echo "$wf_line" | sed -n 's/^[[:space:]]*\([A-Z_][A-Z0-9_]*\)[[:space:]]*:.*/\1/p')
-      if [ -n "$env_var" ] && [ "$env_var" != "$canonical_var" ]; then
-        CANONICAL_LINT_FAIL="${CANONICAL_LINT_FAIL}  ${wf_file}: ${env_var} should be ${canonical_var} (for secrets.${secret_name})\n"
-      fi
-    done < <(grep -rn "secrets\.${secret_name}" "$REPO_ROOT/workflows/" 2>/dev/null || true)
-  done < <(echo "$MANIFEST" | jq -r '.canonical_env_vars | to_entries[] | "\(.key)=\(.value)"')
-
-  if [ -z "$CANONICAL_LINT_FAIL" ]; then
-    pass "10b.1 managed workflows use canonical env var names"
-  else
-    fail "10b.1 managed workflows use canonical env var names" \
-      "non-canonical references found:\n$CANONICAL_LINT_FAIL"
-  fi
-else
-  echo "  SKIP: no secrets_manifest to lint against"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -30,9 +30,6 @@ jobs:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
-      ORG_NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      ORG_RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      ORG_REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
 
   sync-files:
     uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main


### PR DESCRIPTION
## Summary

- Remove `org_secret_source` and `canonical_env_vars` mappings from `repo-settings.json`
- Remove `ORG_NPM_TOKEN`/`ORG_RELEASE_TOKEN`/`ORG_REPO_SYNC_TOKEN` secret inputs and env vars from `enforce-repo-settings.yml`
- Remove org secret forwarding lines from `workflows/enforce-repo-settings.yml`
- Simplify Phase 7 to audit-only (no auto-create) since org secrets are unavailable on GitHub Free
- Remove tests 10.3, 10.4, 10b.1 that validated the removed fields

Closes #463

## Test plan

- [ ] CI checks pass (lint, shell script lint, YAML lint, JSON lint)
- [ ] `enforce-repo-settings.yml` workflow syntax is valid
- [ ] `test-linter-configs.sh` remaining tests pass
- [ ] Phase 7 operates in audit-only mode without errors