### PR TITLE
feat: add .remember/ to distributed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ projects/
 .claude/todos/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.remember/
 .playwright-mcp/
 .serena/
 .auto-claude/


### PR DESCRIPTION
## Summary
- Adds `.remember/` to the "Tool-specific" section of the distributed `.gitignore`
- Claude Code's `remember` plugin creates this directory for session state persistence — it should never be committed
- Downstream repos will pick this up on the next governance sync

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)