### PR TITLE
chore(governance): gitignore Superpowers SDD scratch (.superpowers/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ tui-debug.log
 .nyc_output/
 packages/ai/test/.temp-images/
 docs/superpowers/
+.superpowers/
 !.xcsh/
 .xcsh/plugins/
 .xcsh/contexts/


### PR DESCRIPTION
Adds `.superpowers/` to the managed `.gitignore` (next to the existing `docs/superpowers/`) so the SDD skill's runtime scratch stops appearing as untracked clutter in downstream repos. Closes #715.