### PR TITLE
feat(governance): add git-worktree default (worktree.baseRef + CLAUDE.md guidance)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "worktree": {
+    "baseRef": "fresh"
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.
 - The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. See CONTRIBUTING.md.
 
+## Worktrees
+
+- For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.
+- New worktrees branch fresh from the default branch (`worktree.baseRef` is set to `fresh` in `.claude/settings.json`). The `.claude/worktrees/` directory is already gitignored.
+- If a repository's build needs gitignored inputs (`.env`, secrets, local config), add a repo-local `.worktreeinclude` listing them so new worktrees carry those files in.
+
 ## Engineering Standards
 
 Apply where applicable to this repo:


### PR DESCRIPTION
## Summary

Governs a git-worktree default for the fleet by editing two managed files that redistribute to all downstream repos:

- **`.claude/settings.json`** — add `"worktree": { "baseRef": "fresh" }` (new worktrees branch from `origin/<default-branch>`).
- **`CLAUDE.md`** — add a `## Worktrees` section documenting the convention (prefer a worktree for non-trivial coding tasks; `.claude/worktrees/` already gitignored; optional repo-local `.worktreeinclude` for gitignored build inputs).

No `.gitignore` change — worktree dirs are already ignored. `.worktreeinclude` is intentionally left per-repo (not governed) since its contents differ per repo.

## Testing

- `.claude/settings.json` valid JSON; `biome check` passed.
- `CLAUDE.md` markdownlint passed.
- `pre-commit run --files CLAUDE.md .claude/settings.json` — all hooks passed (governance, biome, markdown, spelling, editorconfig, secrets).

After merge: `Build Managed Files Manifest` → `Dispatch Downstream Enforcement` → downstream `governance/sync-managed-files` PRs propagate to all 38 repos (those not skipping these files).

## Checklist
- [x] Linked to a GitHub issue (Closes #733)
- [x] Tested locally
- [x] Follows project conventions

Closes #733