### PR TITLE
fix: migrate deprecated biome linter `recommended` field to `preset`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "files": {


### PR DESCRIPTION
Closes #596

## What
`biome migrate` on the shared `biome.json`:

```diff
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   }
```

## Why
The super-linter shared workflow runs biome at `version: latest`. Current biome flags `linter.rules.recommended` as **deprecated** ("will be removed in the next major version of Biome — use `preset` instead"). Today it's an info-level diagnostic across consumer repos (it shows up in e.g. `xcsh-chrome-extension`'s `biome ci .` output), but once biome's next major drops the field it becomes a hard failure for every repo using this config. This is the exact, behavior-identical replacement produced by `biome migrate` — `preset: "recommended"` enables the same recommended rule set.

No version pinning — we intentionally keep `version: latest` (pre-release development). This change propagates to consumer repos via `sync-managed-files`.

## Verification
`bunx @biomejs/biome@latest migrate --write` produces exactly this diff and reports "configuration successfully migrated"; `biome ci` no longer emits the deprecation info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)