### PR TITLE
feat: add .xcsh/contexts/ to .gitignore template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ packages/ai/test/.temp-images/
 docs/superpowers/
 !.xcsh/
 .xcsh/plugins/
+.xcsh/contexts/
 .pi_config/
 .opencode/
 .worktree-test-baseline.txt


### PR DESCRIPTION
## Summary

- Add `.xcsh/contexts/` to the governed `.gitignore` template to prevent accidental commit of F5 XC context files containing API tokens and credentials

## Context

The per-folder F5 XC context feature (f5xc-salesdemos/xcsh#1586, f5xc-salesdemos/vscode-f5xc-tools#545) stores authentication context files in `.xcsh/contexts/`. These JSON files contain API tokens and customer credentials that must never be committed to git.

The `.xcsh/` directory is already whitelisted (`!.xcsh/`) and `.xcsh/plugins/` is excluded — this adds the matching exclusion for `.xcsh/contexts/`.

Closes #574

## Test plan

- [ ] Verify `.xcsh/contexts/` entry appears after `.xcsh/plugins/` in `.gitignore`
- [ ] Verify governance sync propagates the change to downstream repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)