### PR TITLE
fix(review): scope retry classifier to the reviewer's own comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -88,9 +88,11 @@ jobs:
           R: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          issue=$(gh api "repos/$R/issues/$PR/comments" --jq 'length' 2>/dev/null || echo 0)
-          rev=$(gh api "repos/$R/pulls/$PR/comments" --jq 'length' 2>/dev/null || echo 0)
-          echo "count=$((issue + rev))" >> "$GITHUB_OUTPUT"
+          ic="$(mktemp)"; pc="$(mktemp)"
+          gh api "repos/$R/issues/$PR/comments" >"$ic" 2>/dev/null || echo '[]' >"$ic"
+          gh api "repos/$R/pulls/$PR/comments" >"$pc" 2>/dev/null || echo '[]' >"$pc"
+          count=$(bash .review-tooling/scripts/reviewer-comment-count.sh "$ic" "$pc")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
 
       # === Claude review — ATTEMPT 1 ===
       # continue-on-error so a transient failure does not end the job before the
@@ -149,9 +151,10 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           BASELINE: ${{ steps.baseline.outputs.count }}
         run: |
-          issue=$(gh api "repos/$R/issues/$PR/comments" --jq 'length' 2>/dev/null || echo 0)
-          rev=$(gh api "repos/$R/pulls/$PR/comments" --jq 'length' 2>/dev/null || echo 0)
-          current=$((issue + rev))
+          ic="$(mktemp)"; pc="$(mktemp)"
+          gh api "repos/$R/issues/$PR/comments" >"$ic" 2>/dev/null || echo '[]' >"$ic"
+          gh api "repos/$R/pulls/$PR/comments" >"$pc" 2>/dev/null || echo '[]' >"$pc"
+          current=$(bash .review-tooling/scripts/reviewer-comment-count.sh "$ic" "$pc")
           verdict_present=0
           [ -s verdict.json ] && verdict_present=1
           decision=$(bash .review-tooling/scripts/review-retry-decision.sh decide "$BASELINE" "$current" "$verdict_present")

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -220,6 +220,10 @@ jobs:
         if: hashFiles('tests/test-claude-review-retry.sh') != ''
         run: bash tests/test-claude-review-retry.sh
 
+      - name: Run reviewer-comment-count test
+        if: hashFiles('tests/test-reviewer-comment-count.sh') != ''
+        run: bash tests/test-reviewer-comment-count.sh
+
       - name: Run protect-managed-files hook test
         if: hashFiles('tests/test-protect-managed-files.sh') != ''
         run: bash tests/test-protect-managed-files.sh

--- a/scripts/reviewer-comment-count.sh
+++ b/scripts/reviewer-comment-count.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# reviewer-comment-count.sh — count ONLY the Claude reviewer's own comments
+# (its one summary comment + its inline review comments) on a PR.
+#
+#   reviewer-comment-count.sh <issue-comments.json> <pull-comments.json>
+#     -> echoes a single integer (0 on unreadable/malformed input)
+#
+# Each argument is a file holding the JSON array returned by the GitHub
+# comments API (issues/{pr}/comments and pulls/{pr}/comments respectively).
+#
+# WHY scoped to the reviewer: the retry classifier (review-retry-decision.sh)
+# compares a BEFORE vs AFTER comment count to tell a pre-posting failure (safe to
+# retry) from a partial review (already posted — do not retry). If it counted
+# EVERY comment, a comment posted by another actor DURING the review window — the
+# super-linter summary (also github-actions[bot]), dependabot, or a human — would
+# inflate the AFTER count and misclassify a clean pre-posting failure as a
+# "partial review", failing the check spuriously. Counting only the reviewer's
+# own comments removes that coupling.
+#
+# Identity: the reviewer posts via the workflow GITHUB_TOKEN, so its author is
+# github-actions[bot] — but so is super-linter's summary, so author alone is not
+# enough for issue comments. The reviewer's summary is matched by content
+# markers ("Code review" / "No issues found" / a severity emoji); super-linter's
+# summary ("Super-linter summary", ✅/❌) matches none of them. Inline review
+# comments are posted only by the reviewer among bots, so for pull comments the
+# bot-author filter suffices.
+set -euo pipefail
+
+issues_json="${1:?usage: reviewer-comment-count.sh <issue-comments.json> <pull-comments.json>}"
+pulls_json="${2:?usage: reviewer-comment-count.sh <issue-comments.json> <pull-comments.json>}"
+
+BOT="github-actions[bot]"
+# Markers that identify the reviewer's summary issue-comment (see REVIEW.md /
+# the plugin command summary template). Kept broad enough to match both the
+# "no issues" summary and the severity-table summary.
+MARKER='Code review|No issues found|🔴|🟠|🟡'
+
+count_issue=$(jq --arg b "$BOT" --arg m "$MARKER" \
+  '[.[] | select((.user.login // "") == $b and ((.body // "") | test($m)))] | length' \
+  "$issues_json" 2>/dev/null || echo 0)
+
+count_pull=$(jq --arg b "$BOT" \
+  '[.[] | select((.user.login // "") == $b)] | length' \
+  "$pulls_json" 2>/dev/null || echo 0)
+
+# Guard against non-numeric (malformed input -> 0, fail toward "nothing posted").
+[[ "$count_issue" =~ ^[0-9]+$ ]] || count_issue=0
+[[ "$count_pull" =~ ^[0-9]+$ ]] || count_pull=0
+echo $((count_issue + count_pull))

--- a/tests/test-reviewer-comment-count.sh
+++ b/tests/test-reviewer-comment-count.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/reviewer-comment-count.sh — the reviewer-scoped
+# comment counter feeding the retry classifier. Proves that comments from other
+# actors (super-linter summary, dependabot, humans) are NOT counted, so a
+# concurrent comment cannot misclassify a pre-posting failure as a partial
+# review. No network.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/reviewer-comment-count.sh"
+BOT="github-actions[bot]"
+
+FAIL=0
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+w() {
+  printf '%s' "$2" >"$WORK/$1"
+  echo "$WORK/$1"
+}
+
+assert_eq() { # <label> <expected> <issues.json> <pulls.json>
+  local got
+  got=$(bash "$SCRIPT" "$3" "$4" 2>/dev/null || echo "ERR")
+  if [ "$got" = "$2" ]; then echo "[OK] $1 → $got"; else
+    echo "[FAIL] $1 — expected $2, got $got"
+    FAIL=1
+  fi
+}
+
+EMPTY=$(w empty.json '[]')
+
+# The bug scenario: only a super-linter summary + a human comment exist (both
+# NOT the reviewer). The reviewer has posted nothing → count MUST be 0.
+NON_REVIEWER=$(w nonrev.json "$(
+  cat <<JSON
+[
+  {"user":{"login":"$BOT"},"body":"<!-- super-linter-summary-comment -->\n# Super-linter summary\n| CHECKOV | Pass ✅ |"},
+  {"user":{"login":"a-human"},"body":"Looks good, but consider X"}
+]
+JSON
+)")
+assert_eq "non-reviewer issue comments not counted (bug scenario)" 0 "$NON_REVIEWER" "$EMPTY"
+
+# Reviewer summary present alongside super-linter + human → exactly 1.
+WITH_SUMMARY=$(w withsum.json "$(
+  cat <<JSON
+[
+  {"user":{"login":"$BOT"},"body":"<!-- super-linter-summary-comment -->\n# Super-linter summary"},
+  {"user":{"login":"$BOT"},"body":"## Code review\n\nNo issues found. Checked for bugs, CLAUDE.md compliance, and authenticated verification."},
+  {"user":{"login":"a-human"},"body":"thanks"}
+]
+JSON
+)")
+assert_eq "reviewer summary counted, others excluded" 1 "$WITH_SUMMARY" "$EMPTY"
+
+# Severity-table summary (emoji marker) also counts.
+EMOJI_SUMMARY=$(w emoji.json "$(
+  cat <<JSON
+[
+  {"user":{"login":"$BOT"},"body":"## Code review\n\n| Severity | Count |\n| 🔴 | 1 |"}
+]
+JSON
+)")
+assert_eq "emoji severity summary counted" 1 "$EMOJI_SUMMARY" "$EMPTY"
+
+# Inline (pull) comments: reviewer bot comments counted, human inline excluded.
+PULLS=$(w pulls.json "$(
+  cat <<JSON
+[
+  {"user":{"login":"$BOT"},"body":"🔴 incorrect logic here"},
+  {"user":{"login":"$BOT"},"body":"🟡 nit: rename"},
+  {"user":{"login":"a-human"},"body":"I disagree"}
+]
+JSON
+)")
+assert_eq "reviewer inline counted, human inline excluded" 2 "$EMPTY" "$PULLS"
+
+# Combined: 1 summary + 2 inline = 3.
+assert_eq "combined summary + inline" 3 "$WITH_SUMMARY" "$PULLS"
+
+# Malformed input → 0 (fail toward "nothing posted").
+BAD=$(w bad.json '{not json')
+assert_eq "malformed issues → 0" 0 "$BAD" "$EMPTY"
+
+# Missing pulls file tolerated: summary still counts (1), missing file → 0 pulls.
+assert_eq "missing pulls file tolerated (summary=1)" 1 "$WITH_SUMMARY" "$WORK/does-not-exist.json"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "reviewer-comment-count tests FAILED"
+  exit 1
+fi
+echo "reviewer-comment-count tests passed"


### PR DESCRIPTION
Closes #750

Fixes a reliability bug where a concurrent comment from another actor (super-linter summary, dependabot, human) during the review window misclassified a transient attempt-1 failure as a partial review and failed the check spuriously (observed on i18n-core #190). Extracts a reviewer-scoped comment counter + hermetic test.