### PR TITLE
feat: translation-freshness CI gate + pre-commit generation hook

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -85,6 +85,7 @@
       { "src": "workflows/enforce-repo-settings.yml", "dest": ".github/workflows/enforce-repo-settings.yml" },
       { "src": "workflows/require-linked-issue.yml", "dest": ".github/workflows/require-linked-issue.yml" },
       { "src": "workflows/super-linter.yml", "dest": ".github/workflows/super-linter.yml" },
+      { "src": "workflows/translation-audit.yml", "dest": ".github/workflows/translation-audit.yml" },
       { "src": ".github/PULL_REQUEST_TEMPLATE.md", "dest": ".github/PULL_REQUEST_TEMPLATE.md" },
       { "src": ".github/ISSUE_TEMPLATE/bug_report.md", "dest": ".github/ISSUE_TEMPLATE/bug_report.md" },
       { "src": ".github/ISSUE_TEMPLATE/feature_request.md", "dest": ".github/ISSUE_TEMPLATE/feature_request.md" },

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -1,0 +1,74 @@
+---
+# Reusable workflow: translation-freshness audit (read-only).
+#
+# Fails a PR when any English doc (docs/en/**/*.md[x]) has a missing or
+# stale translation under docs/<locale>/. "Stale" means the translated
+# file's i18n.sourceHash no longer matches the SHA-256 (first 12 hex) of
+# the current English source.
+#
+# This check performs NO translation (no API calls). Generation happens in
+# pre-commit via `docs-translate --staged`. Repos without docs/en/ pass
+# trivially. Called by the downstream stub .github/workflows/translation-audit.yml
+name: Translation Audit
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Translation freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Audit translation freshness
+        run: |
+          node --input-type=module <<'NODE'
+          import { createHash } from 'node:crypto';
+          import fs from 'node:fs';
+          import path from 'node:path';
+
+          const LOCALES = ['fr','es','de','pt-br','ja','ko','zh-cn','zh-tw','ar','it','hi','th'];
+          const enDir = path.join('docs', 'en');
+          if (!fs.existsSync(enDir)) {
+            console.log('No docs/en/ directory — translation audit not applicable.');
+            process.exit(0);
+          }
+          const hash = (c) => createHash('sha256').update(c).digest('hex').slice(0, 12);
+          const collect = (dir, out = []) => {
+            for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+              const f = path.join(dir, e.name);
+              if (e.isDirectory()) collect(f, out);
+              else if (/\.mdx?$/.test(e.name)) out.push(f);
+            }
+            return out;
+          };
+          const sourceHashOf = (raw) => {
+            const m = raw.match(/^\s*sourceHash:\s*["']?([0-9a-f]{12})["']?\s*$/m);
+            return m ? m[1] : null;
+          };
+
+          const issues = [];
+          for (const enFile of collect(enDir)) {
+            const rel = path.relative(enDir, enFile);
+            const enHash = hash(fs.readFileSync(enFile, 'utf-8'));
+            for (const loc of LOCALES) {
+              const lf = path.join('docs', loc, rel);
+              if (!fs.existsSync(lf)) { issues.push(`MISSING  ${loc}/${rel}`); continue; }
+              const sh = sourceHashOf(fs.readFileSync(lf, 'utf-8'));
+              if (sh && sh !== enHash) issues.push(`STALE    ${loc}/${rel} (stored=${sh} current=${enHash})`);
+            }
+          }
+
+          if (issues.length) {
+            console.error(`\n✖ ${issues.length} translation issue(s) — regenerate with \`docs-translate --staged\` (or --force) and commit:\n`);
+            for (const i of issues) console.error('  ' + i);
+            console.error('\nGeneration runs in pre-commit; this gate only verifies freshness.');
+            process.exit(1);
+          }
+          console.log('✓ All translations are present and fresh.');
+          NODE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,6 +184,26 @@ repos:
         language: system
         pass_filenames: false
 
+  # ===========================================================================
+  # Translation generation — regenerate locale docs when English changes.
+  # Runs docs-translate --staged (docs-theme) for staged docs/en/*.mdx, which
+  # needs ANTHROPIC_API_KEY and the docs-theme toolchain. No-ops gracefully
+  # when either is unavailable; the required CI translation-audit verifies
+  # freshness regardless. Generation is intentionally local, never in CI.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: docs-translate
+        name: "i18n: regenerate translations for staged English docs"
+        entry: >-
+          bash -c
+          'if command -v docs-translate >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ];
+          then docs-translate --staged;
+          else echo "[i18n] docs-translate/ANTHROPIC_API_KEY unavailable — skipping; CI translation-audit will verify freshness."; fi'
+        language: system
+        files: ^docs/en/.*\.mdx?$
+        pass_filenames: false
+
 ci:
   autofix_prs: true
   autoupdate_schedule: weekly
@@ -204,3 +224,4 @@ ci:
     - zizmor
     - checkov
     - gitleaks
+    - docs-translate

--- a/workflows/translation-audit.yml
+++ b/workflows/translation-audit.yml
@@ -14,5 +14,5 @@ permissions:
 
 jobs:
   audit:
+    # Read-only freshness audit — no secrets required.
     uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main
-    secrets: inherit

--- a/workflows/translation-audit.yml
+++ b/workflows/translation-audit.yml
@@ -1,0 +1,18 @@
+---
+# Managed by docs-control. Verifies that translations stay fresh when
+# English docs change. Generation happens in pre-commit (docs-translate
+# --staged); this gate only audits sourceHash freshness (no API calls).
+name: Translation Audit
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main
+    secrets: inherit


### PR DESCRIPTION
Implements the translation-freshness enforcement.

**CI gate (read-only, no API calls):** `translation-audit` reusable workflow fails a PR when any `docs/en/*.mdx` has a missing/stale translation (i18n.sourceHash mismatch). Delivered to downstream repos via managed files; repos without `docs/en` pass trivially.

**Pre-commit generation:** guarded `docs-translate --staged` hook regenerates locale docs when staged English changes (needs docs-theme + ANTHROPIC_API_KEY; no-ops otherwise). Generation stays local, never in CI.

Fleet verified 0 stale/0 missing (excluding terraform-provider-f5xc, whose docs are generated and which is excluded from the gate). After merge + sync, the check will be added as a required status check on docs repos.

Closes #527