### PR TITLE
docs: note local pre-commit is a subset of CI's Super-Linter (textlint gap)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,5 +24,6 @@ Apply where applicable to this repo:
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
 - **Clean branches** — experiment freely, but never commit broken or unneeded (YAGNI) code.
+- **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,3 +134,13 @@ apply what fits.
 - Troubleshoot and experiment freely on a branch.
 - Never commit broken or experimental code, or speculative work that is not needed
   (YAGNI). Keep merged history green.
+
+### Local checks vs CI
+
+- The authoritative lint gate is CI's `Lint Code Base` (Super-Linter). It runs more
+  validators than the local `pre-commit` hooks — notably textlint (`NATURAL_LANGUAGE`)
+  prose and terminology, which `pre-commit` does not run.
+- Passing `pre-commit` locally is necessary but not sufficient. Terminology is enforced
+  (for example `prerelease`, not `pre-release`). Before pushing Markdown or prose,
+  reproduce the full gate — run the Super-Linter image, or textlint with the repo's
+  `.textlintrc` — so CI-only rules do not surprise you.


### PR DESCRIPTION
Bakes a recurring gotcha into the governed templates so every downstream repo (and every human/AI contributor) inherits it, instead of re-learning it each session.

## Why

Local `pre-commit` does **not** run textlint, but CI's `Lint Code Base` (Super-Linter) runs it as `NATURAL_LANGUAGE` with a terminology rule (`.textlintrc`). A change can pass every local hook and still fail CI on prose — exactly what happened on PR #603's first run ("pre-release" → "prerelease").

## Changes

- **`CLAUDE.md`**: one bullet in the `## Engineering Standards` digest — `pre-commit` is a subset; the `Lint Code Base` gate also runs textlint; reproduce before pushing.
- **`CONTRIBUTING.md`**: a `### Local checks vs CI` subsection under `## Engineering Standards` with the full explanation and how to reproduce (Super-Linter image, or textlint with `.textlintrc`).

## Verification

- **textlint** (`textlint-rule-terminology` against `.textlintrc`) on both files → **exit 0**. This is the same check that failed #603, now run locally so the change does not itself trip the rule it documents. The backticked `pre-release` counter-example is correctly skipped (terminology ignores inline code).
- `pre-commit run --files CLAUDE.md CONTRIBUTING.md` → Markdown, Spelling, EditorConfig all pass.

Closes #607