### PR TITLE
chore(governance): ignore bun.lock/starlight-mega-menu; exclude i18n dirs from codespell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ oauth-success.html
 # Lock file preferences (Bun-based repos)
 package-lock.json
 yarn.lock
+bun.lock
 
 # Monorepo build
 .turbo/
@@ -138,6 +139,9 @@ worktrees/
 .wt/
 .codex/
 playground/
+
+# Locally cloned dev repos (checked out alongside the parent, not tracked by it)
+starlight-mega-menu/
 
 # Documentation build artifacts
 docs/_data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,6 +134,11 @@ repos:
         entry: codespell
         language: system
         types: [text]
+        # codespell's own `skip` list only applies during its directory
+        # traversal; when pre-commit passes explicit file paths it is bypassed.
+        # Filter translation dirs here so their foreign-language words
+        # (e.g. German "Referenz") never reach codespell. See issue #579.
+        exclude: ^docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json


### PR DESCRIPTION
Rolls two independent governance-template fixes into a single PR (avoids repeated downstream dispatch / API rate limiting).

## Changes

### `.gitignore` — Closes #599
- Add `bun.lock` under the "Lock file preferences (Bun-based repos)" block (already ignores `package-lock.json`, `yarn.lock`).
- Add `starlight-mega-menu/` — a locally cloned dev repo checked out alongside the parent, never tracked. Fixes it at the governance layer (previously handled per-consumer, the wrong layer).

### `.pre-commit-config.yaml` — Closes #579
- Add `exclude: ^docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/` to the codespell hook. codespell's own `skip` list only applies during its directory traversal and is bypassed when pre-commit passes explicit file paths, causing false positives on foreign-language words. Filtering in pre-commit keeps translation paths from ever reaching codespell. The locale set matches the `skip` list in `.codespellrc` and `FILTER_REGEX_EXCLUDE` in `super-linter.yml`.

## Verification
- `yamllint -c .yamllint.yaml .pre-commit-config.yaml` → clean
- `pre-commit validate-config` → valid
- Regex spot-checked: matches `docs/fr/...`, `docs/de/...`, `docs/zh-cn/...`; does not match `docs/en/...` or `README.md`
- Full pre-commit run on the commit passed

Closes #599
Closes #579