### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-20T13:35:48Z",
-  "source_commit": "a02faaed4ab17cd82e4bc789ff34857ba91b976d",
+  "generated_at": "2026-07-20T15:54:29Z",
+  "source_commit": "bd3c4425eec92789262261fa5822bf4b9af7ae73",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -251,8 +251,8 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "4acd721ce5f78c5cc31d850650bc3344937eae14",
-      "size": 3529
+      "sha": "34daaa7fd603987d64e0b493da7c314278142874",
+      "size": 4043
     }
   }
 }


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.