### PR TITLE
fix: add i18n-core to skip_files for Python linting configs

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -13,7 +13,8 @@
     ],
     "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-    "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+    "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -73,7 +73,8 @@
       ],
       "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
-      "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+      "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+      "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
     },
     "files": [
       { "src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml" },


### PR DESCRIPTION
## Summary
Add `i18n-core` to `skip_files` in both `governance.json` and `repo-settings.json` for Python-related configs (`ruff.toml`, `.ruff.toml`, `.python-lint`, `.mypy.ini`, `.isort.cfg`).

Closes #513

## Why
i18n-core is TypeScript-only. Super-linter v8.6.0 crashes with `FATAL JUPYTER_NBQA_RUFF_LINTER_RULES` when it finds `ruff.toml` in a repo with no Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)