### PR TITLE
fix(settings): re-enable required super-linter for xcsh-chrome-extension

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -57,9 +57,6 @@
     },
     "terraform-provider-xcsh": {
       "excluded_required_contexts": ["audit / Translation freshness"]
-    },
-    "xcsh-chrome-extension": {
-      "excluded_required_contexts": ["lint / Lint Code Base"]
     }
   },
   "topics": [],


### PR DESCRIPTION
## Summary

Re-enables `lint / Lint Code Base` as a **required** status check for `xcsh-chrome-extension` by removing its `repo_overrides` entry (whose sole content was `excluded_required_contexts: ["lint / Lint Code Base"]`). It now inherits the global default required contexts. The exclusion was a leftover "deferred super-linter" that was never re-enabled — it let PR #206 in that repo auto-merge with a failing lint check.

## Related Issue

Closes #616

## Changes

- `.github/config/repo-settings.json`: drop `repo_overrides.xcsh-chrome-extension`.

## Not changed (intentional)

- `xcsh` stays excluded — it has **no super-linter workflow**, so requiring `lint / Lint Code Base` would leave every PR pending forever on a check that never posts.
- `mvp` / `marketplace-claude-code` run super-linter but have empty live required contexts (enforcement drift) — separate follow-up, not this PR.

## Verification

- `jq empty` — repo-settings.json is valid JSON.
- `tests/test-protect-managed-files.sh` — pass/fail counts identical to `main` baseline (62/63); the "valid JSON" assertion passes. Change is neutral to the suite.
- After merge, the `enforce-repo-settings` workflow (triggered by the push to `.github/config/repo-settings.json`) re-applies branch protection; `xcsh-chrome-extension` `main` will then require `check / Check linked issues`, `lint / Lint Code Base`, `audit / Translation freshness`.

## Checklist

- [x] Linked to a GitHub issue
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)