### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-21T19:03:46Z",
-  "source_commit": "9401d1a9086658daf2971b1a2c47c99d771d1725",
+  "generated_at": "2026-07-22T02:07:37Z",
+  "source_commit": "82bd7b64993fa1cc99030fa8e97d1141a72fea64",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,14 +65,14 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "946cb358d92e95756b8e02fc46f5e40cdf937a68",
-      "size": 15439
+      "sha": "3cb0f832495066d20b7602ac027cbf336399a22d",
+      "size": 16969
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "ffc4a9b2112edd430516f9344e6d7d3cf48fa6fd",
-      "size": 2811
+      "sha": "559fb0fdb7021f5443250405fd72c72841a6b23a",
+      "size": 3865
     },
     ".editorconfig": {
       "src": ".editorconfig",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.