### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-19T14:25:36Z",
-  "source_commit": "af9a4d04bb79382049e825aa620bb890df654549",
+  "generated_at": "2026-07-20T01:29:42Z",
+  "source_commit": "444d2c2045f8f6049190d69786c0bdeeef08c4a7",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,14 +65,14 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "5c9261a00f446726ec41b8e05d045af918ee0869",
-      "size": 9916
+      "sha": "fd167553b71e2b00753e1a5b1a7b3d2460fef2ff",
+      "size": 11210
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "daa712aa73adb1338c17d8ac14a2c7348ae56003",
-      "size": 2145
+      "sha": "f01ee67f0c78ef97485fdb1965021ad14a3344a3",
+      "size": 2330
     },
     ".editorconfig": {
       "src": ".editorconfig",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.