### PR TITLE
docs: make git-hygiene cleanup + reporting a proactive part of done

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Once your PR is verified-merged, prune and delete your merged local branch so the workstation does not accumulate branches (see CONTRIBUTING.md for safe `[gone]` cleanup).
+- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Cleanup is part of "done", not a separate ask: once your PR is verified-merged, return to main, delete your merged local branch, and report git hygiene — current branch, uncommitted changes, stale `[gone]` branches — without waiting to be asked (your start-of-session git status is the cue; see CONTRIBUTING.md for safe `[gone]` cleanup).
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Cleanup is part of "done", not a separate ask: once your PR is verified-merged, return to main, delete your merged local branch, and report git hygiene — current branch, uncommitted changes, stale `[gone]` branches — without waiting to be asked (your start-of-session git status is the reminder to check; see CONTRIBUTING.md for safe `[gone]` cleanup).
+- **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches) unprompted — see CONTRIBUTING.md for safe `[gone]` cleanup.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Cleanup is part of "done", not a separate ask: once your PR is verified-merged, return to main, delete your merged local branch, and report git hygiene — current branch, uncommitted changes, stale `[gone]` branches — without waiting to be asked (your start-of-session git status is the cue; see CONTRIBUTING.md for safe `[gone]` cleanup).
+- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Cleanup is part of "done", not a separate ask: once your PR is verified-merged, return to main, delete your merged local branch, and report git hygiene — current branch, uncommitted changes, stale `[gone]` branches — without waiting to be asked (your start-of-session git status is the reminder to check; see CONTRIBUTING.md for safe `[gone]` cleanup).
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,11 @@ apply what fits.
 - When a change publishes a new version or artifact, close the loop end-to-end: download,
   install, and exercise the published version to confirm the fix is real — not merely
   that the pipeline reported success.
+- Leaving a clean workspace is part of "done": once merge is confirmed and CI is green,
+  return to `main`, delete your merged local branch, and proactively report git hygiene
+  — current branch, uncommitted or unmerged changes, and any stale `[gone]` branches —
+  rather than waiting to be asked. See "After merge: clean up local branches" for the
+  safe confirm-then-delete steps.
 
 ### No papering over problems
 


### PR DESCRIPTION
## Summary

Makes git-hygiene cleanup + reporting a proactive part of "done" so agents stop
leaving themselves on a stale merged branch and stop needing to be asked about
uncommitted/unmerged/stale state. Prose-only and DRY — no hook (Claude Code
already injects git status at session start; a hook would duplicate that and risk
surprises across developers' customized environments). The cleanup procedure stays
single-sourced in CONTRIBUTING.md "After merge: clean up local branches".

## Related Issue

Closes #678

## Changes

- `CLAUDE.md` "Clean branches" (no new bullet): cleanup + un-prompted hygiene
  reporting is part of "done"; uses the start-of-session git status as the cue.
- `CONTRIBUTING.md` "Verify before claiming done": one closing bullet ending the
  lifecycle with a clean-workspace + hygiene-report step that cross-references the
  existing "After merge" procedure (not restated).

## Verification evidence

```
textlint: CLAUDE.md rc=0 ; CONTRIBUTING.md rc=0
pre-commit: Markdown lint / Spelling / EditorConfig / Secrets / GOVERNANCE — Passed
parity: 11 bullets / 10 subsections (no new bullet); diff = CLAUDE.md 1 line, CONTRIBUTING.md +5
```

Draft pending an Opus DRY/no-duplication review; CI linked below, watched to green.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; acceptance criteria met (docs change — validated via textlint + pre-commit + review + CI)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
