### PR TITLE
ci(jscpd): exclude test snapshot fixtures (**/snapshots/**)

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -4,6 +4,7 @@
   "ignore": [
     "**/*.yaml",
     "**/*.yml",
+    "**/snapshots/**",
     "**/.github/workflows/**",
     "**/workflows/**",
     "**/node_modules/**",


### PR DESCRIPTION
Follow-up to #566. JSCPD now reads the repo `.jscpd.json` (via `JSCPD_CONFIG_FILE`) and `**/*.yaml` is excluded, but console still hit 11.5% (>10%) from pre-existing near-identical generated fixtures under `docs/snapshots/*.{json,txt}`.

Add `**/snapshots/**` to the ignore. **Verified locally** (`jscpd --config`): duplication drops to **0.99%, exit 0**. Real-source clone detection (JS/TS/Go/…) stays on.

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)