### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-20T03:00:28Z",
-  "source_commit": "0953c968c641eb11e473adc4150a7be2708e3095",
+  "generated_at": "2026-07-20T10:42:29Z",
+  "source_commit": "2727b763dbb527df97cec4e346fe95f24f44ae91",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -251,8 +251,8 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "57ccda58257c9ab6b747b0ca6a344ccda53c5160",
-      "size": 1221
+      "sha": "01d23b3500fb36e5e6cdca61d332f75278f3b931",
+      "size": 2651
     }
   }
 }


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.