### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-05T23:19:11Z",
-  "source_commit": "39f85d31927f6098f832b6da28d40a04b297a439",
+  "generated_at": "2026-07-06T00:19:16Z",
+  "source_commit": "2be7557997deef0f2b972d50ff15c0a9372ee351",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,14 +65,14 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "180a1ab186da63d0e441043c877ee55600640c0a",
-      "size": 4890
+      "sha": "8d344d0448b6cc9a3e9b91c1621a535635e0f820",
+      "size": 5461
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "c40e719676b917d8df993405c82d5b5e43a201b3",
-      "size": 1306
+      "sha": "412d6aeb927d8c9a527531fb6551a19a83de662c",
+      "size": 1449
     },
     ".editorconfig": {
       "src": ".editorconfig",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.