### PR TITLE
fix: remove legacy org secret declarations from reusable workflow

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -27,15 +27,6 @@ on:
       REPO_SETTINGS_TOKEN:
         description: 'Repo-level fallback used by push trigger context'
         required: false
-      ORG_NPM_TOKEN:
-        description: 'Legacy org secret — accepted to unblock startup_failure in stale callers'
-        required: false
-      ORG_RELEASE_TOKEN:
-        description: 'Legacy org secret — accepted to unblock startup_failure in stale callers'
-        required: false
-      ORG_REPO_SYNC_TOKEN:
-        description: 'Legacy org secret — accepted to unblock startup_failure in stale callers'
-        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Remove `ORG_NPM_TOKEN`, `ORG_RELEASE_TOKEN`, and `ORG_REPO_SYNC_TOKEN` optional secret declarations from `enforce-repo-settings.yml`
- These were added as a temporary bridge in PR #472 to unblock `startup_failure` in stale callers
- All 31 downstream repos now have the clean caller template that no longer passes these secrets

Closes #476

## Test plan

- [ ] CI checks pass (no downstream repos will break since none pass these secrets anymore)
- [ ] Verify no references to these secrets remain in the workflow