### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-20T01:29:42Z",
-  "source_commit": "444d2c2045f8f6049190d69786c0bdeeef08c4a7",
+  "generated_at": "2026-07-20T03:00:28Z",
+  "source_commit": "0953c968c641eb11e473adc4150a7be2708e3095",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -241,6 +241,18 @@
       "dest": ".claude/hooks/protect-managed-files.sh",
       "sha": "7d3a4031f5589ee713302ba417d0be9b0be4ca63",
       "size": 3563
+    },
+    "actionlint.yml": {
+      "src": "actionlint.yml",
+      "dest": "actionlint.yml",
+      "sha": "d1c7e47a3869a696bac8b518682bd2be60011607",
+      "size": 407
+    },
+    ".github/workflows/code-review.yml": {
+      "src": "workflows/code-review.yml",
+      "dest": ".github/workflows/code-review.yml",
+      "sha": "57ccda58257c9ab6b747b0ca6a344ccda53c5160",
+      "size": 1221
     }
   }
 }


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.