### PR TITLE
feat: onboard code-review repo into governance

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -35,5 +35,6 @@
   "i18n-core",
   "console",
   "xcsh-chrome-extension",
-  "marketplace-claude-code"
+  "marketplace-claude-code",
+  "code-review"
 ]

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -57,6 +57,9 @@
     },
     "terraform-provider-xcsh": {
       "excluded_required_contexts": ["audit / Translation freshness"]
+    },
+    "code-review": {
+      "excluded_required_contexts": ["audit / Translation freshness"]
     }
   },
   "topics": [],
@@ -151,10 +154,12 @@
         "APPLE_ID",
         "APPLE_PASSWORD",
         "APPLE_TEAM_ID"
-      ]
+      ],
+      "claude_review": ["F5_GATEWAY_TOKEN"]
     },
     "repo_roles": {
       "_default": ["governance"],
+      "code-review": ["governance", "claude_review"],
       "docs-icons": ["governance", "npm_publish"],
       "docs-theme": ["governance", "npm_publish"],
       "docs-builder": ["governance", "release"],


### PR DESCRIPTION
Closes #654.

Onboards the new private `code-review` repo (self-hosted, VPN-connected agentic Claude PR reviewer) into governance:
- add `code-review` to `downstream-repos.json`
- `repo_overrides`: exclude `audit / Translation freshness` (no docs/i18n content)
- `secrets_manifest`: new `claude_review` role (`F5_GATEWAY_TOKEN`), assigned to `code-review`

Deliberately does **not** add a `Claude Review` required context yet — Phase 8 verify would fail on a nonexistent check. That context is added later once the reviewer gate exists.

Verified: JSON valid; Phase 7 secret enforcement is audit-only (warns on missing `F5_GATEWAY_TOKEN` until it is set, does not fail).