### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-20T13:05:32Z",
-  "source_commit": "319f95775e5a2c92a6469de678c4956790050e00",
+  "generated_at": "2026-07-20T13:35:48Z",
+  "source_commit": "a02faaed4ab17cd82e4bc789ff34857ba91b976d",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -107,8 +107,8 @@
     ".markdownlint.json": {
       "src": ".markdownlint.json",
       "dest": ".markdownlint.json",
-      "sha": "1b939df3a9f96c37a29a1b575107f977fb91c9de",
-      "size": 165
+      "sha": "f109fff2f7c9f7fe8418c698d1dcbfa849ee9c02",
+      "size": 182
     },
     ".github/workflows/dependabot-auto-merge.yml": {
       "src": "workflows/dependabot-auto-merge.yml",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.