### PR TITLE
fix: correct .textlintrc API-identifier excludes to match term patterns

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -46,9 +46,9 @@
         "server ?side",
         "sub[- ]class((?:es|ing)?)",
         "user[- ]name(s)?",
-        "[Cc]loudfront",
-        "[Ss]alesforce",
-        "common\\.js"
+        "CloudFront",
+        "Common[ .]?js",
+        "Sales?forces?"
       ]
     }
   }


### PR DESCRIPTION
#640's excludes (`[Cc]loudfront`, `[Ss]alesforce`, `common\.js`) had no effect —
`textlint-rule-terminology` matches `exclude` against the **term definition**, not the
found text. Corrected to the actual term forms:

- `CloudFront` (plain string term)
- `Common[ .]?js` (search pattern of the `CommonJS` pair)
- `Sales?forces?` (search pattern of the `Salesforce` pair)

Verified locally against the real config: `Cloudfront`, `/common.js`, and
`salesforce_commerce_connector` now pass, while a genuine term error (`javascript` →
`JavaScript`) is still caught. This unblocks the provider's regenerated-docs textlint.

Closes #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)