### PR TITLE
feat: onboard console repository into governance ecosystem

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -151,5 +151,11 @@
     "description": "VS Code extension for managing F5 Distributed Cloud resources with IntelliSense and xcsh chat",
     "badges": [{ "name": "CI", "workflow": "ci.yml" }, { "name": "Release", "workflow": "release.yml" }],
     "readme_content": "## Features\n\n- **Resource Management** — Browse, create, edit, and delete F5 Distributed Cloud resources directly from VS Code\n- **Cloud Status** — Real-time global infrastructure health dashboard\n- **AI Chat Assistant** — `@xcsh` chat participant for natural language platform operations\n- **IntelliSense** — JSON schema completions for all F5 XC resource types\n- **Multi-Cloud Integrations** — Works with AWS, Azure, GCP, GitHub, GitLab, Terraform, and Salesforce\n\n## Getting Started\n\n1. Install the extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=RobinMordasiewicz.xcsh)\n2. Install xcsh: `brew install f5xc-salesdemos/tap/xcsh`\n3. Open the Command Palette (`Cmd+Shift+P`) and run **xcsh: Platform Readiness** to check your setup\n4. Add an F5 XC context via **xcsh: Add Context**\n\n## Supported Integrations\n\n| Integration | Install | Authenticate |\n|---|---|---|\n| xcsh | `brew install f5xc-salesdemos/tap/xcsh` | Included with install |\n| AWS CLI | `brew install awscli` | `aws sso login` |\n| Azure CLI | `brew install azure-cli` | `az login` |\n| Google Cloud | `brew install google-cloud-sdk` | `gcloud auth login` |\n| GitHub CLI | `brew install gh` | `gh auth login` |\n| GitLab CLI | `brew install glab` | `glab auth login` |\n| Terraform | `brew install hashicorp/tap/terraform` | N/A |\n| Salesforce CLI | `brew install sf` | `sf org login web` |\n\nRun **xcsh: Platform Readiness** in VS Code to see which integrations are installed and authenticated."
+  },
+  {
+    "label": "Console Catalog",
+    "url": "https://f5xc-salesdemos.github.io/console/llms-full.txt",
+    "description": "Schema-driven inventory of the F5 XC administration console UI — routes, resources, workflows, and browser automation manifests",
+    "badges": [{ "name": "Validate Catalog", "workflow": "validate-catalog.yml" }]
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -31,5 +31,6 @@
   "f5xc-salesdemos/starlight-llms-txt",
   "f5xc-salesdemos/starlight-mega-menu",
   "f5xc-salesdemos/apt-repo",
-  "f5xc-salesdemos/i18n-core"
+  "f5xc-salesdemos/i18n-core",
+  "f5xc-salesdemos/console"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -51,6 +51,9 @@
     },
     "vscode-f5xc-tools": {
       "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]
+    },
+    "console": {
+      "additional_contexts": ["validate / Validate Catalog Schemas"]
     }
   },
   "topics": [],
@@ -74,7 +77,8 @@
       "api-specs": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
       "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-      "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+      "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+      "console": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
     },
     "files": [
       { "src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml" },


### PR DESCRIPTION
## Summary
- Register `f5xc-salesdemos/console` as the 34th downstream repo in governance
- Add Console Catalog entry to `docs-sites.json` with validate badge
- Add `validate-catalog` as required CI context for branch protection
- Skip Python linter configs (console is Node.js only)

## Files Changed
- `.github/config/downstream-repos.json` — add console
- `.github/config/docs-sites.json` — add Console Catalog entry
- `.github/config/repo-settings.json` — add overrides and skip_files

## Test plan
- [ ] Verify `downstream-repos.json` is valid JSON with 34 entries
- [ ] Verify `docs-sites.json` is valid JSON with console entry
- [ ] Verify `repo-settings.json` has console overrides and skip_files
- [ ] After merge: trigger enforcement on console repo

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)