### PR TITLE
fix: exclude SVG assets from biome (unblocks managed-file sync)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,7 +32,8 @@
         "release/**",
         "vendor/**",
         "docs/snapshots/**",
-        ".github/config/managed-files-manifest.json"
+        ".github/config/managed-files-manifest.json",
+        "**/*.svg"
       ],
       "formatter": {
         "enabled": false


### PR DESCRIPTION
biome `latest` (2.5.0) lints standalone `.svg` files and fails `a11y/noSvgWithoutTitle` on `docs/images/hero.svg` — a false positive (the rule targets inline JSX `<svg>`, not asset files). This blocked the `governance/sync-managed-files` PRs (Lint Code Base) in every repo shipping hero.svg (administration, dns, bot-standard, ...), preventing onboarding + stub propagation.

Exclude `**/*.svg` from biome. Verified: `biome ci .` passes on administration with this change. The now-autonomous pipeline propagates the updated biome.json, after which those repos' sync PRs go green and auto-merge.

Closes #537