### PR TITLE
Cap concurrent PR reviews at ~5 + per-PR dedup (closes #684)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,7 +28,11 @@ jobs:
     # HARD GUARD: never let a fork PR reach the self-hosted runner.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, macOS, code-review]
-    timeout-minutes: 30
+    # Generous JOB budget so a run that WAITS in the machine-wide slot queue
+    # (review-slot.sh, up to its 3h max-wait) does not die of timeout before it
+    # even starts reviewing. The actual review is bounded separately by the
+    # step-level timeout on the Claude action below. 240 > the slot max-wait (3h).
+    timeout-minutes: 240
     env:
       ANTHROPIC_BASE_URL: ${{ vars.F5_GATEWAY_URL }}
       # Model claude-opus-4-8 with the 1M-token context beta. Bearer auth via the
@@ -63,7 +67,19 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
+      # Machine-wide concurrency cap: block until one of REVIEW_MAX_SLOTS (default
+      # 5) slots is free, then hold it for the review. Every repo runner on this
+      # host shares the same slot dir, so no more than N reviews EXECUTE at once;
+      # the rest queue here. Appends REVIEW_SLOT to $GITHUB_ENV for the release
+      # step. GitHub Free forces repo-level runners, so this out-of-band semaphore
+      # is what enforces a fleet-wide cap (per-repo `concurrency:` cannot).
+      - name: Acquire review slot
+        run: bash .review-tooling/scripts/review-slot.sh acquire
+
       - name: Claude review (agentic, authenticated)
+        # Bound the ACTUAL review independently of the (large) job timeout that
+        # absorbs slot-queue wait. Matches review-slot.sh's 45m stale threshold.
+        timeout-minutes: 30
         uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e # v1
         with:
           # Bearer gateways: this satisfies the action's launch check; real auth
@@ -99,3 +115,10 @@ jobs:
 
       - name: Gate on verdict
         run: bash .review-tooling/scripts/parse-verdict.sh verdict.json
+
+      # Free the slot no matter how the job ended (success, gate failure, review
+      # timeout, or cancel-in-progress within the runner's cancel grace period).
+      # If a hard kill skips this, review-slot.sh's 45m stale reclaim frees it.
+      - name: Release review slot
+        if: always()
+        run: bash .review-tooling/scripts/review-slot.sh release

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -200,3 +200,7 @@ jobs:
       - name: Run dispatch-matrix test
         if: hashFiles('tests/test-dispatch-matrix.sh') != ''
         run: bash tests/test-dispatch-matrix.sh
+
+      - name: Run review-slot semaphore test
+        if: hashFiles('tests/test-review-slot.sh') != ''
+        run: bash tests/test-review-slot.sh

--- a/scripts/review-slot.sh
+++ b/scripts/review-slot.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# review-slot.sh — machine-wide counting semaphore for the self-hosted Claude PR
+# reviewer. Caps how many reviews execute concurrently across ALL repo runners on
+# this host and queues the rest.
+#
+# Why this exists: the org is on GitHub Free, so runners are repo-level (one
+# ephemeral instance per repo) — GitHub's per-repo `concurrency:` cannot express a
+# fleet-wide "max N". macOS has no `flock` and `shlock` is a single mutex, so the
+# cap is a set of N slot directories claimed with atomic `mkdir` (mkdir either
+# creates the dir and succeeds, or fails if it exists — the atomic primitive).
+#
+# Usage (from claude-review.yml, tooling checked out into .review-tooling):
+#   bash .review-tooling/scripts/review-slot.sh acquire   # blocks until a slot is free
+#   ...run the review...
+#   REVIEW_SLOT=$REVIEW_SLOT bash .review-tooling/scripts/review-slot.sh release
+#
+# acquire appends `REVIEW_SLOT=slot-<n>` to $GITHUB_ENV so a later step (and the
+# `if: always()` release step) knows which slot to free.
+#
+# Tunables (env; machine-wide, not per-repo):
+#   REVIEW_MAX_SLOTS        max concurrent reviews          (default 5)
+#   REVIEW_SLOTS_DIR        slot state dir                  (default ~/.config/code-review-runner/slots)
+#   REVIEW_STALE_SECONDS    reclaim a held slot older than  (default 2700 = 45m > the 30m review cap)
+#   REVIEW_POLL_SECONDS     wait between acquire sweeps      (default 10)
+#   REVIEW_MAX_WAIT_SECONDS give up acquiring after         (default 10800 = 3h)
+#
+set -euo pipefail
+
+N="${REVIEW_MAX_SLOTS:-5}"
+SLOTS_DIR="${REVIEW_SLOTS_DIR:-$HOME/.config/code-review-runner/slots}"
+STALE="${REVIEW_STALE_SECONDS:-2700}"
+POLL="${REVIEW_POLL_SECONDS:-10}"
+MAX_WAIT="${REVIEW_MAX_WAIT_SECONDS:-10800}"
+
+log() { echo "review-slot: $*" >&2; }
+
+write_meta() {
+  # $1 = slot dir. Record claim epoch (the staleness signal) + provenance.
+  {
+    printf 'epoch=%s\n' "$(date +%s)"
+    printf 'repo=%s\n' "${GITHUB_REPOSITORY:-}"
+    printf 'pr=%s\n' "${PR_NUMBER:-}"
+    printf 'run=%s\n' "${GITHUB_RUN_ID:-}"
+  } >"$1/meta"
+  return 0
+}
+
+# Free any slot whose holder is gone: a claim whose recorded epoch is older than
+# STALE (holder cancelled/crashed/timed out — a live review is bounded to 30m), or
+# a meta-less dir left by a crash between mkdir and meta-write, older than STALE by
+# mtime. `find -mmin` is portable across macOS and the Linux CI runner.
+reclaim_stale() {
+  local now d epoch age stale_min
+  now="$(date +%s)"
+  for d in "$SLOTS_DIR"/slot-*; do
+    [ -d "$d" ] || continue
+    epoch="$(sed -n 's/^epoch=//p' "$d/meta" 2>/dev/null | head -1)"
+    # Only act on a numeric epoch; empty/partial meta (just-created slot) is skipped.
+    if [[ "$epoch" =~ ^[0-9]+$ ]]; then
+      age=$((now - epoch))
+      if [ "$age" -ge "$STALE" ]; then rm -rf "$d" 2>/dev/null || true; fi
+    fi
+  done
+  # Belt-and-suspenders: meta-less dirs older than STALE minutes (crash window).
+  stale_min=$((STALE / 60))
+  local m
+  while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    if [ ! -e "$m/meta" ]; then rm -rf "$m" 2>/dev/null || true; fi
+  done < <(find "$SLOTS_DIR" -mindepth 1 -maxdepth 1 -type d -mmin +"$stale_min" 2>/dev/null || true)
+  return 0
+}
+
+try_claim() {
+  # Attempt one atomic claim sweep; on success echo the slot name and return 0.
+  local i slot
+  for ((i = 1; i <= N; i++)); do
+    slot="$SLOTS_DIR/slot-$i"
+    if mkdir "$slot" 2>/dev/null; then
+      write_meta "$slot"
+      echo "slot-$i"
+      return 0
+    fi
+  done
+  return 1
+}
+
+acquire() {
+  mkdir -p "$SLOTS_DIR"
+  local deadline claimed
+  deadline=$(($(date +%s) + MAX_WAIT))
+  while :; do
+    if claimed="$(try_claim)"; then
+      log "acquired $claimed (max $N)"
+      echo "REVIEW_SLOT=$claimed"
+      if [ -n "${GITHUB_ENV:-}" ]; then echo "REVIEW_SLOT=$claimed" >>"$GITHUB_ENV"; fi
+      return 0
+    fi
+    reclaim_stale || true
+    if claimed="$(try_claim)"; then
+      log "acquired $claimed after reclaim (max $N)"
+      echo "REVIEW_SLOT=$claimed"
+      if [ -n "${GITHUB_ENV:-}" ]; then echo "REVIEW_SLOT=$claimed" >>"$GITHUB_ENV"; fi
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      log "timed out after ${MAX_WAIT}s waiting for a free slot (all $N busy)"
+      return 1
+    fi
+    log "all $N slots busy; waiting ${POLL}s"
+    sleep "$POLL"
+  done
+}
+
+release() {
+  local slot="${REVIEW_SLOT:-}"
+  if [ -z "$slot" ]; then
+    log "no REVIEW_SLOT set; nothing to release"
+    return 0
+  fi
+  rm -rf "${SLOTS_DIR:?}/$slot" 2>/dev/null || true
+  log "released $slot"
+  return 0
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+  acquire) acquire ;;
+  release) release ;;
+  *)
+    log "usage: $0 {acquire|release}"
+    return 2
+    ;;
+  esac
+}
+
+main "$@"

--- a/tests/test-review-slot.sh
+++ b/tests/test-review-slot.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/review-slot.sh — the machine-wide counting
+# semaphore that caps concurrent PR reviews on the self-hosted runner.
+# No network / no GitHub; everything runs against temp slot dirs.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/review-slot.sh"
+
+FAIL=0
+check() {
+  local label="$1" cond="$2"
+  if eval "$cond"; then echo "[OK] $label"; else
+    echo "[FAIL] $label"
+    FAIL=1
+  fi
+}
+
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+# --- Test 1: cap — N=5, 12 concurrent workers, peak holders must never exceed 5 ---
+SLOTS="$WORK/slots1"
+ACTIVE="$WORK/active"
+PEAKS="$WORK/peaks"
+ERRLOG="$WORK/err"
+mkdir -p "$SLOTS" "$ACTIVE"
+: >"$PEAKS"
+: >"$ERRLOG"
+
+worker() {
+  local id="$1" genv slot marker level
+  genv="$(mktemp "$WORK/genv.XXXXXX")"
+  # A worker enters the critical section only after acquire returns 0.
+  if ! GITHUB_ENV="$genv" REVIEW_SLOTS_DIR="$SLOTS" REVIEW_MAX_SLOTS=5 \
+    REVIEW_POLL_SECONDS=1 REVIEW_MAX_WAIT_SECONDS=60 REVIEW_STALE_SECONDS=2700 \
+    GITHUB_REPOSITORY="test/repo" PR_NUMBER="$id" GITHUB_RUN_ID="$id" \
+    bash "$SCRIPT" acquire >/dev/null 2>&1; then
+    echo "acquire-failed:$id" >>"$ERRLOG"
+    return 0
+  fi
+  slot="$(grep '^REVIEW_SLOT=' "$genv" | tail -1 | cut -d= -f2)"
+  # Independent concurrency probe: unique marker per worker; the number of
+  # markers present == true number of workers in the critical section right now,
+  # regardless of which slot id each holds (catches a "same slot for all" bug).
+  marker="$ACTIVE/w-$id"
+  : >"$marker"
+  level=$(find "$ACTIVE" -type f | wc -l | tr -d ' ')
+  echo "$level" >>"$PEAKS"
+  sleep 0.5
+  rm -f "$marker"
+  REVIEW_SLOT="$slot" REVIEW_SLOTS_DIR="$SLOTS" bash "$SCRIPT" release >/dev/null 2>&1 || true
+}
+
+for i in $(seq 1 12); do worker "$i" & done
+wait
+
+peak=$(sort -n "$PEAKS" | tail -1)
+[ -z "$peak" ] && peak=0
+remaining=$(find "$SLOTS" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+
+check "all 12 workers acquired (no failures)" "[ ! -s '$ERRLOG' ]"
+check "peak concurrency never exceeded 5 (was $peak)" "[ '$peak' -le 5 ]"
+check "concurrency actually occurred, not serialized (peak $peak >= 2)" "[ '$peak' -ge 2 ]"
+check "all slots released after run (remaining=$remaining)" "[ '$remaining' -eq 0 ]"
+
+# --- Test 2: stale reclaim — a slot older than STALE is reclaimed ---
+SLOTS2="$WORK/slots2"
+mkdir -p "$SLOTS2/slot-1"
+echo "epoch=$(($(date +%s) - 100))" >"$SLOTS2/slot-1/meta"
+genv2="$(mktemp "$WORK/genv2.XXXXXX")"
+rc=0
+GITHUB_ENV="$genv2" REVIEW_SLOTS_DIR="$SLOTS2" REVIEW_MAX_SLOTS=1 \
+  REVIEW_STALE_SECONDS=1 REVIEW_POLL_SECONDS=1 REVIEW_MAX_WAIT_SECONDS=10 \
+  bash "$SCRIPT" acquire >/dev/null 2>&1 || rc=$?
+check "acquire reclaims a stale slot (rc=$rc)" "[ '$rc' -eq 0 ]"
+check "acquire recorded a slot after reclaim" "grep -q '^REVIEW_SLOT=' '$genv2'"
+
+# --- Test 3: a FRESH (live) held slot is NOT stolen; acquire times out ---
+SLOTS3="$WORK/slots3"
+mkdir -p "$SLOTS3/slot-1"
+echo "epoch=$(date +%s)" >"$SLOTS3/slot-1/meta"
+genv3="$(mktemp "$WORK/genv3.XXXXXX")"
+rc3=0
+GITHUB_ENV="$genv3" REVIEW_SLOTS_DIR="$SLOTS3" REVIEW_MAX_SLOTS=1 \
+  REVIEW_STALE_SECONDS=2700 REVIEW_POLL_SECONDS=1 REVIEW_MAX_WAIT_SECONDS=3 \
+  bash "$SCRIPT" acquire >/dev/null 2>&1 || rc3=$?
+check "acquire times out rather than stealing a live slot (rc=$rc3)" "[ '$rc3' -ne 0 ]"
+
+# --- Test 4: release is idempotent / safe when no slot is held ---
+rc4=0
+REVIEW_SLOT="" REVIEW_SLOTS_DIR="$SLOTS3" bash "$SCRIPT" release >/dev/null 2>&1 || rc4=$?
+check "release with empty REVIEW_SLOT is a safe no-op (rc=$rc4)" "[ '$rc4' -eq 0 ]"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "review-slot tests FAILED"
+  exit 1
+fi
+echo "review-slot tests passed"

--- a/workflows/code-review.yml
+++ b/workflows/code-review.yml
@@ -6,6 +6,16 @@ name: Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
+# Per-PR dedup: a new push cancels the superseded in-flight review for the SAME
+# PR, so two reviews of one PR never overlap and a stale commit's review does not
+# hold a machine-wide slot (see review-slot.sh). Concurrency groups are scoped per
+# repository, so this key needs no repo component (PR #5 in two repos never
+# collide). Same idiom as require-linked-issue.yml / super-linter.yml callers.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   review:
     # Real agentic review for HUMAN, same-repo PRs. Skipped for genuine automated


### PR DESCRIPTION
## What

Bounds the self-hosted Claude reviewer's load: **at most ~5 reviews execute at
once (queue the rest), and no two overlapping reviews for the same PR.**

- **`scripts/review-slot.sh`** — machine-wide counting semaphore via atomic
  `mkdir` slots (macOS has no `flock`; `shlock` is single-mutex). `acquire`
  blocks until one of `REVIEW_MAX_SLOTS` (default 5) is free; `release` frees it.
  State lives in `~/.config/code-review-runner/slots`, shared by every repo's
  runner instance on the host — so the cap is fleet-wide even though GitHub Free
  forces repo-level runners (per-repo `concurrency:` can't express it). Age-based
  stale reclaim (45m > the 30m review cap) frees slots left by cancels/crashes.
- **`claude-review.yml`** — `Acquire review slot` before the Claude action,
  `Release review slot` as an `if: always()` step. Job `timeout-minutes` 30→240
  so a job waiting in the slot queue doesn't die; a step-level `timeout-minutes:
  30` bounds the actual review.
- **`workflows/code-review.yml`** (synced caller) — per-PR `concurrency:`
  (`group: <workflow>-<PR#>`, `cancel-in-progress: true`), reusing the proven
  `require-linked-issue.yml`/`super-linter.yml` idiom. Concurrency groups are
  per-repo namespaces, so the key needs no repo component.

## Why this shape

Operator chose to stay on GitHub Free (verified: `plan: free`, 0 org runners) +
a local semaphore rather than a Team upgrade. Two independent controls: GitHub
handles per-PR dedup; the semaphore handles the fleet-wide cap.

## Verification

- **TDD** `tests/test-review-slot.sh` (wired into `super-linter.yml`): 12 workers
  with N=5 → peak concurrency ≤ 5 and ≥ 2 (real concurrency); stale slot
  reclaimed; a live slot is NOT stolen (acquire times out); release is a safe
  no-op with no slot. Passes 3× locally.
- `shellcheck` / `actionlint` / `yamllint` / `zizmor` clean; full `pre-commit`
  green.

## Follow-ups (separate, not in this PR)
- Empirically confirm `if: always()` release runs on `cancel-in-progress`
  cancellation of a self-hosted job (stale-reclaim is the backstop either way).
- Repeatable multi-repo runner provisioning helper (so ≥5 repos can actually
  reach the cap) — `code-review/runner/`.

Closes #684