### PR TITLE
docs: sharpen managed engineering standards for CI verification and idempotency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,9 @@ Apply where applicable to this repo:
 - **Spec first** — start from an engineering-level spec, then work a task/todo list.
 - **TDD** — write the failing test first, then the code.
 - **Automate UAT** — automate acceptance testing wherever possible.
-- **Verify before done** — back every "done" claim with passing tests or reproducible output.
-- **Root-cause only** — never skip, silence, patch over, or band-aid a problem; CI rejects masked issues.
+- **Programmatic & idempotent** — fix with deterministic, re-runnable automation, not one-off manual steps; the same run yields the same result in CI.
+- **Verify before done (IMPORTANT)** — never assume a fix works. Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. Back every "done" claim with command output or a run link.
+- **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
 - **Clean branches** — experiment freely, but never commit broken or unneeded (YAGNI) code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,18 +107,35 @@ apply what fits.
 - For code changes, write the test first, watch it fail, then write code to make it pass.
 - Automate user-acceptance testing wherever possible instead of relying on manual checks.
 
+### Programmatic, idempotent solutions
+
+- Prefer a deterministic, re-runnable script or automation over manual, one-off
+  intervention. If you fixed it by hand, capture it as code.
+- Solutions must be idempotent: running them again, or running them in CI, produces the
+  same result with no drift or side effects.
+
 ### Verify before claiming done
 
-- Substantiate every "it works" / "done" claim with evidence: passing tests or
-  reproducible output.
+- Never guess or assume a change works. Substantiate every "it works" / "done" claim with
+  evidence: passing tests, reproducible output, or a workflow run link.
 - Do not assert completion you have not verified.
+- When a change triggers GitHub Actions, watch every affected workflow run to completion
+  — not just "queued" or "in progress". A merge is not done until its runs are green.
+- When a change publishes a new version or artifact, close the loop end-to-end: download,
+  install, and exercise the published version to confirm the fix is real — not merely
+  that the pipeline reported success.
 
 ### No papering over problems
 
 - When you find a pre-existing problem, fix the root cause. Never skip, ignore, silence,
   patch over, or band-aid it.
+- This applies to lint and CI failures specifically: fix them at the source. Do not
+  suppress them with inline-disable comments (for example `# noqa`, `eslint-disable`),
+  skipped tests, relaxed rules, or ignore lists, and do not hand-wave them as unrelated.
 - CI rejects changes that mask problems (disabling checks, swallowing errors,
   TODO-and-move-on).
+- There is no schedule pressure that justifies a shortcut — take the time to engineer the
+  correct solution.
 
 ### Prerelease: no backward compatibility
 


### PR DESCRIPTION
## Summary

Enhances the managed engineering-standards template (`CLAUDE.md` digest +
`CONTRIBUTING.md` detail, both synced verbatim to downstream repos) so coding
agents follow recurring expectations without needing manual reminders.

Grounded in Anthropic's guidance (code.claude.com/docs/en/memory,
/best-practices): `CLAUDE.md` is advisory context loaded every session, so
short + specific + verifiable rules get followed and bloat gets ignored. The
change sharpens vague rules into concrete ones and adds only the genuinely
missing concepts — net `CLAUDE.md` growth is a single bullet (10 -> 11).

### Changes

**`CLAUDE.md`**
- New bullet: **Programmatic & idempotent** (deterministic, re-runnable, no
  one-off manual steps).
- Sharpened **Verify before done (IMPORTANT)**: watch GitHub Actions runs to
  completion; install/exercise any published version; back claims with output
  or a run link.
- Sharpened **Root-cause only**: names lint/CI failures explicitly — fix at the
  source, never suppress/inline-disable/hand-wave.

**`CONTRIBUTING.md`**
- New `Programmatic, idempotent solutions` subsection.
- Expanded `Verify before claiming done` with the watch -> publish -> install ->
  verify loop.
- Expanded `No papering over problems` with the lint/CI-suppression prohibition
  and a "no schedule pressure justifies a shortcut" line.

## Verification

- Reproduced the CI-only textlint terminology gate locally with the repo
  `.textlintrc` (positive-control confirmed the rule is live): **clean, exit 0**.
- `pre-commit run --files CLAUDE.md CONTRIBUTING.md`: **all pass** (markdownlint,
  codespell, editorconfig, secrets, governance branch check).
- Digest <-> detail parity confirmed: every changed bullet maps to a subsection.

## Test plan (post-merge)

- [ ] `build-managed-files-manifest.yml` regenerates the manifest with new SHAs
      for `CLAUDE.md` and `CONTRIBUTING.md`.
- [ ] A downstream `governance/sync-managed-files` PR opens carrying the new
      wording.

Closes #631
