### PR TITLE
feat: add multilingual language switcher to README template

### DIFF
--- a/README.md.tpl
+++ b/README.md.tpl
@@ -1,3 +1,5 @@
+🌐 English | [日本語](https://f5xc-salesdemos.github.io/__REPO_NAME__/ja/) | [한국어](https://f5xc-salesdemos.github.io/__REPO_NAME__/ko/) | [简体中文](https://f5xc-salesdemos.github.io/__REPO_NAME__/zh-cn/) | [繁體中文](https://f5xc-salesdemos.github.io/__REPO_NAME__/zh-tw/) | [Español](https://f5xc-salesdemos.github.io/__REPO_NAME__/es/) | [Português](https://f5xc-salesdemos.github.io/__REPO_NAME__/pt-br/) | [Français](https://f5xc-salesdemos.github.io/__REPO_NAME__/fr/) | [Deutsch](https://f5xc-salesdemos.github.io/__REPO_NAME__/de/) | [Italiano](https://f5xc-salesdemos.github.io/__REPO_NAME__/it/) | [العربية](https://f5xc-salesdemos.github.io/__REPO_NAME__/ar/) | [हिन्दी](https://f5xc-salesdemos.github.io/__REPO_NAME__/hi/) | [ไทย](https://f5xc-salesdemos.github.io/__REPO_NAME__/th/)
+
 # __TITLE__
 
 [![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/__REPO_NAME__/actions/workflows/github-pages-deploy.yml)


### PR DESCRIPTION
## Summary
- Adds a 12-language switcher bar to the top of `README.md.tpl`
- Uses the existing `__REPO_NAME__` placeholder so links resolve correctly per-repo
- Restores multilingual navigation that was lost when governance sync overwrote hand-crafted READMEs (e.g. vscode-f5xc-tools)

Closes #515

## Test plan
- [ ] Verify the template renders correctly with `__REPO_NAME__` replaced
- [ ] Confirm downstream repos pick up the language switcher on next governance sync
- [ ] Spot-check that language links resolve to the correct docs-site pages