### PR TITLE
feat: add locale-lint script to detect hardcoded locale lists

### DIFF
--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -27,12 +27,12 @@ check_pattern() {
   local pattern="$1"
   local results
   results=$(grep -rn --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' \
-    -E "$pattern" . 2>/dev/null \
-    | grep -vE "($EXCLUDE_DIRS)" \
-    | grep -vE "($EXCLUDE_FILES)" \
-    | grep -vE "from\s+['\"]@f5xc-salesdemos/i18n-core" \
-    | grep -vE "i18n-core/(src|dist)/" \
-    || true)
+    -E "$pattern" . 2>/dev/null |
+    grep -vE "($EXCLUDE_DIRS)" |
+    grep -vE "($EXCLUDE_FILES)" |
+    grep -vE "from\s+['\"]@f5xc-salesdemos/i18n-core" |
+    grep -vE "i18n-core/(src|dist)/" ||
+    true)
 
   if [ -n "$results" ]; then
     echo "$results"

--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Detects hardcoded locale lists that should import from @f5xc-salesdemos/i18n-core.
+# Run from any repo root: bash scripts/locale-lint.sh
+# Exit 0 = clean, Exit 1 = violations found.
+set -euo pipefail
+
+VIOLATIONS=0
+
+# Patterns that indicate a hardcoded locale list rather than an i18n-core import
+PATTERNS=(
+  # Inline slug arrays containing 3+ locale codes (high confidence)
+  "'pt-br'.*'zh-cn'.*'zh-tw'"
+  '"pt-br".*"zh-cn".*"zh-tw"'
+  # Inline constant definitions that should come from i18n-core
+  'VALID_LOCALE_SLUGS\s*=\s*new\s+Set'
+  '(const|let|var|export)\s+LOCALE_DISPLAY_NAMES'
+  '(const|let|var|export)\s+LANG_TO_SLUG'
+  # Inline langToSlug function definition (not an import alias)
+  'function\s+langToSlug'
+)
+
+# Directories and files to exclude
+EXCLUDE_DIRS="node_modules|dist|\.git|coverage|\.astro|\.next|out|build"
+EXCLUDE_FILES="locale-lint\.sh|\.test\.|\.spec\."
+
+check_pattern() {
+  local pattern="$1"
+  local results
+  results=$(grep -rn --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' \
+    -E "$pattern" . 2>/dev/null \
+    | grep -vE "($EXCLUDE_DIRS)" \
+    | grep -vE "($EXCLUDE_FILES)" \
+    | grep -vE "from\s+['\"]@f5xc-salesdemos/i18n-core" \
+    | grep -vE "i18n-core/(src|dist)/" \
+    || true)
+
+  if [ -n "$results" ]; then
+    echo "$results"
+    return 1
+  fi
+  return 0
+}
+
+echo "Locale lint: checking for hardcoded locale lists..."
+echo ""
+
+for pattern in "${PATTERNS[@]}"; do
+  if ! check_pattern "$pattern"; then
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done
+
+echo ""
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "FAIL: Found $VIOLATIONS pattern(s) with hardcoded locale data."
+  echo "These should import from @f5xc-salesdemos/i18n-core instead."
+  exit 1
+else
+  echo "PASS: No hardcoded locale lists detected."
+  exit 0
+fi

--- a/tests/test-locale-lint.sh
+++ b/tests/test-locale-lint.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Tests for scripts/locale-lint.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 — $2"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LINT_SCRIPT="$SCRIPT_DIR/scripts/locale-lint.sh"
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+setup_clean_repo() {
+  rm -rf "$TMPDIR_BASE/repo"
+  mkdir -p "$TMPDIR_BASE/repo/src"
+}
+
+run_lint() {
+  local dir="$1"
+  local exit_code=0
+  local output
+  output=$(cd "$dir" && bash "$LINT_SCRIPT" 2>&1) || exit_code=$?
+  echo "$output"
+  return $exit_code
+}
+
+echo ""
+echo "=== Locale Lint Tests ==="
+
+# Test 1: clean repo passes
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/app.ts" <<'TS'
+import { VALID_SLUGS } from '@f5xc-salesdemos/i18n-core';
+console.log(VALID_SLUGS);
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+  pass "1. clean repo with i18n-core import passes"
+else
+  fail "1. clean repo passes" "exit $EXIT_CODE"
+fi
+
+# Test 2: hardcoded slug array is detected
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+const LOCALES = ['en', 'fr', 'pt-br', 'zh-cn', 'zh-tw', 'ar'];
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 1 ]; then
+  pass "2. hardcoded slug array detected"
+else
+  fail "2. hardcoded slug array detected" "exit $EXIT_CODE (expected 1)"
+fi
+
+# Test 3: inline VALID_LOCALE_SLUGS definition is detected
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 1 ]; then
+  pass "3. inline VALID_LOCALE_SLUGS detected"
+else
+  fail "3. inline VALID_LOCALE_SLUGS detected" "exit $EXIT_CODE (expected 1)"
+fi
+
+# Test 4: inline LOCALE_DISPLAY_NAMES definition is detected
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+const LOCALE_DISPLAY_NAMES: Record<string, string> = {
+  en: "English",
+  fr: "French",
+};
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 1 ]; then
+  pass "4. inline LOCALE_DISPLAY_NAMES detected"
+else
+  fail "4. inline LOCALE_DISPLAY_NAMES detected" "exit $EXIT_CODE (expected 1)"
+fi
+
+# Test 5: inline langToSlug function is detected
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+function langToSlug(lang: string): string {
+  return lang.toLowerCase();
+}
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 1 ]; then
+  pass "5. inline langToSlug function detected"
+else
+  fail "5. inline langToSlug function detected" "exit $EXIT_CODE (expected 1)"
+fi
+
+# Test 6: re-export from i18n-core is allowed
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/good.ts" <<'TS'
+import { LOCALE_DISPLAY_NAMES } from '@f5xc-salesdemos/i18n-core';
+export { LOCALE_DISPLAY_NAMES };
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+  pass "6. re-export from i18n-core allowed"
+else
+  fail "6. re-export from i18n-core allowed" "exit $EXIT_CODE"
+fi
+
+# Test 7: node_modules are excluded
+setup_clean_repo
+mkdir -p "$TMPDIR_BASE/repo/node_modules/some-pkg"
+cat > "$TMPDIR_BASE/repo/node_modules/some-pkg/index.ts" <<'TS'
+const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+  pass "7. node_modules excluded"
+else
+  fail "7. node_modules excluded" "exit $EXIT_CODE"
+fi
+
+# Test 8: test files are excluded
+setup_clean_repo
+cat > "$TMPDIR_BASE/repo/src/locales.test.ts" <<'TS'
+const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+  pass "8. test files excluded"
+else
+  fail "8. test files excluded" "exit $EXIT_CODE"
+fi
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed ($((PASS + FAIL)) total)"
+echo "════════════════════════════════════════════"
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/tests/test-locale-lint.sh
+++ b/tests/test-locale-lint.sh
@@ -5,8 +5,14 @@ set -euo pipefail
 PASS=0
 FAIL=0
 
-pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
-fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 — $2"; }
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: $1 — $2"
+}
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 LINT_SCRIPT="$SCRIPT_DIR/scripts/locale-lint.sh"
@@ -32,7 +38,7 @@ echo "=== Locale Lint Tests ==="
 
 # Test 1: clean repo passes
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/app.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/app.ts" <<'TS'
 import { VALID_SLUGS } from '@f5xc-salesdemos/i18n-core';
 console.log(VALID_SLUGS);
 TS
@@ -47,7 +53,7 @@ fi
 
 # Test 2: hardcoded slug array is detected
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
 const LOCALES = ['en', 'fr', 'pt-br', 'zh-cn', 'zh-tw', 'ar'];
 TS
 OUTPUT=""
@@ -61,7 +67,7 @@ fi
 
 # Test 3: inline VALID_LOCALE_SLUGS definition is detected
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
 const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
 TS
 OUTPUT=""
@@ -75,7 +81,7 @@ fi
 
 # Test 4: inline LOCALE_DISPLAY_NAMES definition is detected
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
 const LOCALE_DISPLAY_NAMES: Record<string, string> = {
   en: "English",
   fr: "French",
@@ -92,7 +98,7 @@ fi
 
 # Test 5: inline langToSlug function is detected
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
 function langToSlug(lang: string): string {
   return lang.toLowerCase();
 }
@@ -108,7 +114,7 @@ fi
 
 # Test 6: re-export from i18n-core is allowed
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/good.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/good.ts" <<'TS'
 import { LOCALE_DISPLAY_NAMES } from '@f5xc-salesdemos/i18n-core';
 export { LOCALE_DISPLAY_NAMES };
 TS
@@ -124,7 +130,7 @@ fi
 # Test 7: node_modules are excluded
 setup_clean_repo
 mkdir -p "$TMPDIR_BASE/repo/node_modules/some-pkg"
-cat > "$TMPDIR_BASE/repo/node_modules/some-pkg/index.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/node_modules/some-pkg/index.ts" <<'TS'
 const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
 TS
 OUTPUT=""
@@ -138,7 +144,7 @@ fi
 
 # Test 8: test files are excluded
 setup_clean_repo
-cat > "$TMPDIR_BASE/repo/src/locales.test.ts" <<'TS'
+cat >"$TMPDIR_BASE/repo/src/locales.test.ts" <<'TS'
 const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
 TS
 OUTPUT=""


### PR DESCRIPTION
## Summary
- Add `scripts/locale-lint.sh` — detects hardcoded locale lists that should import from `@f5xc-salesdemos/i18n-core`
- Add `tests/test-locale-lint.sh` — 8 tests covering detection and exclusion cases
- Detects: inline slug arrays, VALID_LOCALE_SLUGS/LOCALE_DISPLAY_NAMES/LANG_TO_SLUG definitions, langToSlug function definitions
- Excludes: node_modules, dist, test files, valid i18n-core imports

Closes #508

## Test plan
- [x] 8 unit tests pass locally
- [x] Verified on docs-theme, xcsh, starlight-mega-menu — all pass (no false positives)
- [ ] Shell Unit Tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)