### PR TITLE
docs: de-bloat CLAUDE.md and add engineering standards to CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,24 @@
 Files in `.claude/governance.json` are managed by docs-control.
 A hook blocks direct edits — open an issue in docs-control instead.
 
-## Git Workflow
+## Workflow
 
-- The `main` branch is protected — never commit or push directly to it.
-- Create a feature branch, commit there, and open a pull request.
-- Every pull request must reference a GitHub issue (CI enforces this).
+- `main` is protected — never commit or push to it directly.
+- Work on a feature branch and open a pull request.
+- Every PR must reference a detailed GitHub issue (CI enforces this).
 
-See `CONTRIBUTING.md` for project rules.
+## Engineering Standards
+
+Apply where applicable to this repo:
+
+- **Detailed issue** — CI stays red until the PR links a detailed issue (problem, scope, acceptance criteria).
+- **Spec first** — start from an engineering-level spec, then work a task/todo list.
+- **TDD** — write the failing test first, then the code.
+- **Automate UAT** — automate acceptance testing wherever possible.
+- **Verify before done** — back every "done" claim with passing tests or reproducible output.
+- **Root-cause only** — never skip, silence, patch over, or band-aid a problem; CI rejects masked issues.
+- **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
+- **DRY** — reuse existing code, patterns, and content before adding new.
+- **Clean branches** — experiment freely, but never commit broken or unneeded (YAGNI) code.
+
+See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,3 +83,54 @@ If you are Claude Code, Copilot, or another AI coding assistant, follow these ru
 6. **Fill out the PR template checklist** completely.
 7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
 8. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.
+
+## Engineering Standards
+
+These standards apply to all contributors — human and AI — for every change, where
+applicable to this repository. Code standards apply to code changes; docs-only repos
+apply what fits.
+
+### Detailed issues
+
+- A linked issue is not enough — it must be *detailed*: problem statement, scope, and
+  acceptance criteria.
+- CI blocks any PR with no linked issue; thin or empty issues are rejected in review.
+
+### Specs and task-driven work
+
+- Start non-trivial work from an engineering-level spec: what and why, the interfaces or
+  content affected, and acceptance criteria.
+- Break the spec into an explicit task/todo list and work it item by item.
+
+### Test-driven development
+
+- For code changes, write the test first, watch it fail, then write code to make it pass.
+- Automate user-acceptance testing wherever possible instead of relying on manual checks.
+
+### Verify before claiming done
+
+- Substantiate every "it works" / "done" claim with evidence: passing tests or
+  reproducible output.
+- Do not assert completion you have not verified.
+
+### No papering over problems
+
+- When you find a pre-existing problem, fix the root cause. Never skip, ignore, silence,
+  patch over, or band-aid it.
+- CI rejects changes that mask problems (disabling checks, swallowing errors,
+  TODO-and-move-on).
+
+### Prerelease: no backward compatibility
+
+- This is prerelease code heading to production. Make clean-break changes.
+- Do not add compatibility shims or preserve deprecated interfaces — remove and replace.
+
+### DRY — reuse first
+
+- Reuse existing code, patterns, and content before adding new. Do not duplicate.
+
+### Clean branches
+
+- Troubleshoot and experiment freely on a branch.
+- Never commit broken or experimental code, or speculative work that is not needed
+  (YAGNI). Keep merged history green.


### PR DESCRIPTION
Refreshes the two governed templates distributed verbatim to all downstream repos.

> Note: the harness fix (#604) that was briefly folded in here has already merged separately via #605, so this PR is back to docs-only, rebased on the latest `main`.

## `CLAUDE.md` — leaner, standards in-context (Variant B)
- Removed the `## Git Workflow` block that duplicated `CONTRIBUTING.md`.
- Kept `## Managed Files` + a tight 3-bullet `## Workflow`.
- Added a terse one-line-per-rule `## Engineering Standards` digest so the rules stay in Claude's always-loaded context in every repo — including `xcsh`, which ships `CLAUDE.md` but opts out of `CONTRIBUTING.md`.

## `CONTRIBUTING.md` — authoritative SOP home
- Appended `## Engineering Standards` after `## AI Assistant Guidelines`: detailed issues, specs/task-driven work, TDD + UAT automation, verify-before-done, no papering over problems, pre-release/no-backward-compat (clean-break), DRY, clean branches (no broken/YAGNI commits).

## Notes
- Accuracy: `require-linked-issue.yml` verifies a linked issue *exists*; it can't judge whether it's *detailed*. The wording states "detailed" as the standard (standard + review enforced).
- Out of scope: `.claude/CLAUDE.md` (repo-local persona file, not governed/distributed).

## Verification
- `pre-commit run --files CLAUDE.md CONTRIBUTING.md` → Markdown lint, Spelling, EditorConfig all pass.

Closes #602