### PR TITLE
fix: add marketplace-claude-code to downstream repos

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -33,5 +33,6 @@
   "apt-repo",
   "i18n-core",
   "console",
-  "xcsh-chrome-extension"
+  "xcsh-chrome-extension",
+  "marketplace-claude-code"
 ]


### PR DESCRIPTION
Closes #594

Onboard to governance management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)