### PR TITLE
feat: distribute locale-lint.sh as managed file

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -12,7 +12,8 @@
       ".github/workflows/super-linter.yml"
     ],
     "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"]
+    "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
+    "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",
@@ -51,6 +52,8 @@
     ".isort.cfg",
     ".python-lint",
     ".mypy.ini",
+    "scripts/locale-lint.sh",
+    "trivy.yaml",
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -114,6 +114,8 @@
       { "src": ".python-lint", "dest": ".python-lint" },
       { "src": ".mypy.ini", "dest": ".mypy.ini" },
 
+      { "src": "scripts/locale-lint.sh", "dest": "scripts/locale-lint.sh" },
+
       { "src": ".claude/governance.json", "dest": ".claude/governance.json" },
       { "src": ".claude/settings.json", "dest": ".claude/settings.json" },
       { "src": ".claude/hooks/protect-managed-files.sh", "dest": ".claude/hooks/protect-managed-files.sh" }


### PR DESCRIPTION
## Summary
- Add `scripts/locale-lint.sh` to `managed_files` in repo-settings.json and `protected_files` in governance.json
- Fix pre-existing manifest inconsistencies:
  - Add `trivy.yaml` to governance.json (was in repo-settings but missing from governance)
  - Add `vscode-f5xc-tools` to governance.json skip_files (was in repo-settings but missing from governance)

Closes #510

## Test plan
- [x] Tests 3.1 and 3.5 now pass locally (manifest consistency)
- [ ] Shell Unit Tests pass in CI
- [ ] After merge, governance sync distributes locale-lint.sh to all downstream repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)