### PR TITLE
fix: enforce markdownlint MD013 (400) locally to match CI

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-  "MD013": false,
+  "MD013": { "line_length": 400 },
   "MD029": false,
   "MD033": false,
   "MD040": false,


### PR DESCRIPTION
## Summary

Aligns local markdownlint with CI: pins `MD013` to `{ "line_length": 400 }` in
`.markdownlint.json` so pre-commit enforces the same 400-char limit CI already
enforces (via Super-Linter's bundled default). Fixes the gap where over-long
lines passed pre-commit and only failed CI (PR #679).

## Related Issue

Closes #681

## Changes

- `.markdownlint.json`: `"MD013": false` -> `"MD013": { "line_length": 400 }`.

## Verification evidence

```
JSON valid (jq)
tracked markdown lines >400 chars: NONE (longest tracked line = CLAUDE.md:27 @ 351)
=> enabling MD013:400 introduces zero new failures; matches CI's verified default
pre-commit on .markdownlint.json: passed
```

No CI workflow change; no downstream regression (committed content already
complies with CI's existing 400).

## Note (out of scope)

Local and CI markdownlint also diverge on other rules (CI uses Super-Linter's
bundled default; local uses this file's different disable set). Full single-source
unification is flagged in #681 as a separate decision.

## Checklist

- [x] Linked to a GitHub issue
- [x] Feature-complete and verified — not exploratory
- [x] Tests written first (TDD) and passing; acceptance criteria met (config change — verified no tracked line >400; matches CI default)
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green
- [x] Follows project conventions
