### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-17T23:42:21Z",
-  "source_commit": "24900f057b3aad069bac9c3d28a538e147575fa4",
+  "generated_at": "2026-06-18T01:31:59Z",
+  "source_commit": "f12695dbc1e210b77ef5dffd6e8c435bca5fd576",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -119,8 +119,8 @@
     "biome.json": {
       "src": "biome.json",
       "dest": "biome.json",
-      "sha": "6f4d7ab6e7bc9ed8d13a5aa59f3730649f911efa",
-      "size": 1120
+      "sha": "bf7266aa579c90af61cd2c31dd324daec76a5244",
+      "size": 1140
     },
     ".jscpd.json": {
       "src": ".jscpd.json",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.