### PR TITLE
fix: add --pull always to docs-builder docker run

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -110,7 +110,7 @@ jobs:
           mkdir -p ${{ runner.temp }}/docs-output
           chmod 777 ${{ runner.temp }}/docs-output
 
-          docker run --rm \
+          docker run --rm --pull always \
             --name docs-builder \
             -v ${{ github.workspace }}/${{ inputs.content-path || 'docs' }}:/content/docs:ro \
             ${{ steps.assets.outputs.mounts }} \


### PR DESCRIPTION
Ensures freshest image is always used. Closes #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)