### PR TITLE
feat: add i18n-core to downstream repos governance

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -30,5 +30,6 @@
   "f5xc-salesdemos/vscode-f5xc-tools",
   "f5xc-salesdemos/starlight-llms-txt",
   "f5xc-salesdemos/starlight-mega-menu",
-  "f5xc-salesdemos/apt-repo"
+  "f5xc-salesdemos/apt-repo",
+  "f5xc-salesdemos/i18n-core"
 ]

--- a/docs/images/hero.svg
+++ b/docs/images/hero.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<title>F5 Distributed Cloud Documentation</title>
 <style>
   :root {
     --color-N600: #0f1e57;


### PR DESCRIPTION
## Summary
- Add `f5xc-salesdemos/i18n-core` to `.github/config/downstream-repos.json`
- Enables governance sync (managed files, repo settings enforcement) for the new i18n-core package

Closes #504

## Test plan
- [ ] Verify governance dispatch includes i18n-core on next sync cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)