### PR TITLE
feat: auto-enable auto-merge on non-draft PRs org-wide

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -104,6 +104,7 @@
       { "src": ".yamllint.yaml", "dest": ".yamllint.yaml" },
       { "src": ".markdownlint.json", "dest": ".markdownlint.json" },
       { "src": "workflows/dependabot-auto-merge.yml", "dest": ".github/workflows/dependabot-auto-merge.yml" },
+      { "src": "workflows/auto-merge.yml", "dest": ".github/workflows/auto-merge.yml" },
 
       { "src": "biome.json", "dest": "biome.json" },
       { "src": ".jscpd.json", "dest": ".jscpd.json" },

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,27 @@
+---
+name: Auto-Merge
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Enable auto-merge on any non-draft PR. Branch protection + required status
+    # checks (e.g. "Check linked issues", lint, tests) still gate the actual
+    # merge — this only means "merge when green". Work-in-progress uses draft PRs.
+    # Dependabot PRs are handled by dependabot-auto-merge.yml.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -1,0 +1,19 @@
+---
+name: Auto-Merge
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  call:
+    # Enable auto-merge on any non-draft PR (merge still gated by branch
+    # protection + required checks). Dependabot PRs use dependabot-auto-merge.yml.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]'
+    uses: f5xc-salesdemos/docs-control/.github/workflows/auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
Closes #548

## Problem

Human conventional-commit PRs require a manual `gh pr merge --auto --squash` to flow through the pipeline — only Dependabot and internal release/regen PRs self-enable auto-merge. (~10 manual merges in a recent multi-repo effort.)

## Change

A managed **Auto-Merge** workflow, mirroring the Dependabot two-file pattern:
- `.github/workflows/auto-merge.yml` — reusable impl (`workflow_call`) that also self-triggers on `pull_request_target` for docs-control's own PRs.
- `workflows/auto-merge.yml` — thin caller, registered in `repo-settings.json` `managed_files` so `sync-managed-files` distributes it to every governed repo.

On any **non-draft** PR it runs `gh pr merge --auto --squash`. Branch protection + required checks (incl. `Check linked issues`) still gate the actual merge — this only means "merge when green". WIP uses draft PRs; Dependabot PRs stay on `dependabot-auto-merge.yml`.

## Safety

- `pull_request_target` runs in the base-repo context and **does not check out or run PR code** (only the merge API), and repos are internal (no forks). zizmor: no findings.
- `PR_URL` passed via `env:` (GitHub-generated `html_url`), not interpolated — no injection.

## Notes

- The `managed-files-manifest.json` regenerates automatically post-merge (its workflow runs on `push: main`).
- This PR must be **merged manually** (bootstrap) — the auto-merge workflow isn't on `main` yet. After it lands, all subsequent non-draft PRs (including the downstream sync PRs) auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)