### PR TITLE
feat: add per-repo extra badges to README template system

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -2,12 +2,14 @@
   {
     "label": "f5xc Docs Builder",
     "url": "https://f5xc-salesdemos.github.io/docs-builder/llms-full.txt",
-    "description": "Containerized Astro + Starlight documentation build system"
+    "description": "Containerized Astro + Starlight documentation build system",
+    "badges": [{ "name": "Build Image", "workflow": "build-image.yml" }]
   },
   {
     "label": "XC Docs Theme",
     "url": "https://f5xc-salesdemos.github.io/docs-theme/llms-full.txt",
-    "description": "Shared branding and styling for F5 Distributed Cloud documentation sites"
+    "description": "Shared branding and styling for F5 Distributed Cloud documentation sites",
+    "badges": [{ "name": "Release", "workflow": "release.yml" }]
   },
   {
     "label": "F5 XC Docs",
@@ -77,12 +79,17 @@
   {
     "label": "API Specs",
     "url": "https://f5xc-salesdemos.github.io/api-specs/llms-full.txt",
-    "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud"
+    "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud",
+    "badges": [{ "name": "Validate and Release", "workflow": "validate-and-release.yml" }]
   },
   {
     "label": "API Specs Enriched",
     "url": "https://f5xc-salesdemos.github.io/api-specs-enriched/llms-full.txt",
-    "description": "Enriched OpenAPI specifications for F5 Distributed Cloud"
+    "description": "Enriched OpenAPI specifications for F5 Distributed Cloud",
+    "badges": [
+      { "name": "Tests", "workflow": "tests.yml" },
+      { "name": "Sync and Enrich", "workflow": "sync-and-enrich.yml" }
+    ]
   },
   {
     "label": "Client-Side Defense",
@@ -92,27 +99,35 @@
   {
     "label": "Docs Icons",
     "url": "https://f5xc-salesdemos.github.io/docs-icons/llms-full.txt",
-    "description": "NPM icon packages and plugins for the F5 XC documentation build system"
+    "description": "NPM icon packages and plugins for the F5 XC documentation build system",
+    "badges": [{ "name": "NPM Publish", "workflow": "npm-publish.yml" }]
   },
   {
     "label": "Terraform Provider",
     "url": "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms-full.txt",
-    "description": "Terraform provider for F5 Distributed Cloud"
+    "description": "Terraform provider for F5 Distributed Cloud",
+    "badges": [{ "name": "CI", "workflow": "ci.yml" }]
   },
   {
     "label": "Dev Container",
     "url": "https://f5xc-salesdemos.github.io/devcontainer/llms-full.txt",
-    "description": "Isolated development environment with AI coding tools"
+    "description": "Isolated development environment with AI coding tools",
+    "badges": [{ "name": "Docker Publish", "workflow": "docker-publish.yml" }]
   },
   {
     "label": "Marketplace",
     "url": "https://f5xc-salesdemos.github.io/marketplace/llms-full.txt",
-    "description": "AI-powered marketplace for F5 Distributed Cloud solutions"
+    "description": "AI-powered marketplace for F5 Distributed Cloud solutions",
+    "badges": [
+      { "name": "Validate Plugins", "workflow": "validate-plugins.yml" },
+      { "name": "Release Plugins", "workflow": "release-plugins.yml" }
+    ]
   },
   {
     "label": "xcsh",
     "url": "https://f5xc-salesdemos.github.io/xcsh/llms-full.txt",
-    "description": "AI-powered development environment and CLI tool"
+    "description": "AI-powered development environment and CLI tool",
+    "badges": [{ "name": "CI", "workflow": "ci.yml" }]
   },
   {
     "label": "CDN Simulator",
@@ -122,7 +137,8 @@
   {
     "label": "Origin Server",
     "url": "https://f5xc-salesdemos.github.io/origin-server/llms-full.txt",
-    "description": "Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments"
+    "description": "Ubuntu 24.04 origin server with vulnerable web applications for F5 XC demo environments",
+    "badges": [{ "name": "Release", "workflow": "release.yml" }]
   },
   {
     "label": "Demo Resources",
@@ -132,6 +148,7 @@
   {
     "label": "VS Code Extension",
     "url": "https://f5xc-salesdemos.github.io/vscode-f5xc-tools/llms-full.txt",
-    "description": "VS Code extension for managing F5 Distributed Cloud resources with IntelliSense and xcsh chat"
+    "description": "VS Code extension for managing F5 Distributed Cloud resources with IntelliSense and xcsh chat",
+    "badges": [{ "name": "CI", "workflow": "ci.yml" }, { "name": "Release", "workflow": "release.yml" }]
   }
 ]

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -420,6 +420,13 @@ jobs:
 
               DOCS_URL="https://f5xc-salesdemos.github.io/${REPO}/"
 
+              # Extract per-repo extra badges from docs-sites.json
+              README_BADGES=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" --arg o "$OWNER" \
+                '[.[] | select(.url | contains("/" + $r + "/")) | .badges // [] | .[]] |
+                 if length == 0 then empty
+                 else .[] | "[![\(.name)](https://github.com/\($o)/\($r)/actions/workflows/\(.workflow)/badge.svg)](https://github.com/\($o)/\($r)/actions/workflows/\(.workflow))"
+                 end' 2>/dev/null) || true
+
               # Fetch README.md.tpl from docs-control
               README_TPL=$(fetch_governed "README.md.tpl" "repos/${CONFIG_REPO}/contents/README.md.tpl")
 
@@ -430,6 +437,16 @@ jobs:
                 sed "s|__DESCRIPTION__|${README_DESC}|g" | \
                 sed "s|__REPO_NAME__|${REPO}|g" | \
                 sed "s|__DOCS_URL__|${DOCS_URL}|g" > /tmp/generated_readme.md
+
+              # Replace __EXTRA_BADGES__ placeholder — inject per-repo badge lines or remove
+              if [ -n "$README_BADGES" ]; then
+                printf '%s\n' "$README_BADGES" > /tmp/extra_badges.tmp
+                sed -i '/__EXTRA_BADGES__/{r /tmp/extra_badges.tmp
+                d;}' /tmp/generated_readme.md
+              else
+                sed -i '/__EXTRA_BADGES__/d' /tmp/generated_readme.md
+              fi
+
               GENERATED_README=$(cat /tmp/generated_readme.md)
 
               # Compare with current README.md in target repo (local disk, no API).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # f5xc-salesdemos
 
+[![Enforce Repository Settings](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/enforce-repo-settings.yml)
+[![Dispatch Downstream](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/dispatch-downstream.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/dispatch-downstream.yml)
+[![Build Managed Files Manifest](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/build-managed-files-manifest.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/build-managed-files-manifest.yml)
+[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/github-pages-deploy.yml)
+[![Super-Linter](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/super-linter.yml/badge.svg)](https://github.com/f5xc-salesdemos/docs-control/actions/workflows/super-linter.yml)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 
 ## Contributing

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -2,6 +2,7 @@
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/github-pages-deploy.yml)
 [![Repository Settings](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/enforce-repo-settings.yml)
+__EXTRA_BADGES__
 [![License](https://img.shields.io/github/license/f5xc-salesdemos/__REPO_NAME__)](LICENSE)
 
 __DESCRIPTION__


### PR DESCRIPTION
## Summary

- Add `extra_badges` array field to `docs-sites.json` for per-repo custom badge injection
- Update `sync-managed-files.yml` workflow to process the new `extra_badges` field and inject badges into generated READMEs
- Update `README.md.tpl` template with the extra badges placeholder
- Regenerate `README.md` with the new template output

Closes #473

## Test plan

- [ ] CI checks pass (Check linked issues + Lint Code Base)
- [ ] Verify `sync-managed-files.yml` correctly reads `extra_badges` from `docs-sites.json`
- [ ] Verify generated README includes extra badges when configured