### PR TITLE
fix: remove --field source_sha from dispatch to unblock stale repos

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -35,19 +35,17 @@ jobs:
       - name: Dispatch enforce-repo-settings to all downstream repos
         env:
           GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
-          SOURCE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
         run: |
           set -euo pipefail
 
           dispatch_one() {
             local repo="$1"
-            local sha="$2"
             local attempt=1
             local max=3
             local delay=2
             while true; do
               if gh workflow run enforce-repo-settings.yml \
-                  --repo "$repo" --field source_sha="$sha" >/dev/null 2>&1; then
+                  --repo "$repo" >/dev/null 2>&1; then
                 printf '[OK]   %s\n' "$repo"
                 return 0
               fi
@@ -79,7 +77,7 @@ jobs:
             echo "--- Batch ${batch} (repos $((i+1))-$((i+${#batch_repos[@]})) of ${TOTAL}) ---"
 
             for repo in "${batch_repos[@]}"; do
-              dispatch_one "$repo" "$SOURCE_SHA" >> "$LOG" 2>&1 &
+              dispatch_one "$repo" >> "$LOG" 2>&1 &
             done
             wait
 


### PR DESCRIPTION
## Summary

- Removes `--field source_sha` from `gh workflow run` in dispatch-downstream
- Fixes dispatch failure for downstream repos that haven't synced the updated `enforce-repo-settings.yml` template yet (e.g., `starlight-mega-menu`)

Closes #542

## Test plan

- [ ] After merge, re-run dispatch and verify all 34 repos succeed (including starlight-mega-menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)