### PR TITLE
fix: auto-merge uses PAT so merge-pushes trigger downstream workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,4 +24,10 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT (REPO_SYNC_TOKEN) so the eventual merge-push is attributed
+          # to a real user — not github-actions[bot]. This makes the push trigger
+          # downstream workflows (release.yml, github-pages-deploy.yml, CI).
+          # GITHUB_TOKEN merges are blocked by GitHub's recursion prevention.
+          # Fallback to GITHUB_TOKEN for repos without REPO_SYNC_TOKEN (merge
+          # still works, downstream triggers just don't fire).
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Root-cause fix: GITHUB_TOKEN merges don't trigger downstream workflows (recursion prevention). Use REPO_SYNC_TOKEN (PAT) with GITHUB_TOKEN fallback so merge-pushes fire release + docs-deploy triggers. Backward-compatible: repos without REPO_SYNC_TOKEN fall back to GITHUB_TOKEN (no behavior change). Closes #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)