### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-20T10:42:29Z",
-  "source_commit": "2727b763dbb527df97cec4e346fe95f24f44ae91",
+  "generated_at": "2026-07-20T10:48:27Z",
+  "source_commit": "18331d8c3bf562c787bf85c546d43d45149bac32",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -251,8 +251,8 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "01d23b3500fb36e5e6cdca61d332f75278f3b931",
-      "size": 2651
+      "sha": "4acd721ce5f78c5cc31d850650bc3344937eae14",
+      "size": 3529
     }
   }
 }


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.