### PR TITLE
feat: allowlist API-identifier tokens in managed .textlintrc

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -45,7 +45,10 @@
         "client ?side",
         "server ?side",
         "sub[- ]class((?:es|ing)?)",
-        "user[- ]name(s)?"
+        "user[- ]name(s)?",
+        "[Cc]loudfront",
+        "[Ss]alesforce",
+        "common\\.js"
       ]
     }
   }


### PR DESCRIPTION
Adds three `rules.terminology.exclude` entries so the terminology gate stops flagging
F5 XC **API identifiers** (not prose) in downstream generated reference docs, which
currently blocks `terraform-provider-xcsh` docs lint and releases:

- `[Cc]loudfront` — CloudFront connector enum value + `cloudfrontCloudfrontType` schema
- `[Ss]alesforce` — `salesforce_commerce_connector` enum value
- `common\.js` — literal path (`default to '/common.js'`)

Genuine upstream prose typos (`Java Script`, `webpages`) are handled at the enrichment
source (api-specs-enriched#957), not suppressed here. `.textlintrc` validated as JSON.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)