### PR TITLE
fix: preserve trailing newline when syncing managed files

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -216,6 +216,15 @@ jobs:
                 continue
               fi
 
+              # Restore exactly one trailing newline. The content above is
+              # captured via bash $(...) / $(cat ...), which strips trailing
+              # newlines. biome, yamllint and editorconfig-checker all require
+              # a final newline, so the stripped blob fails Lint Code Base in
+              # every downstream sync PR; the missing newline also makes the
+              # committed blob's SHA never match the source, causing perpetual
+              # drift. Normalizing to a single trailing newline fixes both.
+              content="${content%$'\n'}"$'\n'
+
               tree_items=$(echo "$tree_items" | jq \
                 --arg path "$dest_file" \
                 --arg content "$content" \


### PR DESCRIPTION
## Root cause
`sync-managed-files` captures file content via bash `$(...)`/`$(cat ...)`, which **strips trailing newlines**. biome, yamllint, and editorconfig-checker all **require** a final newline, so every downstream `governance/sync-managed-files` PR fails **Lint Code Base** on the synced JSON/YAML configs (verified: administration #497 fails biome on `biome.json`/`.claude/*.json`, which differ from source only by "No newline at end of file"). The missing newline also makes the committed blob SHA never match the source → **perpetual drift / PR churn**.

## Fix
Normalize each file to exactly one trailing newline before committing it to the git tree. Can only add a missing newline (never corrupts content). Fixes the lint failures **and** the drift churn systemically.

Closes #544