### PR TITLE
ci: set JSCPD_CONFIG_FILE so Super-Linter uses the repo .jscpd.json

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -102,6 +102,12 @@ jobs:
           # Explicit config file name — super-linter v8 defaults to
           # .yamllint.yml but our managed config uses .yamllint.yaml
           YAML_YAMLLINT_CONFIG_FILE: .yamllint.yaml
+          # Without an explicit config file, Super-Linter's JSCPD uses its
+          # bundled default and IGNORES the repo .jscpd.json (so the ignore /
+          # threshold never apply). Point it at the managed repo config.
+          # Filename only — a full path triggers the doubled-slash
+          # "rules file doesn't exist" bug (super-linter #6734).
+          JSCPD_CONFIG_FILE: .jscpd.json
           # Point Trivy at our governance config (skip-dirs for
           # .mypy_cache, .ruff_cache, .pytest_cache so the fs walker
           # doesn't hit dangling symlinks mid-run). See issue #377.


### PR DESCRIPTION
Follow-up to #563. Super-Linter's JSCPD was using its **bundled** config and ignoring the managed repo `.jscpd.json`, so the `**/*.yaml` ignore had no effect in CI. Every other linter here sets an explicit `*_CONFIG_FILE`; JSCPD didn't.

Set `JSCPD_CONFIG_FILE: .jscpd.json` (filename only — a full path triggers the doubled-slash 'rules file doesn't exist' bug, super-linter #6734). With this, JSCPD reads the repo config (`**/*.yaml` ignore) → declarative YAML catalogues stop failing clone detection.

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)