### PR TITLE
docs: reinforce task-list discipline (evidence-backed status, no deferral)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,11 @@ A hook blocks direct edits — open an issue in docs-control instead.
 Apply where applicable to this repo:
 
 - **Detailed issue** — CI stays red until the PR links a detailed issue (problem, scope, acceptance criteria).
-- **Spec first** — start from an engineering-level spec, then work a task/todo list.
+- **Spec first** — start from an engineering-level spec, then work an explicit task list to the end. Keep it current, finish every item, and never silently defer or abandon work; if blocked, mark it blocked and say what's needed.
 - **TDD** — write the failing test first, then the code.
 - **Automate UAT** — automate acceptance testing wherever possible.
 - **Programmatic & idempotent** — fix with deterministic, re-runnable automation, not one-off manual steps; the same run yields the same result in CI.
-- **Verify before done (IMPORTANT)** — never guess; verify locally before you push. Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. Every PR must carry evidence (commands, output, run link) — no unverified claims.
+- **Verify before done (IMPORTANT)** — never guess; verify locally before you push, and mark a task complete only when its result is verified with evidence (commands, output, run link). Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. No unverified claims.
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,19 @@ apply what fits.
 - Start non-trivial work from an engineering-level spec: what and why, the interfaces or
   content affected, and acceptance criteria.
 - Break the spec into an explicit task/todo list and work it item by item.
+- Keep the task list current: exactly one item in progress at a time, mark it complete
+  the moment it is genuinely done, and add newly-discovered work as new items rather than
+  silently widening an existing one.
+- Mark a task complete only with verifiable evidence of its result — the command run and
+  its output, a passing test, or a run link — never on inference or "should work" (see
+  "Verify before claiming done").
+- Work the list to completion. Do not defer, punt, or silently leave items incomplete or
+  half-done. If you cannot finish an item, keep it open, mark it blocked, and state
+  exactly what blocks it and what is needed — surface it, do not drop it.
+- For long or unattended runs where finishing matters, set a `/goal` completion condition
+  (for example, "every task-list item complete with evidence") so the session keeps
+  working toward it instead of stopping early. The condition must be checkable from what
+  you have surfaced in the session, since the evaluator cannot run tools.
 
 ### Test-driven development
 
@@ -119,6 +132,8 @@ apply what fits.
 - Never guess or assume a change works. Substantiate every "it works" / "done" claim with
   evidence: passing tests, reproducible output, or a workflow run link.
 - Do not assert completion you have not verified.
+- This applies per task-list item, not only at the end: do not mark an item complete
+  without its evidence.
 - Verify locally before you push: run the tests, then run or exercise the change itself
   (the dev server, or the actual command path a user hits) and confirm the behavior. CI
   and the PR are not your test harness — do not push to find out whether it works.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,9 +101,10 @@ apply what fits.
 - Start non-trivial work from an engineering-level spec: what and why, the interfaces or
   content affected, and acceptance criteria.
 - Break the spec into an explicit task/todo list and work it item by item.
-- Keep the task list current: exactly one item in progress at a time, mark it complete
-  the moment it is genuinely done, and add newly-discovered work as new items rather than
-  silently widening an existing one.
+- Keep the task list current: generally one item in progress at a time (one per worker
+  when work is fanned out across agents), mark it complete the moment it is genuinely
+  done, add newly-discovered work as new items rather than silently widening an existing
+  one, and remove an item that turns out unnecessary with a note — never silently.
 - Mark a task complete only with verifiable evidence of its result — the command run and
   its output, a passing test, or a run link — never on inference or "should work" (see
   "Verify before claiming done").
@@ -111,7 +112,8 @@ apply what fits.
   half-done. If you cannot finish an item, keep it open, mark it blocked, and state
   exactly what blocks it and what is needed — surface it, do not drop it.
 - For long or unattended runs where finishing matters, set a `/goal` completion condition
-  (for example, "every task-list item complete with evidence") so the session keeps
+  (for example, "every task-list item complete with evidence, or explicitly blocked and
+  surfaced") so the session keeps
   working toward it instead of stopping early. The condition must be checkable from what
   you have surfaced in the session, since the evaluator cannot run tools.
 


### PR DESCRIPTION
## Summary

Reinforces task-list discipline so agents work from a maintained list, mark
items complete only with evidence, and never randomly defer/abandon work.
Advisory docs (per Anthropic, CLAUDE.md is advisory) plus documenting `/goal` as
the opt-in, session-scoped deterministic gate — no always-on Stop hook (that
would trap unrelated sessions across ~37 repos).

## Related Issue

Closes #663

## Changes

- `CLAUDE.md`: sharpened "Spec first" (work the list to completion; never silently
  defer/abandon; mark blocked with reason) and "Verify before done" (task complete
  only with evidence). No net new bullet (stays 11).
- `CONTRIBUTING.md`: expanded "Specs and task-driven work" (keep-current,
  evidence-per-item, work-to-completion/no-deferral, `/goal` note) and added a
  per-item tie-in under "Verify before claiming done".

## Verification evidence

```
textlint: CLAUDE.md rc=0 ; CONTRIBUTING.md rc=0
pre-commit: Markdown lint / Spelling / EditorConfig / Secrets / GOVERNANCE — Passed
parity: 11 bullets / 10 subsections (no new bullet)
```

Draft until an Opus whole-diff review clears it; CI linked below, watched to
green before merge.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met (docs change — validated via textlint + pre-commit + review + CI)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
