### PR TITLE
fix: exclude i18n locale directories from super-linter FILTER_REGEX_EXCLUDE

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -66,7 +66,7 @@ jobs:
           # generated (parser.c from `tree-sitter generate`) or hand-written
           # to upstream tree-sitter conventions that do not match
           # clang-format's default style; excluding preserves fork fidelity.
-          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/|tree-sitter-[^/]+/src/(parser|scanner)\\.(c|h)$)"
+          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/|tree-sitter-[^/]+/src/(parser|scanner)\\.(c|h)$|docs/(fr|es|de|ja|pt-br|ko|zh-cn|zh-tw|ar|it|hi|th)/)"
           # Disable Prettier — Biome handles formatting for
           # JS/TS/JSON/CSS/HTML/GraphQL/JSX/Vue; yamllint handles
           # YAML; markdownlint handles Markdown.


### PR DESCRIPTION
## Summary

Add i18n locale directories to `FILTER_REGEX_EXCLUDE` in the super-linter workflow. The `.codespellrc` skip patterns don't take effect when super-linter passes files individually to codespell.

## Pattern added
`docs/(fr|es|de|ja|pt-br|ko|zh-cn|zh-tw|ar|it|hi|th)/`

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)