### PR TITLE
fix: remove duplicate Getting Started section from README template

### DIFF
--- a/README.md.tpl
+++ b/README.md.tpl
@@ -13,15 +13,6 @@ __EXTRA_CONTENT__
 
 Full documentation is available at **[__DOCS_URL__](__DOCS_URL__)**.
 
-## Getting Started
-
-```bash
-git clone https://github.com/f5xc-salesdemos/__REPO_NAME__.git
-```
-
-See the [documentation](__DOCS_URL__) for detailed setup
-and usage guides.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for workflow rules,


### PR DESCRIPTION
## Summary

- Remove the "Getting Started" section from `README.md.tpl` that contained a generic `git clone` command and documentation link
- This section duplicates the per-repo `readme_content` Getting Started section injected via `__EXTRA_CONTENT__` (e.g., vscode-f5xc-tools has its own Getting Started)
- For repos without `readme_content`, the existing Documentation link already directs users to setup guides

Closes #482

## Test plan

- [ ] CI checks pass
- [ ] Verify generated READMEs for repos with `readme_content` no longer have duplicate Getting Started sections
- [ ] Verify generated READMEs for repos without `readme_content` still have a functional Documentation link