### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-21T00:53:50Z",
-  "source_commit": "2a92eedc63c7a475b31cf8ee2095b2fc443a9e49",
+  "generated_at": "2026-07-21T10:46:50Z",
+  "source_commit": "0fa53b92a8d1bf7a0aa495ff2c0df328e9340de2",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -251,8 +251,8 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "34daaa7fd603987d64e0b493da7c314278142874",
-      "size": 4043
+      "sha": "319d8e5778ca47ee645f31ee4003d0b3a50df055",
+      "size": 5164
     }
   }
 }


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.