### PR TITLE
fix: accept legacy org secrets to unblock startup_failure across 28 repos

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -27,6 +27,15 @@ on:
       REPO_SETTINGS_TOKEN:
         description: 'Repo-level fallback used by push trigger context'
         required: false
+      ORG_NPM_TOKEN:
+        description: 'Legacy org secret — accepted to unblock startup_failure in stale callers'
+        required: false
+      ORG_RELEASE_TOKEN:
+        description: 'Legacy org secret — accepted to unblock startup_failure in stale callers'
+        required: false
+      ORG_REPO_SYNC_TOKEN:
+        description: 'Legacy org secret — accepted to unblock startup_failure in stale callers'
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Declare `ORG_NPM_TOKEN`, `ORG_RELEASE_TOKEN`, and `ORG_REPO_SYNC_TOKEN` as `required: false` secrets in the reusable `enforce-repo-settings` workflow's `workflow_call` block
- Unblocks GitHub Actions `startup_failure` on 28 downstream repos caused by commit 6bc59ac distributing a caller template that passes undeclared secrets
- Enables the enforcement workflow to sync the already-fixed caller template (bd2082c) and remove the extra secrets from downstream repos

Closes #471

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge, verify `enforce-repo-settings` workflow no longer produces `startup_failure` on downstream repos
- [ ] Verify downstream repos receive the clean caller template via sync