### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-08T18:46:27Z",
-  "source_commit": "b8f86397ace8ae35998b4370ec2de1d3f0f2fefd",
+  "generated_at": "2026-07-08T20:00:08Z",
+  "source_commit": "3684e567949b62b3dfeea549d482ff8814a84d32",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,8 +65,8 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "d81e3d7bd67559ff3a7777a38363f7c880149cb8",
-      "size": 6601
+      "sha": "24f9db602fa1f815309be6971ef7545267f02608",
+      "size": 6763
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.