### PR TITLE
fix(jscpd): ignore full generated/translated docs tree (unblocks tfp-xcsh sync)

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -16,8 +16,6 @@
     "**/internal/client/**",
     "**/internal/provider/**",
     "**/templates/**",
-    "**/docs/resources/**",
-    "**/docs/data-sources/**",
-    "**/docs/functions/**"
+    "**/docs/**"
   ]
 }


### PR DESCRIPTION
Replaces the narrow `**/docs/{resources,data-sources,functions}/**` ignores with `**/docs/**`.

**Why:** those patterns require `docs/data-sources` as consecutive segments, so they miss the i18n layout (`docs/en/data-sources/`) and don't cover generated `guides`. In terraform-provider-xcsh that leaves ~224 generated docs tripping JSCPD (29.7%), blocking the required lint gate and governance sync (#610). JSCPD is a source-code copy-paste detector; generated/translated docs are not source.

**Verified** on terraform-provider-xcsh: 29.7% → 6.8% duplication, jscpd exit 0, **no** Go/TS source clones suppressed.

Closes #611