### PR TITLE
chore: onboard webapp-api-protection

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -77,6 +77,11 @@
     "description": "F5 XC API security"
   },
   {
+    "label": "Web App & API Protection",
+    "url": "https://f5-sales-demo.github.io/webapp-api-protection/llms-full.txt",
+    "description": "F5 XC web application and API protection"
+  },
+  {
     "label": "API Specs",
     "url": "https://f5-sales-demo.github.io/api-specs/llms-full.txt",
     "description": "OpenAPI spec validation and reconciliation for F5 Distributed Cloud",

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -14,6 +14,7 @@
   "ddos",
   "waf",
   "api-protection",
+  "webapp-api-protection",
   "api-specs",
   "api-specs-enriched",
   "csd",


### PR DESCRIPTION
## Summary

Onboards the new `webapp-api-protection` downstream repository into the docs-control ecosystem.

- Adds `webapp-api-protection` to `.github/config/downstream-repos.json` (dispatch/enforcement fan-out).
- Adds a `Web App & API Protection` entry to `.github/config/docs-sites.json`.

## Testing

- `python3 -c 'json.load(...)'` on both files — valid JSON.

Closes #629