### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-24T01:40:40Z",
-  "source_commit": "38a84dc4f17f5a087315fe49217ac4d91992a284",
+  "generated_at": "2026-06-24T13:21:01Z",
+  "source_commit": "6f2e99b3856cd25847209adf3a6acea86cde408a",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -83,8 +83,8 @@
     ".gitignore": {
       "src": ".gitignore",
       "dest": ".gitignore",
-      "sha": "b0f295c4b94b34ed5d135a65eff6ffb0d3210272",
-      "size": 2383
+      "sha": "8ef9f95d8726be499dc6824ac067464345fd9478",
+      "size": 2399
     },
     "LICENSE": {
       "src": "LICENSE",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.