### PR TITLE
fix: open manifest PR with PAT so its CI runs (unblock auto-merge)

### DIFF
--- a/.github/workflows/build-managed-files-manifest.yml
+++ b/.github/workflows/build-managed-files-manifest.yml
@@ -62,6 +62,10 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          # Use a PAT so the manifest PR (and its branch push) are attributed
+          # to a real user — PRs opened with the default GITHUB_TOKEN do not
+          # trigger CI, leaving required checks unreported and auto-merge stuck.
+          token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
       - name: Build manifest
         env:
@@ -128,7 +132,8 @@ jobs:
         # from biome, so the PR's Lint Code Base passes. Falls back to today's
         # per-file sync behavior if anything here is skipped.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (not GITHUB_TOKEN) so the PR triggers CI and auto-merge can proceed.
+          GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           MANIFEST_PATH: .github/config/managed-files-manifest.json
           BRANCH: sync/manifest
         run: |


### PR DESCRIPTION
Follow-up to #532. The manifest PR was opened with the default GITHUB_TOKEN, so GitHub did not run its checks (recursion prevention) and auto-merge stayed BLOCKED (PR #533 stuck with no checks).

Check out and run the PR step with `REPO_SETTINGS_TOKEN` (PAT, already used by dispatch-downstream) so the manifest PR's required checks run and auto-merge completes — making manifest propagation fully autonomous.

Closes #534