### PR TITLE
feat(review): YAGNI, semantic-DRY, and orphaned-code review dimensions

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -38,6 +38,24 @@ break is certain.
 Style/naming/refactor suggestions are 🟡 Nit at most. Report at most five nits;
 summarize the rest as "plus N similar items".
 
+## Additional review dimensions (🟠 Medium or 🟡 Nit only — never 🔴)
+
+Also look for the following, but only when you are confident (validate first —
+false positives here erode trust). Never let these block the merge:
+
+- **Newly-orphaned code** — code the change makes unreachable or unused (a
+  function, export, or file no longer referenced after this diff). Confirm it is
+  genuinely unreferenced in the repo before flagging.
+- **Reinvented logic (DRY)** — new code that reimplements an existing repo
+  utility or helper instead of reusing it. Name the existing symbol and its path
+  so the author can reuse it.
+- **YAGNI / overengineering** — speculative generality: abstraction, config
+  surface, or features built for needs not present in this change or its linked
+  issue. Scope tightly: do NOT flag tests, security or error-handling baselines,
+  or genuine interface boundaries, and a single concrete caller is not
+  "premature". Flag only when the extra machinery materially raises the
+  maintenance burden; prefer 🟡 unless it clearly does.
+
 ## Do not report
 
 - Anything CI already enforces (lint, formatting, type errors).

--- a/REVIEWER-SPEC.md
+++ b/REVIEWER-SPEC.md
@@ -60,11 +60,27 @@ rubric — WS1-PR1b activates it end-to-end.)*
 - **Deterministic layers (WS3/WS4).** Cross-module dead-code (Knip, Python
   dead-code) and dedicated SAST (Semgrep/CodeQL, SARIF → Code Scanning) run in the
   lint gate; the reviewer covers judgment calls.
-- **Reviewer dimensions (WS5).** Explicit, correctly-scoped YAGNI/overengineering
-  and reinvented-logic (semantic DRY) dimensions; flag code the diff newly
-  orphans. Capped at 🟠/🟡 to protect the low false-positive rate.
 - **Reliability/ops (WS6).** Org-level runner pool (remove the single-laptop
   single point of failure), findings/override telemetry, model fallback.
+
+Implemented since: **WS5 reviewer dimensions** — correctly-scoped
+YAGNI/overengineering, reinvented-logic (semantic DRY), and newly-orphaned-code
+checks, capped at 🟠/🟡 (see `REVIEW.md`).
+
+## Known residual risks
+
+- **Branch-prefix bypass (accepted, documented).** Genuine automated branches
+  (`governance/`, `sync/`, `release/`, `openapi-sync/`, `plugin-sync/`, `deps/`,
+  `docs/update-`, `auto-*`, `autoresearch/`) skip the real review and get a
+  synthetic passing status, because they are created by human-owned automation
+  PATs (so `github.actor` is a human and cannot be distinguished from a person
+  naming a branch with one of those prefixes). RESIDUAL RISK: a write-access
+  contributor could bypass the required review by using such a prefix. Mitigated
+  today by trusted-write-access + the fork hard-guard. Full closure needs an
+  org-level branch-creation ruleset restricting who may push those prefixes, or a
+  dedicated automation App/bot identity so the bypass keys on actor, not branch
+  name — deferred as an org-admin decision (see caller `workflows/code-review.yml`
+  comments).
 
 See `docs-control/REVIEW.md` for the operative rubric and
 `f5-sales-demo/code-review/docs/REVIEWER-GAP-ANALYSIS.md` for the full

--- a/plugins/f5-review/code-review-f5/commands/code-review.md
+++ b/plugins/f5-review/code-review-f5/commands/code-review.md
@@ -35,6 +35,20 @@ internal APIs** using the authenticated CLIs on this VPN-connected runner
   🟠, choose 🟠 — only block when the break is certain.
 - Everything else is 🟡 Nit at most; report at most five nits.
 
+**Additional review dimensions (report as 🟠 Medium or 🟡 Nit only — never 🔴,
+and only when confident; validate before flagging):**
+
+- **Newly-orphaned code** — flag code this diff makes unreachable or unused (a
+  function/export/file no longer referenced after the change). Confirm it is
+  genuinely unreferenced in the repo before flagging.
+- **Reinvented logic (DRY)** — flag new code that duplicates an existing repo
+  utility/helper instead of reusing it; name the existing symbol and its path.
+- **YAGNI / overengineering** — flag speculative generality (abstraction, config
+  surface, or features built for needs not present in this change or its linked
+  issue). Scope tightly: do NOT flag tests, security/error-handling baselines, or
+  genuine interface boundaries, and a single concrete caller is not "premature".
+  Flag only when the extra machinery materially raises maintenance burden.
+
 **Agent assumptions (applies to all agents and subagents):**
 
 - All tools are functional and will work without error. Do not test tools or


### PR DESCRIPTION
Closes #748

WS5: adds correctly-scoped YAGNI/overengineering, reinvented-logic (semantic DRY), and newly-orphaned-code dimensions (🟠/🟡 only, never blocking; validate-before-flag to protect the low FP rate). Documents the deferred branch-prefix bypass residual risk (PR1c) in REVIEWER-SPEC.md.