### PR TITLE
fix: harden reviewer auto-pass against branch-name bypass (#674)

### DIFF
--- a/workflows/code-review.yml
+++ b/workflows/code-review.yml
@@ -8,18 +8,30 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   review:
-    # Skip fork PRs (they must never reach the self-hosted runner) and automated
-    # bot branches so governance/dependabot PRs are not gated on the laptop runner.
-    # NOTE: skipping this reusable-workflow caller does NOT satisfy a required
-    # `review / claude-review` context — a skipped caller reports `review`, and the
-    # nested `review / claude-review` context is never produced, which deadlocks the
-    # excluded PRs. The review-status-automated job below posts that context instead.
+    # Real agentic review for HUMAN, same-repo PRs. Skipped for genuine automated
+    # branches (handled by review-status-automated below) so fleet automation is
+    # not gated on the laptop runner. Skipping a reusable-workflow caller does NOT
+    # satisfy a required `review / claude-review` context (the nested context is
+    # never produced), so the skip set here MUST exactly mirror the automated set
+    # below — anything skipped here must get its status posted there, or the PR
+    # deadlocks.
+    #
+    # dependabot/ requires actor == dependabot[bot]: a human naming a branch
+    # `dependabot/x` therefore gets the REAL review, not a free pass. governance/,
+    # sync/ and release/ are created by the sync workflow via a human-owned PAT
+    # (REPO_SYNC_TOKEN), so github.actor is a human account and cannot distinguish
+    # a genuine sync PR from a person naming the branch — a prefix check is the
+    # best signal available here. RESIDUAL RISK: a write-access contributor could
+    # bypass the required review by using one of those prefixes. Mitigated by
+    # trusted-write-access + the reusable's fork guard; full closure requires a
+    # dedicated bot/App identity for the sync or a branch-creation ruleset
+    # restricting who may push governance/*, sync/*, release/*.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
-      !startsWith(github.head_ref, 'governance/') &&
-      !startsWith(github.head_ref, 'sync/') &&
-      !startsWith(github.head_ref, 'dependabot/') &&
-      !startsWith(github.head_ref, 'release/')
+      !(startsWith(github.head_ref, 'governance/') ||
+        startsWith(github.head_ref, 'sync/') ||
+        startsWith(github.head_ref, 'release/') ||
+        (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
     uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@main
     permissions:
       contents: read
@@ -28,18 +40,18 @@ jobs:
       F5_GATEWAY_TOKEN: ${{ secrets.F5_GATEWAY_TOKEN }}
       REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
-  # Automated branches skip the reviewer above (never touching the self-hosted
-  # runner), so the required `review / claude-review` context would otherwise never
-  # post and the PR would deadlock. Post it as a passing commit status on exactly
-  # those branches (same-repo only, so GITHUB_TOKEN can write and forks are
-  # excluded). Human PRs get the real check from the `review` job instead.
+  # Genuine automated branches skip the reviewer above (never touching the
+  # self-hosted runner), so the required `review / claude-review` context would
+  # never post and the PR would deadlock. Post it as a passing commit status on
+  # exactly those branches (same-repo only, so GITHUB_TOKEN can write and forks
+  # are excluded). Condition MUST mirror the negated `review` condition above.
   review-status-automated:
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.head_ref, 'governance/') ||
        startsWith(github.head_ref, 'sync/') ||
-       startsWith(github.head_ref, 'dependabot/') ||
-       startsWith(github.head_ref, 'release/'))
+       startsWith(github.head_ref, 'release/') ||
+       (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
     runs-on: ubuntu-latest
     permissions:
       statuses: write


### PR DESCRIPTION
Closes #674. Closes the dependabot spoofing vector with an actor check; documents the governance/sync/release residual (PAT-authored, actor-indistinguishable) + full-closure options. Conditions kept mirrored so bot PRs still don't deadlock.