### PR TITLE
fix(code-review): satisfy required review/claude-review on automated PRs

### DIFF
--- a/workflows/code-review.yml
+++ b/workflows/code-review.yml
@@ -10,8 +10,10 @@ jobs:
   review:
     # Skip fork PRs (they must never reach the self-hosted runner) and automated
     # bot branches so governance/dependabot PRs are not gated on the laptop runner.
-    # A required check that is skipped via `if:` is treated as passing by branch
-    # protection (same pattern as the require-linked-issue gate).
+    # NOTE: skipping this reusable-workflow caller does NOT satisfy a required
+    # `review / claude-review` context — a skipped caller reports `review`, and the
+    # nested `review / claude-review` context is never produced, which deadlocks the
+    # excluded PRs. The review-status-automated job below posts that context instead.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.head_ref, 'governance/') &&
@@ -25,3 +27,30 @@ jobs:
     secrets:
       F5_GATEWAY_TOKEN: ${{ secrets.F5_GATEWAY_TOKEN }}
       REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
+
+  # Automated branches skip the reviewer above (never touching the self-hosted
+  # runner), so the required `review / claude-review` context would otherwise never
+  # post and the PR would deadlock. Post it as a passing commit status on exactly
+  # those branches (same-repo only, so GITHUB_TOKEN can write and forks are
+  # excluded). Human PRs get the real check from the `review` job instead.
+  review-status-automated:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (startsWith(github.head_ref, 'governance/') ||
+       startsWith(github.head_ref, 'sync/') ||
+       startsWith(github.head_ref, 'dependabot/') ||
+       startsWith(github.head_ref, 'release/'))
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Post passing review/claude-review status for automated PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+            -f state=success \
+            -f context='review / claude-review' \
+            -f description='Automated PR: AI review not required'


### PR DESCRIPTION
## Summary

Fixes a deadlock where automated PRs (governance sync, dependabot, release) can
never merge on repos that require the `review / claude-review` check (code-review,
dns). The reusable-workflow `review` caller is intentionally skipped on those
branches, but a skipped caller never posts the nested `review / claude-review`
context, so branch protection waits forever.

## Related Issue

Closes #669

## Changes

- `workflows/code-review.yml`: add a GitHub-hosted `review-status-automated` shim
  that posts a passing `review / claude-review` commit status on
  governance/sync/dependabot/release branches (same-repo only). Real reviewer
  unchanged for human PRs. Corrected the misleading comment.

## Verification evidence

```
actionlint workflows/code-review.yml -> clean
pre-commit (YAML lint, GitHub Actions security/zizmor, secrets, editorconfig) -> Passed
```

Root cause proven on code-review#26: rollup showed `review: SKIPPED` with no
`review / claude-review` context; a sibling sync PR without that required context
merged with 0 reviews. Post-merge, the sync PR carrying this fix runs the fixed
workflow on itself (pull_request uses head's workflow) and should self-unblock.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; acceptance criteria met (workflow change — validated via actionlint + pre-commit; end-to-end verified post-merge on the sync PR)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
