### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-21T17:49:21Z",
-  "source_commit": "9846001a13773f05ef037e617a92c14278bb4940",
+  "generated_at": "2026-07-21T17:54:08Z",
+  "source_commit": "818ba663a3d036f3a1f1d8a301990c084aa8f79e",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -83,8 +83,8 @@
     ".gitignore": {
       "src": ".gitignore",
       "dest": ".gitignore",
-      "sha": "56d6f2bd57638b75e64839dbb3ee5988dab5c975",
-      "size": 2595
+      "sha": "445e3c172760d25e3a400fcb387b004c6fc31bfd",
+      "size": 2609
     },
     "LICENSE": {
       "src": "LICENSE",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.