### PR TITLE
Fix plugin name and docs label for xcsh rebrand

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,7 @@
 # Persona Activation
 
 This repository uses Sales Engineer persona skills from the
-`f5xc-sales-engineer` plugin. When the user's message matches
+`xcsh-sales-engineer` plugin. When the user's message matches
 a trigger pattern below, **invoke the corresponding skill and
 follow its instructions exactly**.
 
@@ -9,12 +9,12 @@ follow its instructions exactly**.
 
 | Trigger phrases | Skill | Action |
 | --------------- | ----- | ------ |
-| "prepare the demo", "prep the demo", "get ready for the demo", "is the demo environment ready", "is the demo ready", "the meeting will be starting soon", "check the demo", "pre-flight", "preflight check" | `f5xc-sales-engineer:demo-executor` | Invoke skill, run Prepare stage (delegates to `demo-housekeeping` subagent for Readiness Verification Matrix) |
-| "run the demo", "execute the demo", "start the demo", "API demo" | `f5xc-sales-engineer:demo-executor` | Invoke skill, run Execute stage (intro, phases, conclusion) |
-| "question and answer", "Q&A", "open it up for questions", "take questions" | `f5xc-sales-engineer:demo-executor` | Invoke skill, enter Q&A stage |
-| "tear down", "clean up", "tear down the demo", "end the meeting" | `f5xc-sales-engineer:demo-executor` | Invoke skill, confirm with operator, run Teardown stage |
-| "walk through the demo", "present the demo", "show the demo", "walkthrough" | `f5xc-sales-engineer:presenter` | Invoke skill, begin walkthrough sequence |
-| "answer questions", "question about", "explain", "what does" | `f5xc-sales-engineer:subject-matter-expert` | Invoke skill, answer as subject matter expert |
+| "prepare the demo", "prep the demo", "get ready for the demo", "is the demo environment ready", "is the demo ready", "the meeting will be starting soon", "check the demo", "pre-flight", "preflight check" | `xcsh-sales-engineer:demo-executor` | Invoke skill, run Prepare stage (delegates to `demo-housekeeping` subagent for Readiness Verification Matrix) |
+| "run the demo", "execute the demo", "start the demo", "API demo" | `xcsh-sales-engineer:demo-executor` | Invoke skill, run Execute stage (intro, phases, conclusion) |
+| "question and answer", "Q&A", "open it up for questions", "take questions" | `xcsh-sales-engineer:demo-executor` | Invoke skill, enter Q&A stage |
+| "tear down", "clean up", "tear down the demo", "end the meeting" | `xcsh-sales-engineer:demo-executor` | Invoke skill, confirm with operator, run Teardown stage |
+| "walk through the demo", "present the demo", "show the demo", "walkthrough" | `xcsh-sales-engineer:presenter` | Invoke skill, begin walkthrough sequence |
+| "answer questions", "question about", "explain", "what does" | `xcsh-sales-engineer:subject-matter-expert` | Invoke skill, answer as subject matter expert |
 
 ## Activation Rules
 
@@ -41,6 +41,6 @@ Skills read product-specific content from these repo-local files:
 ## Ambiguous Intent
 
 If the user's request relates to the demo but does not clearly
-match a single trigger above, invoke the `f5xc-sales-engineer:sales-engineer`
+match a single trigger above, invoke the `xcsh-sales-engineer:sales-engineer`
 skill. It serves as the index of all available personas and will
 help determine the correct one to activate.

--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -1,6 +1,6 @@
 [
   {
-    "label": "f5xc Docs Builder",
+    "label": "xcsh Docs Builder",
     "url": "https://f5xc-salesdemos.github.io/docs-builder/llms-full.txt",
     "description": "Containerized Astro + Starlight documentation build system",
     "badges": [{ "name": "Build Image", "workflow": "build-image.yml" }]


### PR DESCRIPTION
## Summary
CLAUDE.md plugin name and docs-sites.json label

Final pass (iteration 3) of xcsh ecosystem rebrand.

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)