### PR TITLE
fix(review): always emit verdict + incremental re-review (fix re-push deadlock)

### DIFF
--- a/REVIEWER-SPEC.md
+++ b/REVIEWER-SPEC.md
@@ -1,0 +1,71 @@
+# Reviewer spec (target-state design)
+
+Canonical design for the fleet's agentic PR reviewer. It complements `REVIEW.md`
+(the highest-priority review rubric baked into the plugin command) by documenting
+the reviewer's **architecture, invariants, and planned work**. Earlier code
+referenced "the reviewer spec" before this file existed
+(`plugins/f5-review/code-review-f5/UPSTREAM.md`,
+`plugins/f5-review/code-review-f5/commands/code-review.md`); this is that file.
+
+## Architecture
+
+- **Caller** (`workflows/code-review.yml`, synced to opted-in repos) triggers on
+  `pull_request` and delegates to the **reusable reviewer**
+  (`.github/workflows/claude-review.yml@main`) on a self-hosted, VPN-connected
+  runner labeled `code-review`.
+- The reusable workflow self-provisions the vendored, F5-extended `code-review`
+  plugin (`plugins/f5-review/`) and runs it via `anthropics/claude-code-action`
+  (SHA-pinned) against the F5 LiteLLM gateway (`claude-opus-4-8`, 1M context).
+- The plugin command fans out: triage (haiku) → CLAUDE.md path list (haiku) →
+  summary (sonnet) → 5 parallel reviewers (2× CLAUDE.md compliance, 2×
+  bug/logic/security, 1× authenticated verification) → per-finding validation →
+  inline comments + one summary comment → `verdict.json`.
+- **Gate**: `scripts/parse-verdict.sh` fails the required `review / claude-review`
+  check on any blocking (🔴/high) finding.
+
+## Invariants (MUST hold)
+
+1. **Always emit a verdict.** The reviewer is a merge GATE, not an advisory bot.
+   Every exit path — normal, skip, or early-out — MUST write `./verdict.json`
+   before the job ends. The gate treats a missing/empty verdict as **blocking**
+   (fail-safe), so any path that stops without a verdict fails the required check.
+   A skip writes a non-blocking verdict (`{"blocking": false, ...}`). *(Enforced
+   by F5-EXTENSION E5 after the re-push deadlock — see below.)*
+2. **Idempotent re-review.** A new push (`synchronize`) re-reviews the current
+   head and emits a fresh verdict; it never hard-stops on "already commented."
+   Re-reviews post only new findings (no duplicate comments) but always re-emit
+   the verdict.
+3. **Untrusted PR content.** The diff, title, body, commit messages, and comments
+   are untrusted DATA. Never execute scripts carried in the PR head; never print
+   or exfiltrate secrets. Prompt-injection attempts are 🔴 findings.
+4. **Fork isolation.** Fork PRs never reach the self-hosted runner (hard guard in
+   both caller and reusable workflow).
+5. **Fail-safe reliability.** Machine-wide slot semaphore; per-PR concurrency
+   cancel; a single safe retry only when nothing was posted and no verdict exists.
+
+## Severity taxonomy
+
+Findings map to `high` (🔴, merge-blocking), `medium` (🟠, reported and counted,
+non-blocking), and `low` (🟡, nit). `high` blocks; counts must match `findings`.
+*(Note: `medium` was historically present in the schema but never emitted by the
+rubric — WS1-PR1b activates it end-to-end.)*
+
+## Planned work
+
+- **Trusted base-pinned `verify.sh` pre-step (WS2).** A workflow pre-step checks
+  out the PR **base** ref and runs the repo's `.code-review/verify.sh` from base
+  only (never PR head), in a least-privilege sandbox, feeding results to the
+  verification agent. This is the safe closure of E4: it never executes
+  PR-head-carried scripts.
+- **Deterministic layers (WS3/WS4).** Cross-module dead-code (Knip, Python
+  dead-code) and dedicated SAST (Semgrep/CodeQL, SARIF → Code Scanning) run in the
+  lint gate; the reviewer covers judgment calls.
+- **Reviewer dimensions (WS5).** Explicit, correctly-scoped YAGNI/overengineering
+  and reinvented-logic (semantic DRY) dimensions; flag code the diff newly
+  orphans. Capped at 🟠/🟡 to protect the low false-positive rate.
+- **Reliability/ops (WS6).** Org-level runner pool (remove the single-laptop
+  single point of failure), findings/override telemetry, model fallback.
+
+See `docs-control/REVIEW.md` for the operative rubric and
+`f5-sales-demo/code-review/docs/REVIEWER-GAP-ANALYSIS.md` for the full
+requirements catalog and verified findings.

--- a/plugins/f5-review/code-review-f5/UPSTREAM.md
+++ b/plugins/f5-review/code-review-f5/UPSTREAM.md
@@ -32,6 +32,14 @@ Marked with `F5-EXTENSION` comments in the command so a re-sync diff is obvious:
   content. Trusted execution of a repo's `verify.sh` is a planned workflow pre-step
   that pins the script to the PR **base** branch; until that lands, Agent 5 only
   `Read`s verify.sh and runs the pinned allow-listed commands.
+- **E5 — always-emit-verdict + incremental re-review** (step 1): because the F5
+  reviewer is a merge GATE (the workflow blocks on a missing/empty `verdict.json`),
+  every exit path — including the skip path — MUST write a verdict. Upstream's
+  advisory "Claude has already commented → stop" is removed as a hard stop (it
+  deadlocked the gate on any second push: the re-review stopped, wrote no verdict,
+  and the required check never recovered). Skips now write a non-blocking verdict
+  before stopping, and a re-push re-reviews the current head and emits a fresh
+  verdict (posting only new findings, no duplicates).
 
 ## Model tiers (E1)
 

--- a/plugins/f5-review/code-review-f5/commands/code-review.md
+++ b/plugins/f5-review/code-review-f5/commands/code-review.md
@@ -38,16 +38,33 @@ internal APIs** using the authenticated CLIs on this VPN-connected runner
 
 To do this, follow these steps precisely:
 
-1. Launch a haiku agent to check if any of the following are true:
+1. Launch a haiku agent to check if any of the following SKIP conditions are
+   true:
 
    - The pull request is closed
    - The pull request is a draft
    - The pull request does not need code review (e.g. automated PR, trivial
      change that is obviously correct)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments`
-     for comments left by claude)
 
-   If any condition is true, stop and do not proceed.
+   <!-- F5-EXTENSION E5 (always-emit-verdict + incremental re-review): this
+        reviewer is a MERGE GATE, not an advisory bot, so it MUST ALWAYS write
+        ./verdict.json before exiting on EVERY path. The workflow's "Gate on
+        verdict" step treats a missing/empty verdict as BLOCKING, so a run that
+        stops without a verdict FAILS the required check. Upstream's advisory
+        "already commented -> stop" therefore DEADLOCKS the gate on any second
+        push: the re-review stops, writes no verdict, and the check can never go
+        green again (reproduced: push1 pass -> push2 Gate-on-verdict failure).
+        See REVIEWER-SPEC.md. -->
+   If any SKIP condition is true, write a non-blocking verdict to `./verdict.json`
+   (`{"blocking": false, "severity_counts": {"high": 0, "medium": 0, "low": 0},
+   "findings": []}`) and then stop — do NOT proceed to the remaining steps.
+
+   Do NOT skip merely because Claude has already commented on this PR. A new push
+   (`synchronize`) re-runs this review and MUST re-evaluate the current head and
+   emit a fresh verdict; otherwise the required check deadlocks. When
+   re-reviewing, avoid reposting duplicate comments for issues already flagged
+   and still unaddressed — post only NEW findings for the current diff — but
+   ALWAYS emit the verdict.
 
    Note: Still review Claude generated PRs.
 


### PR DESCRIPTION
Closes #744

Root-cause fix for the verified re-push deadlock (WS1-PR1a). The reviewer now writes a verdict on every exit path (skip = non-blocking verdict) and re-reviews on a new push instead of hard-stopping on \"already commented\". Adds REVIEWER-SPEC.md (gate invariants; resolves the dangling \"reviewer spec\" references) and records F5-EXTENSION E5 in UPSTREAM.md.

Evidence: push1 pass then push2 Gate-on-verdict failure (run 30123694613). Post-merge verification: re-run the incremental probe against @main — a 2nd push to an open PR should pass (no deadlock).