### PR TITLE
ci: exclude declarative YAML from JSCPD (revert ineffective #561 filter)

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -66,16 +66,7 @@ jobs:
           # generated (parser.c from `tree-sitter generate`) or hand-written
           # to upstream tree-sitter conventions that do not match
           # clang-format's default style; excluding preserves fork fidelity.
-          # catalog/workflows/: declarative console-automation workflows are
-          # legitimately near-identical (one shared UI component → identical
-          # step sequences) and are validated by the repo's own Validate Catalog
-          # Schemas job; excluding them stops JSCPD flagging them as clones. The
-          # repo .jscpd.json declares the same intent via **/workflows/**, but
-          # that ignore is not honored when Super-Linter passes changed files
-          # explicitly (VALIDATE_ALL_CODEBASE:false). Scoped to catalog/workflows/
-          # so .github/workflows/ actionlint is unaffected; no-op for repos
-          # without that path. See issue #560.
-          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/|catalog/workflows/|tree-sitter-[^/]+/src/(parser|scanner)\\.(c|h)$|docs/(fr|es|de|ja|pt-br|ko|zh-cn|zh-tw|ar|it|hi|th)/|src/i18n/.*translations)"
+          FILTER_REGEX_EXCLUDE: "(dist/|build/|release/|vendor/|tree-sitter-[^/]+/src/(parser|scanner)\\.(c|h)$|docs/(fr|es|de|ja|pt-br|ko|zh-cn|zh-tw|ar|it|hi|th)/|src/i18n/.*translations)"
           # Disable Prettier — Biome handles formatting for
           # JS/TS/JSON/CSS/HTML/GraphQL/JSX/Vue; yamllint handles
           # YAML; markdownlint handles Markdown.

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -2,6 +2,8 @@
   "threshold": 10,
   "reporters": ["console"],
   "ignore": [
+    "**/*.yaml",
+    "**/*.yml",
     "**/.github/workflows/**",
     "**/workflows/**",
     "**/node_modules/**",


### PR DESCRIPTION
## Summary
Properly fixes JSCPD failing on declarative YAML catalogues, and reverts the ineffective `FILTER_REGEX_EXCLUDE` change from #561.

## Why #561 didn't work
JSCPD scans the **entire workspace** (ignores `VALIDATE_ALL_CODEBASE`), so `FILTER_REGEX_EXCLUDE` (a per-file filter) never affected it. Verified locally that jscpd's **path-based** ignore globs (`**/workflows/**`, `catalog/workflows/**`) are **not honored** — clones still flagged.

## Root issue
Declarative catalogues are legitimately repetitive: console's `catalog/` is **29.4% duplicated** (dominated by `catalog/resources/*.yaml` — e.g. api-credential 30, address-allocator 17), over the 10% threshold. JSCPD has been red on every console PR (bypassed by auto-merge).

## Fix (verified)
`**/*.yaml` + `**/*.yml` in `.jscpd.json` `ignore` → **0 clones, exit 0** (via `jscpd --config`, the same way super-linter invokes it). Clone detection remains on for JS/TS/Go/etc.

## Changes
- `.jscpd.json`: add `**/*.yaml` + `**/*.yml` to `ignore`.
- `.github/workflows/super-linter.yml`: revert the `catalog/workflows/` `FILTER_REGEX_EXCLUDE` addition.

Propagates to consumer repos via governance sync; unblocks console PR #35.

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)