### PR TITLE
feat(governance): onboard xcsh-chrome-extension

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -157,5 +157,10 @@
     "url": "https://f5xc-salesdemos.github.io/console/llms-full.txt",
     "description": "Schema-driven inventory of the F5 XC administration console UI — routes, resources, workflows, and browser automation manifests",
     "badges": [{ "name": "Validate Catalog", "workflow": "validate-catalog.yml" }]
+  },
+  {
+    "label": "xcsh Chrome Extension",
+    "url": "https://f5xc-salesdemos.github.io/xcsh-chrome-extension/llms-full.txt",
+    "description": "Chrome extension companion for the xcsh AI-powered F5 Distributed Cloud CLI"
   }
 ]

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -32,5 +32,6 @@
   "f5xc-salesdemos/starlight-mega-menu",
   "f5xc-salesdemos/apt-repo",
   "f5xc-salesdemos/i18n-core",
-  "f5xc-salesdemos/console"
+  "f5xc-salesdemos/console",
+  "f5xc-salesdemos/xcsh-chrome-extension"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -57,6 +57,9 @@
     },
     "terraform-provider-f5xc": {
       "excluded_required_contexts": ["audit / Translation freshness"]
+    },
+    "xcsh-chrome-extension": {
+      "excluded_required_contexts": ["lint / Lint Code Base"]
     }
   },
   "topics": [],
@@ -81,7 +84,8 @@
       "api-specs-enriched": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini"],
       "vscode-f5xc-tools": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
       "i18n-core": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-      "console": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+      "console": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+      "xcsh-chrome-extension": ["ruff.toml", ".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
     },
     "files": [
       { "src": "workflows/github-pages-deploy.yml", "dest": ".github/workflows/github-pages-deploy.yml" },

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules/
 dist/
 *.tgz
 
+# Chrome extension signing key (never commit)
+key.pem
+
 # Environment
 .env
 .env.*


### PR DESCRIPTION
Registers `xcsh-chrome-extension` as a managed downstream repo. Closes #551.

## Changes
- `downstream-repos.json`: enforcement dispatch target
- `docs-sites.json`: README generation metadata
- `repo-settings.json`: skip Python linter configs (Bun/TS repo) + exclude super-linter from required checks
- `.gitignore`: add `key.pem` (CWS signing key)

## Verification
- `test-linter-configs.sh`: 99 pass
- `test-dispatch-matrix.sh`: clean
- All 3 JSON config files validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)