### PR TITLE
feat: add additional textlint terminology exclusions for generated Terraform docs

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -45,7 +45,13 @@
         "User Name",
         "username",
         "Internet",
-        "internet"
+        "internet",
+        "Javascript",
+        "MAC OS",
+        "OS X",
+        "Sdk",
+        "Client Side",
+        "Code Base"
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Add six upstream F5 XC API terms to the textlint terminology exclusion list: `Javascript`, `MAC OS`, `OS X`, `Sdk`, `Client Side`, `Code Base`
- These terms originate from upstream API spec descriptions and cannot be rewritten, causing NATURAL_LANGUAGE lint failures on the terraform-provider-f5xc auto-regenerate PR #511
- Extends the initial exclusions from PR #465

Closes #466

## Test plan

- [ ] CI `Lint Code Base` check passes with the updated `.textlintrc`
- [ ] Verify the terraform-provider-f5xc auto-regenerate PR #511 no longer fails on these terms