### PR TITLE
De-gate starlight-mega-menu until properly sync-onboarded (refs #704)

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -147,9 +147,6 @@
     "starlight-llms-txt": {
       "additional_contexts": ["review / claude-review"]
     },
-    "starlight-mega-menu": {
-      "additional_contexts": ["review / claude-review"]
-    },
     "apt-repo": {
       "additional_contexts": ["review / claude-review"]
     },
@@ -393,7 +390,7 @@
       "docs-builder": ["governance", "release", "claude_review"],
       "origin-server": ["governance", "release", "claude_review"],
       "starlight-llms-txt": ["governance", "npm_publish", "claude_review"],
-      "starlight-mega-menu": ["governance", "npm_publish", "claude_review"],
+      "starlight-mega-menu": ["governance", "npm_publish"],
       "xcsh": ["governance", "npm_publish", "apple_signing", "claude_review"],
       "vscode-xcsh": ["governance", "vscode_extension", "claude_review"],
       "terraform-provider-xcsh": ["governance", "terraform_provider", "claude_review"],


### PR DESCRIPTION
starlight-mega-menu is missing the governance sync suite (sync-managed-files.yml 404), so the caller never synced and requiring review deadlocked it. Removes its review override + claude_review role so config matches the cleared live protection. Re-add after proper onboarding (tracked in #704).

Closes #706