### PR TITLE
docs: add install-free local textlint command to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,3 +161,5 @@ apply what fits.
   (for example `prerelease`, not `pre-release`). Before pushing Markdown or prose,
   reproduce the full gate — run the Super-Linter image, or textlint with the repo's
   `.textlintrc` — so CI-only rules do not surprise you.
+- Install-free local textlint (no `package.json` required):
+  `npx --yes --package textlint --package textlint-rule-terminology textlint -c .textlintrc <files>`.


### PR DESCRIPTION
Adds the exact install-free textlint command to the "Local checks vs CI" section so contributors can reproduce the CI-only NATURAL_LANGUAGE gate without Docker.

Verified: ran the documented command on the edited file (clean); pre-commit passes.

Also serves as the live UAT for #634 — its merge should auto-fan-out downstream with no manual dispatch.

Closes #636