### PR TITLE
feat: PR verification-evidence gate + reinforce verify-before-merge

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,13 @@ A clear and concise description of what actually happened.
 - Browser: [e.g., Chrome 120, Firefox 121]
 - Version/Commit: [e.g., commit SHA or tag]
 
+## Acceptance Criteria
+
+How we will know the bug is fixed — the specific, objectively verifiable conditions,
+ideally a failing test that turns green.
+
+- [ ]
+
 ## Additional Context
 
 Add any other context, screenshots, or log output about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,6 +20,13 @@ Describe how you'd like this feature to work.
 
 Describe any alternative solutions or features you've considered.
 
+## Acceptance Criteria
+
+A checklist of specific, objectively verifiable conditions that must all be true for
+this to be considered done. Each item should be testable, not aspirational.
+
+- [ ]
+
 ## Additional Context
 
 Add any other context, mockups, or references about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,19 @@ Closes #
 
 -
 
+## Verification evidence
+
+Show, don't assert. Paste the commands you ran and their output (tests, local
+run or dev server, lint) and link the green CI run. "It should work" is not
+evidence — an unverified PR is not ready to merge.
+
+-
+
 ## Checklist
 
-- [ ] Linked to a GitHub issue (required — CI will block merge without it)
-- [ ] Tested locally
+- [ ] Linked to a GitHub issue (required — CI blocks merge without it)
+- [ ] Feature-complete and verified — not exploratory or trial-and-error code
+- [ ] Tests written first (TDD) and passing; the issue's acceptance criteria are met
+- [ ] Verified locally by running or exercising the change — evidence pasted above
+- [ ] CI watched to green (not just queued)
 - [ ] Follows project conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,11 @@ Apply where applicable to this repo:
 - **TDD** — write the failing test first, then the code.
 - **Automate UAT** — automate acceptance testing wherever possible.
 - **Programmatic & idempotent** — fix with deterministic, re-runnable automation, not one-off manual steps; the same run yields the same result in CI.
-- **Verify before done (IMPORTANT)** — never assume a fix works. Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. Back every "done" claim with command output or a run link.
+- **Verify before done (IMPORTANT)** — never guess; verify locally before you push. Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. Every PR must carry evidence (commands, output, run link) — no unverified claims.
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — experiment freely, but never commit broken or unneeded (YAGNI) code.
+- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,14 @@ apply what fits.
 - Never guess or assume a change works. Substantiate every "it works" / "done" claim with
   evidence: passing tests, reproducible output, or a workflow run link.
 - Do not assert completion you have not verified.
+- Verify locally before you push: run the tests, then run or exercise the change itself
+  (the dev server, or the actual command path a user hits) and confirm the behavior. CI
+  and the PR are not your test harness — do not push to find out whether it works.
+- Every PR must carry that verification evidence in its description (see the PR
+  template): the commands you ran and their output, and a link to the green run.
+  Reviewers should not merge a PR whose evidence is missing.
+- Where a change needs human judgment (user-facing behavior, UX, product decisions), get
+  explicit human acceptance before merge — green CI alone is not acceptance.
 - When a change triggers GitHub Actions, watch every affected workflow run to completion
   — not just "queued" or "in progress". A merge is not done until its runs are green.
 - When a change publishes a new version or artifact, close the loop end-to-end: download,
@@ -148,7 +156,12 @@ apply what fits.
 
 ### Clean branches
 
-- Troubleshoot and experiment freely on a branch.
+- A branch is for trial-and-error: guess, probe, refactor, and learn freely while you
+  converge on the correct solution.
+- Only the verified, feature-complete result merges. Never open a PR "to see if it
+  works" — open it when it works — and never merge exploratory or trial-and-error code.
+  Iterating in the open with repeated broken PRs pollutes the repo; converge on the
+  branch first, then merge the meaningful change.
 - Never commit broken or experimental code, or speculative work that is not needed
   (YAGNI). Keep merged history green.
 


### PR DESCRIPTION
## Summary

Reinforces verify-before-merge discipline ecosystem-wide by adding the missing
enforcement surface — a required PR verification-evidence gate — and tightening
the managed docs and issue templates. Prose alone (advisory CLAUDE.md) did not
stop guess→push→merge-slop; this adds a concrete, human-reviewable gate per
Anthropic's "show evidence, don't assert" guidance.

## Related Issue

Closes #650

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: new **Verification evidence** section +
  stronger checklist.
- `CLAUDE.md`: sharpened "Verify before done" and "Clean branches" bullets (no
  net growth).
- `CONTRIBUTING.md`: expanded "Verify before claiming done" and "Clean branches".
- `.github/ISSUE_TEMPLATE/{feature_request,bug_report}.md`: added Acceptance
  Criteria sections.

## Verification evidence

Local textlint (the CI-only `NATURAL_LANGUAGE` terminology gate), run per file
with the repo `.textlintrc`:

```
[clean] .github/PULL_REQUEST_TEMPLATE.md
[clean] .github/ISSUE_TEMPLATE/feature_request.md
[clean] .github/ISSUE_TEMPLATE/bug_report.md
[clean] CLAUDE.md
[clean] CONTRIBUTING.md
textlint overall rc=0
```

`pre-commit run --files` on all five changed files:

```
Markdown lint...............................................................Passed
Spelling check..............................................................Passed
EditorConfig check..........................................................Passed
Secrets detection...........................................................Passed
```

CI run for this PR is linked in the checks below; will be watched to green
before merge.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met (docs/template change — validated via textlint + pre-commit + CI)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
