### PR TITLE
chore(deps): track @f5xc-salesdemos/* npm packages daily with auto-merge

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -417,7 +417,7 @@ jobs:
               DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
 
               if [ "$HAS_NPM" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      # First-party @f5xc-salesdemos/* packages: track latest daily, all update types\n      # (auto-merged once CI is green) so internal deps never drift behind.\n      f5xc-internal:\n        patterns:\n          - \"@f5xc-salesdemos/*\"\n        update-types:\n          - \"major\"\n          - \"minor\"\n          - \"patch\"\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
               fi
 
               if [ "$HAS_PIP" = true ]; then


### PR DESCRIPTION
Closes #587

## What
Update the **managed** Dependabot npm config (generated in `sync-managed-files.yml` and synced to all downstream npm repos) so first-party `@f5xc-salesdemos/*` packages always track latest:

- npm ecosystem schedule: **weekly → daily**.
- New **`f5xc-internal`** group matching `@f5xc-salesdemos/*` for **all update types** (major/minor/patch), grouped into a single PR (ordered before `npm-minor-patch`).

The existing `dependabot-auto-merge.yml` already approves + enables auto-merge for every Dependabot PR once CI is green — so no auto-merge change is needed; internal deps will now refresh daily and merge themselves.

## Why
First-party packages (pi-utils, pi-resource-management, i18n-core) release fast; the weekly/minor-patch-only policy let them lag (e.g. pi-utils 19.45→19.48 in days). This keeps every downstream npm repo on the latest internal packages with zero manual touch.

## Validation
- Rendered the generated `dependabot.yml` from the edited block and validated it as YAML; npm `schedule.interval: daily`, groups `[f5xc-internal, npm-minor-patch]`, `f5xc-internal` = `@f5xc-salesdemos/*` × {major,minor,patch}.
- Scope: npm repos only (the group is npm-specific); pip/docker/actions blocks unchanged. Trailing-newline behavior unchanged (added by the write step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)