### PR TITLE
fix: dispatch downstream when manifest lands on main (not on build completion)

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -1,16 +1,21 @@
 ---
 name: Dispatch Downstream Enforcement
 
-# Runs AFTER "Build Managed Files Manifest" completes, never concurrently
-# with it. The manifest is the source of truth sync reads; triggering on
-# the manifest build's completion (rather than the same push) guarantees
-# the freshly-committed manifest is in place before downstream sync fetches
-# it — eliminating the race where sync read a stale manifest and skipped
-# newly-added managed files. workflow_dispatch is kept as a manual fallback.
+# Fans out downstream enforcement once the regenerated manifest has LANDED on
+# main. The manifest is the source of truth sync reads; because main is
+# protected, "Build Managed Files Manifest" cannot push it directly and routes
+# it through an auto-merging sync/manifest PR. Triggering on that PR's merge
+# (a push to main touching the manifest) — not on the build's completion —
+# guarantees downstream reads the fresh manifest instead of racing the still-open
+# PR and fanning out the stale one (issue #634). repo-settings.json is included
+# so settings-only changes, which leave the manifest untouched, still enforce
+# downstream. workflow_dispatch is kept as a manual fallback.
 on:
-  workflow_run:
-    workflows: ["Build Managed Files Manifest"]
-    types: [completed]
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/managed-files-manifest.json'
+      - '.github/config/repo-settings.json'
   workflow_dispatch:
 
 permissions:
@@ -23,11 +28,9 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    # Only fan out when the manifest build succeeded (or on manual dispatch).
-    # Skips on manifest-build failure so downstream never syncs a bad manifest.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+    # No conclusion guard needed: dispatch now fires only when the manifest has
+    # already landed on main. A bad manifest fails the sync/manifest PR's checks
+    # and never merges, so it can never reach main to trigger this workflow.
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -40,6 +40,19 @@ check "aggregates FAIL_COUNT" "grep -q 'FAIL_COUNT' '$WF'"
 check "consumes downstream-repos.json" "grep -q 'downstream-repos.json' '$WF'"
 check "config is JSON array" "jq -e 'type == \"array\" and length > 0' '$CONFIG' > /dev/null"
 
+# Trigger: dispatch must run when the regenerated manifest LANDS on main (the
+# auto-merging sync/manifest PR merges), not when the manifest build completes.
+# Triggering on build completion races the PR merge and fans out a stale
+# manifest — see issue #634.
+check "triggers on manifest landing on main" \
+  "grep -q 'managed-files-manifest.json' '$WF'"
+check "triggers on repo-settings.json (settings-only changes)" \
+  "grep -q 'repo-settings.json' '$WF'"
+check "does NOT trigger on build workflow_run (stale-manifest race)" \
+  "! grep -q 'workflow_run:' '$WF'"
+check "keeps manual workflow_dispatch fallback" \
+  "grep -q 'workflow_dispatch:' '$WF'"
+
 if command -v actionlint >/dev/null 2>&1; then
   check "actionlint clean" "actionlint '$WF' >/dev/null 2>&1"
 fi


### PR DESCRIPTION
## Summary

Fixes the race where a managed-source change never fans out to downstream repos
automatically (issue #634).

`Build Managed Files Manifest` routes the regenerated manifest through an
auto-merging `sync/manifest` PR (main is protected). `Dispatch Downstream
Enforcement` triggered on that build's `workflow_run` completion — firing while
the PR was still open, so it fanned out the **stale** manifest. Merging the PR
did not re-trigger the build, so no fresh dispatch ever ran.

## Change

- `dispatch-downstream.yml`: trigger on `push` to `main` touching
  `managed-files-manifest.json` (the manifest landing) or `repo-settings.json`
  (settings-only changes). Removed the `workflow_run` trigger and the obsolete
  build-conclusion `if:` guard. `workflow_dispatch` retained.
- `tests/test-dispatch-matrix.sh`: assert the new trigger (manifest landing +
  repo-settings, no `workflow_run`, keeps `workflow_dispatch`).

## Verification

- TDD: added assertions failed against the old trigger, pass after the fix —
  `test-dispatch-matrix.sh` 15/15 OK.
- `actionlint` clean; `pre-commit` (yamllint, shellcheck, actionlint, zizmor,
  secrets) all pass.
- Post-merge live UAT (in the linked issue): a real managed-file change fans out
  to downstream **without** any manual dispatch.

Closes #634
