### PR TITLE
Onboard demo-resource-template to blocking Claude review (first batch, closes #693)

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -64,6 +64,9 @@
     },
     "dns": {
       "additional_contexts": ["review / claude-review"]
+    },
+    "demo-resource-template": {
+      "additional_contexts": ["review / claude-review"]
     }
   },
   "topics": [],
@@ -141,7 +144,7 @@
       {
         "src": "workflows/code-review.yml",
         "dest": ".github/workflows/code-review.yml",
-        "only_repos": ["code-review", "dns"]
+        "only_repos": ["code-review", "dns", "demo-resource-template"]
       }
     ]
   },
@@ -173,6 +176,7 @@
       "_default": ["governance"],
       "code-review": ["governance", "claude_review", "xcsh"],
       "dns": ["governance", "claude_review"],
+      "demo-resource-template": ["governance", "claude_review"],
       "docs-icons": ["governance", "npm_publish"],
       "docs-theme": ["governance", "npm_publish"],
       "docs-builder": ["governance", "release"],


### PR DESCRIPTION
First verified rollout batch. Adds demo-resource-template to the caller `only_repos`, a `repo_overrides` entry requiring `review / claude-review`, and the `claude_review` role. Runner online + gateway secret set. After merge, the sync fan-out delivers the caller + enforces the required context; then smoke-tested via `uat/run-uat.sh`. Closes #693