### PR TITLE
docs: make prerelease/pre-production the explicit premise for no-backward-compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Apply where applicable to this repo:
 - **Programmatic & idempotent** — fix with deterministic, re-runnable automation, not one-off manual steps; the same run yields the same result in CI.
 - **Verify before done (IMPORTANT)** — never guess; verify locally before you push, and mark a task complete only when its result is verified with evidence (commands, output, run link). Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. No unverified claims.
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
-- **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
+- **No backward compat** — prerelease, pre-production code under active development; make clean-break changes, never add compatibility shims or keep deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
 - **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches) unprompted — see CONTRIBUTING.md for safe `[gone]` cleanup.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,8 +169,8 @@ apply what fits.
 
 ### Prerelease: no backward compatibility
 
-- This is prerelease code heading to production. Make clean-break changes.
-- Do not add compatibility shims or preserve deprecated interfaces — remove and replace.
+- This is prerelease, pre-production code still in development, heading to production.
+- Because nothing depends on a stable release yet, make clean-break changes: remove and replace — no compatibility shims, no deprecated interfaces.
 
 ### DRY — reuse first
 


### PR DESCRIPTION
## Summary

Makes the **prerelease / pre-production / in-development** status the explicit premise for the
"no backward compatibility" policy, in both managed source files. Wording only — no structural
change; preserves the two-tier pattern (terse `CLAUDE.md` bullet + detailed `CONTRIBUTING.md`
section). No dead duplication existed to remove.

## Changes

- `CLAUDE.md` — "No backward compat" bullet now names *prerelease, pre-production code under
  active development* as the reason for clean-break changes.
- `CONTRIBUTING.md` — "Prerelease: no backward compatibility" section states the same, with the
  rationale ("nothing depends on a stable release yet").

## Verification

- `textlint` (terminology, repo `.textlintrc`) — exit 0; `pre-production` not flagged, `prerelease`/`backward` spellings preserved.
- `markdownlint-cli2` (MD013=400) — 0 issues.
- `pre-commit run --files CLAUDE.md CONTRIBUTING.md` — all hooks Passed.
- Post-merge: manifest regen → dispatch → downstream sync will propagate to consumer repos.

Closes #687
