### PR TITLE
docs: concurrent-session isolation guidance (worktree + s-<slug>/ prefix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease, pre-production code under active development; make clean-break changes, never add compatibility shims or keep deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches) unprompted — see CONTRIBUTING.md for safe `[gone]` cleanup.
+- **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches) unprompted — see CONTRIBUTING.md for safe `[gone]` cleanup and per-session isolation of concurrent sessions.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,25 @@ apply what fits.
 - Never commit broken or experimental code, or speculative work that is not needed
   (YAGNI). Keep merged history green.
 
+#### Concurrent sessions on a shared workstation
+
+- Multiple sessions on one workstation authenticate through the same `gh` login, so every
+  branch, PR, and commit is attributed to the same GitHub user — the username cannot tell you
+  which live session produced which artifact. Use the stable per-session
+  `CLAUDE_CODE_SESSION_ID` as the discriminator.
+- Derive a short slug once per session: `SLUG=$(printf '%.8s' "$CLAUDE_CODE_SESSION_ID")`
+  (for example `515f9231`).
+- Isolate each session in its own git worktree so concurrent sessions cannot mutate one shared
+  checkout: `git worktree add ../<repo>-$SLUG s-$SLUG/<branch>`.
+- Prefix every branch `s-<slug>/…` (for example `s-515f9231/docs/653-local-branch-hygiene`).
+  The prefix shows in `git branch` and the `gh pr list` head-branch column and is searchable, so
+  a session can find its own in-flight work:
+  - `gh pr list --search "head:s-<slug>"` — this session's PRs
+  - `git branch --list "s-<slug>/*"` — this session's local branches
+- Composes with the after-merge `[gone]` cleanup below: cleanup is naturally scoped per session,
+  and retiring the merged branch also removes its worktree.
+- Advisory only — a local-workstation concern CI cannot enforce.
+
 #### After merge: clean up local branches
 
 - The server deletes the remote branch on merge (`delete_branch_on_merge`); the local


### PR DESCRIPTION
## Summary

Advisory guidance so concurrent Claude Code sessions on one workstation are mutually
distinguishable and isolated. All sessions share a single `gh` login, so every branch/PR/commit
is attributed to the same GitHub user; `CLAUDE_CODE_SESSION_ID` is the missing per-session
discriminator. Docs-only, following the digest→detail + anti-bloat pattern (extends the
**Clean branches** area from #653).

## Changes

- **`CLAUDE.md`** — extend the existing **Clean branches** bullet's single `CONTRIBUTING.md`
  pointer to also cover per-session isolation. No new top-level bullet; one pointer kept DRY.
- **`CONTRIBUTING.md`** — new `#### Concurrent sessions on a shared workstation` sub-block under
  `### Clean branches` (ahead of the after-merge `[gone]` cleanup it composes with): slug from
  `CLAUDE_CODE_SESSION_ID`, per-session `git worktree`, `s-<slug>/…` branch prefix, and the
  `gh pr list --search "head:s-<slug>"` / `git branch --list "s-<slug>/*"` filters.

## Safety / non-bypass

`s-<slug>/…` starts with `s-`, matching **none** of the `workflows/code-review.yml` bypass
prefixes (`governance/`, `sync/`, `release/`, `openapi-sync/`, `deps/`, `docs/update-`,
`auto-regenerate/`, `autoresearch/`, `dependabot/`). Session PRs still get the REAL blocking
review and still require a linked issue. This PR itself is such a branch — its `code-review`
gate running a real review is the live proof.

## Verification

- Local: `textlint` (terminology) exit 0 — "worktree" not flagged; `markdownlint` (MD013=400)
  0 issues; `pre-commit` all hooks Passed.
- Advisory only — no CI gate, no hook (mirrors #653).
- Post-merge: manifest regen → dispatch → downstream sync propagates to consumer repos.

Closes #707
