### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-26T13:19:54Z",
-  "source_commit": "dc74dc0c8cf652a73da3208843a67535660286a4",
+  "generated_at": "2026-06-30T02:34:59Z",
+  "source_commit": "66ef3ba55f5ff6baf949989d26e7e78974e29b38",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -125,8 +125,8 @@
     "biome.json": {
       "src": "biome.json",
       "dest": "biome.json",
-      "sha": "bf7266aa579c90af61cd2c31dd324daec76a5244",
-      "size": 1140
+      "sha": "38154e50194259656ba1e33051db87ace55c98cb",
+      "size": 1144
     },
     ".jscpd.json": {
       "src": ".jscpd.json",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.