### PR TITLE
feat: require translation-audit check (+ fix console catalog check name)

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -30,7 +30,7 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues", "lint / Lint Code Base"],
+        "contexts": ["check / Check linked issues", "lint / Lint Code Base", "audit / Translation freshness"],
         "self_contexts": ["Check linked issues", "Lint Code Base"]
       },
       "required_pull_request_reviews": null,
@@ -53,7 +53,10 @@
       "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]
     },
     "console": {
-      "additional_contexts": ["validate / Validate Catalog Schemas"]
+      "additional_contexts": ["Validate Catalog Schemas"]
+    },
+    "terraform-provider-f5xc": {
+      "excluded_required_contexts": ["audit / Translation freshness"]
     }
   },
   "topics": [],


### PR DESCRIPTION
All 33 docs repos (every downstream repo except terraform-provider-f5xc) now have the translation-audit workflow, so make **`audit / Translation freshness`** a required status check fleet-wide.

- Added to the global required contexts.
- Excluded for `terraform-provider-f5xc` (generated, intentionally-untranslated docs/en; lacks the stub).
- Also fixes console: its required context was `validate / Validate Catalog Schemas` (reusable-workflow naming) but the regular workflow reports `Validate Catalog Schemas` — the mismatch left every console PR unmergeable.

Applied fleet-wide by enforce-repo-settings on merge.

Closes #546