### PR TITLE
fix(ci): annotate justified pull_request_target in synced caller templates

### DIFF
--- a/workflows/dependabot-auto-merge.yml
+++ b/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,12 @@
 ---
 name: Dependabot Auto-Merge
 
-on: pull_request_target
+on:
+  # zizmor: ignore[dangerous-triggers] — Dependabot PRs get a read-only token under
+  # `pull_request`, so pull_request_target is required to approve and merge them.
+  # Gated to actor == dependabot[bot]; the caller only dispatches the reusable
+  # workflow — no PR-code checkout or exec.
+  pull_request_target:
 
 permissions:
   contents: write

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -2,6 +2,10 @@
 name: Require Linked Issue
 
 on:
+  # zizmor: ignore[dangerous-triggers] — this caller needs pull-requests:write on
+  # fork PRs so the required linked-issue check can post its status/comment; a plain
+  # `pull_request` gives forks a read-only token and the required check deadlocks.
+  # The caller only dispatches the reusable workflow — no PR-code checkout or exec.
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 


### PR DESCRIPTION
## Summary

Fixes a fleet-wide pre-existing `zizmor` finding: the caller templates synced to every consumer repo triggered on `pull_request_target` **without** the justified `# zizmor: ignore[dangerous-triggers]` annotation that docs-control's own `.github/workflows/` reusables already carry. docs-control itself passed zizmor, but every consumer (e.g. code-review) tripped **2 HIGH** findings on any workflow change.

`pull_request_target` is required on both callers (fork/dependabot PRs get a read-only token under `pull_request`, deadlocking the required linked-issue status and the dependabot approve/merge). Neither caller checks out or executes PR code — they only dispatch the reusable workflow. Added the justified ignore + rationale to both templates; triggers/behavior unchanged.

## Files

- `workflows/require-linked-issue.yml`
- `workflows/dependabot-auto-merge.yml`

## Verification

- `zizmor --config zizmor.yaml` → **No findings** on both (2 ignored).
- `actionlint` clean; YAML valid; triggers unchanged.
- Propagates to consumers via governance sync.

Closes #738
