### PR TITLE
fix: use exact match for self-exclusion in protect-managed-files hook

### DIFF
--- a/.claude/hooks/protect-managed-files.sh
+++ b/.claude/hooks/protect-managed-files.sh
@@ -11,10 +11,19 @@ if ! read -t 0 2>/dev/null; then
   exit 0
 fi
 
-# ── Self-exclusion: allow edits in docs-control itself ──────────────
+# ── Self-exclusion: allow edits in the governance source repo ───────
 REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-if echo "$REMOTE_URL" | grep -q "docs-control"; then
-  exit 0
+SCRIPT_DIR_EARLY="$(cd "$(dirname "$0")" && pwd)"
+GOVERNANCE_EARLY="${SCRIPT_DIR_EARLY}/../governance.json"
+SOURCE_REPO=""
+if [ -f "$GOVERNANCE_EARLY" ]; then
+  SOURCE_REPO=$(jq -r '.source_repo // empty' "$GOVERNANCE_EARLY" 2>/dev/null || echo "")
+fi
+if [ -n "$SOURCE_REPO" ] && [ -n "$REMOTE_URL" ]; then
+  REMOTE_PATH=$(echo "$REMOTE_URL" | sed 's|\.git$||' | sed -E 's|.*[:/]([^/]+/[^/]+)$|\1|')
+  if [ "$REMOTE_PATH" = "$SOURCE_REPO" ]; then
+    exit 0
+  fi
 fi
 
 # ── Read tool input from stdin ──────────────────────────────────────

--- a/tests/test-protect-managed-files.sh
+++ b/tests/test-protect-managed-files.sh
@@ -245,6 +245,51 @@ assert_exit_code 0 "$EXIT_CODE" "4.1 self-exclusion: protected file allowed in d
 # Test 4.2: no BLOCKED message in docs-control
 assert_not_contains "$OUTPUT" "BLOCKED" "4.2 self-exclusion: no BLOCKED message in docs-control"
 
+# Test 4.3: hook blocks repos with similar names (substring bypass prevention)
+EVIL_DOWN="$TMPDIR_BASE/evil-downstream"
+mkdir -p "$EVIL_DOWN/.claude/hooks"
+cp "$HOOK_SCRIPT" "$EVIL_DOWN/.claude/hooks/"
+cp "$GOVERNANCE_JSON" "$EVIL_DOWN/.claude/"
+(
+  cd "$EVIL_DOWN"
+  git init -q
+  git remote add origin https://github.com/evil/docs-control-fork.git
+)
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_hook "$EVIL_DOWN" "CLAUDE.md") || EXIT_CODE=$?
+assert_exit_code 2 "$EXIT_CODE" "4.3 substring bypass: evil/docs-control-fork is NOT self-excluded"
+
+# Test 4.4: hook blocks repos with docs-control as substring prefix
+EVIL_DOWN2="$TMPDIR_BASE/evil-downstream2"
+mkdir -p "$EVIL_DOWN2/.claude/hooks"
+cp "$HOOK_SCRIPT" "$EVIL_DOWN2/.claude/hooks/"
+cp "$GOVERNANCE_JSON" "$EVIL_DOWN2/.claude/"
+(
+  cd "$EVIL_DOWN2"
+  git init -q
+  git remote add origin https://github.com/f5xc-salesdemos/docs-control-utils.git
+)
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_hook "$EVIL_DOWN2" "CLAUDE.md") || EXIT_CODE=$?
+assert_exit_code 2 "$EXIT_CODE" "4.4 substring bypass: docs-control-utils is NOT self-excluded"
+
+# Test 4.5: self-exclusion works with SSH remote URL format
+SSH_DOWN="$TMPDIR_BASE/ssh-downstream"
+mkdir -p "$SSH_DOWN/.claude/hooks"
+cp "$HOOK_SCRIPT" "$SSH_DOWN/.claude/hooks/"
+cp "$GOVERNANCE_JSON" "$SSH_DOWN/.claude/"
+(
+  cd "$SSH_DOWN"
+  git init -q
+  git remote add origin git@github.com:f5xc-salesdemos/docs-control.git
+)
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_hook "$SSH_DOWN" "CONTRIBUTING.md") || EXIT_CODE=$?
+assert_exit_code 0 "$EXIT_CODE" "4.5 self-exclusion works with SSH remote URL"
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5: Hook Behavior — Blocking Protected Files
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Replace substring `grep -q "docs-control"` with exact match against `source_repo` from governance.json
- Extracts org/repo path from remote URL via sed, compares against canonical source_repo
- Works with HTTPS and SSH remote URL formats
- Added 3 new tests: substring bypass prevention (2 cases) and SSH URL format

Closes #503

## Security impact
The old pattern would bypass file protection for any repo containing "docs-control" in its name (e.g., `evil/docs-control-fork`). The new pattern only matches the exact `f5xc-salesdemos/docs-control` repo.

## Test plan
- [ ] Shell Unit Tests pass in CI (Linux)
- [ ] Test 4.3: `evil/docs-control-fork` is NOT self-excluded
- [ ] Test 4.4: `docs-control-utils` is NOT self-excluded  
- [ ] Test 4.5: SSH remote URL format works for self-exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)