### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-22T17:18:40Z",
-  "source_commit": "f16764b7a274845abf8559dde96ce3074830fb3c",
+  "generated_at": "2026-06-23T03:35:53Z",
+  "source_commit": "6d716cc7cfdbeb98a606edb5889f0d10ddf92fac",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -131,8 +131,8 @@
     ".jscpd.json": {
       "src": ".jscpd.json",
       "dest": ".jscpd.json",
-      "sha": "118883cbed7f6cd88c86144a00114e593ec110f3",
-      "size": 414
+      "sha": "974ed891b1e7a23e601bc7cdfacb47b007a95d5d",
+      "size": 447
     },
     ".textlintrc": {
       "src": ".textlintrc",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.