### PR TITLE
feat: require Claude Review on code-review + add xcsh secrets role (#661)

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -59,6 +59,7 @@
       "excluded_required_contexts": ["audit / Translation freshness"]
     },
     "code-review": {
+      "additional_contexts": ["review / claude-review"],
       "excluded_required_contexts": ["audit / Translation freshness"]
     }
   },
@@ -155,11 +156,12 @@
         "APPLE_PASSWORD",
         "APPLE_TEAM_ID"
       ],
-      "claude_review": ["F5_GATEWAY_TOKEN"]
+      "claude_review": ["F5_GATEWAY_TOKEN"],
+      "xcsh": ["XCSH_API_URL", "XCSH_API_TOKEN", "XCSH_USERNAME", "XCSH_CONSOLE_PASSWORD"]
     },
     "repo_roles": {
       "_default": ["governance"],
-      "code-review": ["governance", "claude_review"],
+      "code-review": ["governance", "claude_review", "xcsh"],
       "docs-icons": ["governance", "npm_publish"],
       "docs-theme": ["governance", "npm_publish"],
       "docs-builder": ["governance", "release"],


### PR DESCRIPTION
Closes #661.
- code-review `repo_overrides.additional_contexts`: `review / claude-review` (the reviewer becomes a required, merge-blocking check; self-review.yml provides it and is already live on main).
- `secrets_manifest`: new `xcsh` role (XCSH_API_URL/API_TOKEN/USERNAME/CONSOLE_PASSWORD) assigned to code-review, so those secrets aren't flagged 'unexpected' by the Phase 7 audit.