### PR TITLE
docs: add after-merge local branch-hygiene guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work.
+- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Once your PR is verified-merged, prune and delete your local `[gone]` branches so the workstation does not accumulate merged branches.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,29 @@ apply what fits.
 - Never commit broken or experimental code, or speculative work that is not needed
   (YAGNI). Keep merged history green.
 
+#### After merge: clean up local branches
+
+- The server deletes the remote branch on merge (`delete_branch_on_merge`); the local
+  copy remains and must be cleaned up, or merged branches accumulate on the workstation.
+- Once your PR is merged and CI is green, return to `main` and prune:
+  `git checkout main && git pull && git fetch --prune`.
+- Delete every branch whose upstream is gone. Squash-merges mean these are not ancestors
+  of `main` (so `git branch --merged` misses them); their deleted upstream marks them
+  `[gone]`. The `/clean_gone` skill does this in one step (and removes associated
+  worktrees) where available; otherwise detect and delete them with:
+
+  ```bash
+  git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads \
+    | awk '$2 == "[gone]" {print $1}' \
+    | xargs -r git branch -D
+  ```
+
+- Detect `[gone]` with `%(upstream:track)` as above (it emits a literal `[gone]`); do not
+  grep `git branch -vv`, which renders it as `[origin/<branch>: gone]` and will not match.
+- Safety: delete only `[gone]` branches. Never delete a branch with unmerged commits or
+  uncommitted changes, and never force-delete unmerged work. If unsure, leave the branch
+  and surface it for a human.
+
 ### Local checks vs CI
 
 - The authoritative lint gate is CI's `Lint Code Base` (Super-Linter). It runs more


### PR DESCRIPTION
## Summary

Adds after-merge local branch-hygiene guidance so workstations stop
accumulating merged branches (the server deletes the remote on merge, but the
local copy lingers). Advisory guidance in the two managed docs — a local
concern CI cannot enforce — reusing `/clean_gone` and git's `[gone]` marker.

## Related Issue

Closes #653

## Changes

- `CLAUDE.md`: folded an after-merge cleanup clause into the existing "Clean
  branches" bullet (no new bullet).
- `CONTRIBUTING.md`: added an "After merge: clean up local branches" block with
  the safe prune sequence, `/clean_gone`, the reliable `%(upstream:track)`
  detection idiom (with the `git branch -vv` caveat), and `[gone]`-only safety.

## Verification evidence

Local textlint (the CI-only `NATURAL_LANGUAGE` terminology gate), per file:

```
CLAUDE.md rc=0
CONTRIBUTING.md rc=0
```

`pre-commit run --files CLAUDE.md CONTRIBUTING.md`:

```
Markdown lint...............................................................Passed
Spelling check..............................................................Passed
EditorConfig check..........................................................Passed
Secrets detection...........................................................Passed
GOVERNANCE: never commit directly to main...................................Passed
```

Parity unchanged: 11 `- **` bullets / 10 `###` subsections (the new `####`
heading sits under the existing `### Clean branches`). CI run linked below;
watched to green before merge.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met (docs change — validated via textlint + pre-commit + CI)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
