### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-09T21:29:54Z",
-  "source_commit": "6c2ab2ba9f0f868e7d23494f232e0083fa38df9a",
+  "generated_at": "2026-07-15T23:54:21Z",
+  "source_commit": "00ece005999eede71e48ec21213c3263823ec18e",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -131,8 +131,8 @@
     ".jscpd.json": {
       "src": ".jscpd.json",
       "dest": ".jscpd.json",
-      "sha": "de30efb15f2d7ecfc9eac3d045495f733ff8b984",
-      "size": 401
+      "sha": "d8be4c6c375e2dd1fbea46c3fcc74c389a293154",
+      "size": 422
     },
     ".textlintrc": {
       "src": ".textlintrc",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.