### PR TITLE
fix: break language switcher into multiple lines for MD013 compliance

### DIFF
--- a/README.md.tpl
+++ b/README.md.tpl
@@ -1,4 +1,16 @@
-🌐 English | [日本語](https://f5xc-salesdemos.github.io/__REPO_NAME__/ja/) | [한국어](https://f5xc-salesdemos.github.io/__REPO_NAME__/ko/) | [简体中文](https://f5xc-salesdemos.github.io/__REPO_NAME__/zh-cn/) | [繁體中文](https://f5xc-salesdemos.github.io/__REPO_NAME__/zh-tw/) | [Español](https://f5xc-salesdemos.github.io/__REPO_NAME__/es/) | [Português](https://f5xc-salesdemos.github.io/__REPO_NAME__/pt-br/) | [Français](https://f5xc-salesdemos.github.io/__REPO_NAME__/fr/) | [Deutsch](https://f5xc-salesdemos.github.io/__REPO_NAME__/de/) | [Italiano](https://f5xc-salesdemos.github.io/__REPO_NAME__/it/) | [العربية](https://f5xc-salesdemos.github.io/__REPO_NAME__/ar/) | [हिन्दी](https://f5xc-salesdemos.github.io/__REPO_NAME__/hi/) | [ไทย](https://f5xc-salesdemos.github.io/__REPO_NAME__/th/)
+🌐 English |
+[日本語](https://f5xc-salesdemos.github.io/__REPO_NAME__/ja/) |
+[한국어](https://f5xc-salesdemos.github.io/__REPO_NAME__/ko/) |
+[简体中文](https://f5xc-salesdemos.github.io/__REPO_NAME__/zh-cn/) |
+[繁體中文](https://f5xc-salesdemos.github.io/__REPO_NAME__/zh-tw/) |
+[Español](https://f5xc-salesdemos.github.io/__REPO_NAME__/es/) |
+[Português](https://f5xc-salesdemos.github.io/__REPO_NAME__/pt-br/) |
+[Français](https://f5xc-salesdemos.github.io/__REPO_NAME__/fr/) |
+[Deutsch](https://f5xc-salesdemos.github.io/__REPO_NAME__/de/) |
+[Italiano](https://f5xc-salesdemos.github.io/__REPO_NAME__/it/) |
+[العربية](https://f5xc-salesdemos.github.io/__REPO_NAME__/ar/) |
+[हिन्दी](https://f5xc-salesdemos.github.io/__REPO_NAME__/hi/) |
+[ไทย](https://f5xc-salesdemos.github.io/__REPO_NAME__/th/)
 
 # __TITLE__
 


### PR DESCRIPTION
## Summary
- Splits the language switcher bar in `README.md.tpl` across multiple lines
- Each line is well under the 400-char MD013 limit
- Markdown renders consecutive lines as a single paragraph — visual output unchanged

Resolves #517

Fixes downstream CI failure on vscode-f5xc-tools PR #412 where super-linter flagged the 832-char language bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)