### PR TITLE
fix: make [gone]-branch cleanup guidance safe (no blind force-delete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Once your PR is verified-merged, prune and delete your local `[gone]` branches so the workstation does not accumulate merged branches.
+- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Once your PR is verified-merged, prune and delete your merged local branch so the workstation does not accumulate branches (see CONTRIBUTING.md for safe `[gone]` cleanup).
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,22 +171,31 @@ apply what fits.
   copy remains and must be cleaned up, or merged branches accumulate on the workstation.
 - Once your PR is merged and CI is green, return to `main` and prune:
   `git checkout main && git pull && git fetch --prune`.
-- Delete every branch whose upstream is gone. Squash-merges mean these are not ancestors
-  of `main` (so `git branch --merged` misses them); their deleted upstream marks them
-  `[gone]`. The `/clean_gone` skill does this in one step (and removes associated
-  worktrees) where available; otherwise detect and delete them with:
+- Pruning marks any branch whose upstream was deleted as `[gone]`. Squash-merges mean a
+  merged branch is not an ancestor of `main` (so `git branch --merged` misses it) and
+  `git branch -d` refuses it — removing it requires the force flag, `git branch -D`.
+- `[gone]` means only "the remote branch is gone." That is usually a merge, but it is
+  also true for a PR closed without merging or a manually deleted remote — in which case
+  the local branch still holds unmerged commits. So confirm the work actually merged
+  before force-deleting; never blind-pipe the `[gone]` list into `git branch -D`.
+- Easiest and safest: run the `/clean_gone` skill where available (it removes `[gone]`
+  branches and their worktrees). Otherwise, first list the `[gone]` branches, confirm
+  each one's PR merged, then delete only the confirmed ones:
 
   ```bash
+  # 1) list branches whose upstream is gone (literal "[gone]" via %(upstream:track);
+  #    do NOT grep `git branch -vv`, which renders it as "[origin/<branch>: gone]")
   git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads \
-    | awk '$2 == "[gone]" {print $1}' \
-    | xargs -r git branch -D
+    | awk '$2 == "[gone]" {print $1}'
+  # 2) confirm a branch actually merged (returns the merged PR if so)
+  gh pr list --state merged --head <branch>
+  # 3) delete the confirmed-merged branch (force flag is required, see above)
+  git branch -D <branch>
   ```
 
-- Detect `[gone]` with `%(upstream:track)` as above (it emits a literal `[gone]`); do not
-  grep `git branch -vv`, which renders it as `[origin/<branch>: gone]` and will not match.
-- Safety: delete only `[gone]` branches. Never delete a branch with unmerged commits or
-  uncommitted changes, and never force-delete unmerged work. If unsure, leave the branch
-  and surface it for a human.
+- Safety: a `[gone]` branch may still hold unmerged commits, so never `git branch -D` one
+  whose PR you have not confirmed merged, and never delete a branch with uncommitted
+  changes. When unsure, keep the branch and surface it for a human.
 
 ### Local checks vs CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,16 +178,18 @@ apply what fits.
   also true for a PR closed without merging or a manually deleted remote — in which case
   the local branch still holds unmerged commits. So confirm the work actually merged
   before force-deleting; never blind-pipe the `[gone]` list into `git branch -D`.
-- Easiest and safest: run the `/clean_gone` skill where available (it removes `[gone]`
-  branches and their worktrees). Otherwise, first list the `[gone]` branches, confirm
-  each one's PR merged, then delete only the confirmed ones:
+- Use this manual, confirm-then-delete flow: list the `[gone]` branches, confirm each
+  one's PR actually merged, then delete only the confirmed ones. (A `/clean_gone` skill
+  exists, but it force-deletes every `[gone]` branch with no merge check — the exact
+  closed-unmerged hazard above — so do not treat it as safe.)
 
   ```bash
   # 1) list branches whose upstream is gone (literal "[gone]" via %(upstream:track);
   #    do NOT grep `git branch -vv`, which renders it as "[origin/<branch>: gone]")
   git for-each-ref --format '%(refname:short) %(upstream:track)' refs/heads \
     | awk '$2 == "[gone]" {print $1}'
-  # 2) confirm a branch actually merged (returns the merged PR if so)
+  # 2) confirm the branch actually merged — check the returned PR is the right one,
+  #    since --head matches by name and branch names can be reused
   gh pr list --state merged --head <branch>
   # 3) delete the confirmed-merged branch (force flag is required, see above)
   git branch -D <branch>


### PR DESCRIPTION
## Summary

Fixes the safety defect in #656's after-merge cleanup guidance (found in
whole-branch review): the block shipped an auto-runnable `git branch -D`
one-liner whose "never force-delete unmerged work" rail contradicted the force
delete, and `[gone]` != "merged" (also closed-unmerged / deleted remote), so the
blind loop could irreversibly delete unmerged work across ~37 repos.

## Related Issue

Closes #658

## Changes

- `CONTRIBUTING.md`: list → confirm-merged (`gh pr list --state merged --head
  <branch>`) → delete; explain `[gone]` != merged and that `-D` force is required
  for squash-merges; keep `/clean_gone`; fix the contradictory safety rail.
- `CLAUDE.md`: folded clause now deletes your merged local branch (not blanket
  `[gone]`), pointing to CONTRIBUTING.md.

## Verification evidence

```
textlint: CLAUDE.md rc=0 ; CONTRIBUTING.md rc=0
pre-commit: Markdown lint / Spelling / EditorConfig / Secrets / GOVERNANCE — Passed
```

Opus whole-branch review of this fix diff requested before marking ready; CI
linked below, watched to green before merge.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met (docs fix — validated via textlint + pre-commit + review + CI)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
