### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-20T17:57:49Z",
-  "source_commit": "82681d288616d109b01082cc8c9c1ea300e85984",
+  "generated_at": "2026-06-22T17:18:40Z",
+  "source_commit": "f16764b7a274845abf8559dde96ce3074830fb3c",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -83,8 +83,8 @@
     ".gitignore": {
       "src": ".gitignore",
       "dest": ".gitignore",
-      "sha": "ed1de5959ce781a75d1d594373cdbaf47e4ed502",
-      "size": 2328
+      "sha": "b0f295c4b94b34ed5d135a65eff6ffb0d3210272",
+      "size": 2383
     },
     "LICENSE": {
       "src": "LICENSE",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.