### PR TITLE
docs: remove duplicated detailed-issue rule from CLAUDE.md (DRY)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,6 @@ A hook blocks direct edits — open an issue in docs-control instead.
 
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Every PR must reference a detailed GitHub issue (CI enforces this).
 
 ## Engineering Standards
 


### PR DESCRIPTION
## Summary

Removes a DRY violation in `CLAUDE.md`: the "PR must link a detailed issue (CI enforces)" rule
was stated in both `## Workflow` and `## Engineering Standards`. The Engineering Standards
"**Detailed issue**" bullet is a strict superset (rule + CI enforcement + problem/scope/acceptance),
so the Workflow bullet added nothing.

## Change

- Drop `## Workflow` bullet "Every PR must reference a detailed GitHub issue (CI enforces this)."
- `## Workflow` keeps the branch/PR mechanics; the detailed-issue requirement now lives in exactly
  one place (Engineering Standards).

## Verification

- `textlint` (terminology) exit 0; `markdownlint-cli2` 0 issues; `pre-commit` all hooks Passed.
- Post-merge: manifest regen → dispatch → downstream sync propagates to consumer repos.

Closes #695
