### PR TITLE
fix: opt terraform-provider-xcsh out of the i18n cohort (#618)

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -8,7 +8,9 @@
       ".ruff.toml",
       ".python-lint",
       ".mypy.ini",
-      ".github/workflows/super-linter.yml"
+      ".github/workflows/super-linter.yml",
+      ".github/workflows/translation-audit.yml",
+      "scripts/locale-lint.sh"
     ],
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -74,7 +74,9 @@
         ".ruff.toml",
         ".python-lint",
         ".mypy.ini",
-        ".github/workflows/super-linter.yml"
+        ".github/workflows/super-linter.yml",
+        ".github/workflows/translation-audit.yml",
+        "scripts/locale-lint.sh"
       ],
       "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],


### PR DESCRIPTION
Closes #618.

Adds `.github/workflows/translation-audit.yml` and `scripts/locale-lint.sh` to `skip_files.xcsh` in **both** `.claude/governance.json` and `.github/config/repo-settings.json`, so the managed-file sync stops distributing/enforcing the i18n audit stub and locale linter to `terraform-provider-xcsh`. This unblocks a companion provider PR that deletes the redundant `docs/en/` tree + those two files without the sync re-adding them.

### Why
Provider docs are auto-generated on every rebuild (`transform-docs.go` + `tfplugindocs` → flat `docs/{resources,data-sources,functions,guides}`). Maintaining a `docs/en/` i18n source plus 12 locale translations for constantly-changing pre-release code is prohibitively costly. Owner decision (per #618): opt out for pre-release, re-enable when the API surface stabilizes.

### Findings that shape the fix
- **`docs/en/` is not actively scaffolded** — it is stale/behind (105 vs 122 flat resources) and only ever edited by the provider's own auto-regenerate `codespell --write-changes docs/` walk. So provider-side deletion is durable; scope item 3 ("disable scaffolding") is moot — there is no active scaffolder to disable.
- **No pre-commit divergence needed** — the `docs-translate` hook is scoped `files: ^docs/en/.*\.mdx?$`; with `docs/en/` gone it never matches, so the shared `.pre-commit-config.yaml` stays uniform across repos (no need to skip it or fork a variant). This satisfies the "no docs-translate hook runs on xcsh" intent without divergence.
- **Required-check exclusion already correct** (`audit / Translation freshness` excluded for xcsh).

### Companion provider PR (separate)
Deletes `docs/en/`, `.github/workflows/translation-audit.yml`, `scripts/locale-lint.sh`; closes stale PR #759. Merges after this one so the deletions aren't re-synced.

### Acceptance criteria
- [x] `translation-audit.yml` + `scripts/locale-lint.sh` in `skip_files.xcsh` (both configs).
- [x] Shared `.pre-commit-config.yaml` unchanged; `docs-translate` hook inert on xcsh (no `docs/en/`).
- [ ] Provider PR removes `docs/en/` + the two files; `#759` closed (companion PR).
- [x] Required checks on xcsh main unchanged.