### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-23T03:35:53Z",
-  "source_commit": "6d716cc7cfdbeb98a606edb5889f0d10ddf92fac",
+  "generated_at": "2026-06-23T04:18:20Z",
+  "source_commit": "a5670d1386a12e86f8e2ea94795cf60341b3d2ba",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -131,8 +131,8 @@
     ".jscpd.json": {
       "src": ".jscpd.json",
       "dest": ".jscpd.json",
-      "sha": "974ed891b1e7a23e601bc7cdfacb47b007a95d5d",
-      "size": 447
+      "sha": "e8304ee91d245c6aa4642c61f7220b13a83a996f",
+      "size": 470
     },
     ".textlintrc": {
       "src": ".textlintrc",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.