### PR TITLE
chore: exclude generated docs/snapshots from biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,7 @@
   },
   "overrides": [
     {
-      "includes": ["dist/**", "build/**", "release/**", "vendor/**"],
+      "includes": ["dist/**", "build/**", "release/**", "vendor/**", "docs/snapshots/**"],
       "formatter": {
         "enabled": false
       },


### PR DESCRIPTION
Adds `docs/snapshots/**` to the managed `biome.json` formatter+linter disable override so generated UI snapshot data is not linted/formatted.

Strictly more permissive — only disables checks on generated snapshot data, so no downstream repo can newly fail. Unblocks a green super-linter in repos like console that keep captured snapshots under docs/snapshots/.

Closes #525