### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-30T02:34:59Z",
-  "source_commit": "66ef3ba55f5ff6baf949989d26e7e78974e29b38",
+  "generated_at": "2026-07-05T21:03:16Z",
+  "source_commit": "825ba0d1e558e6f0b8451669397c4398de5bd0db",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -83,8 +83,8 @@
     ".gitignore": {
       "src": ".gitignore",
       "dest": ".gitignore",
-      "sha": "8ef9f95d8726be499dc6824ac067464345fd9478",
-      "size": 2399
+      "sha": "0e6909d0d1aff9df88606b20db262f4f813ead5c",
+      "size": 2511
     },
     "LICENSE": {
       "src": "LICENSE",
@@ -95,8 +95,8 @@
     ".pre-commit-config.yaml": {
       "src": ".pre-commit-config.yaml",
       "dest": ".pre-commit-config.yaml",
-      "sha": "18a5ceecb195c8b9f5ecee466c4be57e717f9b67",
-      "size": 8478
+      "sha": "02b977013430f4ae1fdd0d6deb73c3b228764298",
+      "size": 8846
     },
     ".yamllint.yaml": {
       "src": ".yamllint.yaml",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.