### PR TITLE
fix(ci): least-privilege secret passing in managed callers (drop secrets: inherit)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,7 +8,14 @@ name: Auto-Merge
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
+  # Declared so callers can pass REPO_SYNC_TOKEN EXPLICITLY instead of
+  # `secrets: inherit` (least privilege — the caller hands over one secret, not
+  # every repository secret). `required: false` preserves the documented
+  # REPO_SYNC_TOKEN || GITHUB_TOKEN fallback for repos without the PAT.
   workflow_call:
+    secrets:
+      REPO_SYNC_TOKEN:
+        required: false
 
 permissions:
   contents: write

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -20,4 +20,9 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
     uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@main
-    secrets: inherit
+    # Least privilege: pass ONLY the secret the reusable needs, not every
+    # repository secret (`secrets: inherit`). REPO_SYNC_TOKEN is the PAT that lets
+    # an auto-merge trigger downstream workflows; the reusable falls back to
+    # GITHUB_TOKEN when it is unset, so repos without the PAT still work.
+    secrets:
+      REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}

--- a/workflows/dependabot-auto-merge.yml
+++ b/workflows/dependabot-auto-merge.yml
@@ -15,5 +15,6 @@ permissions:
 jobs:
   call:
     if: github.actor == 'dependabot[bot]'
+    # No `secrets:` — least privilege. The reusable uses only the automatic
+    # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@main
-    secrets: inherit

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -19,5 +19,7 @@ concurrency:
 
 jobs:
   check:
+    # No `secrets:` — least privilege. The reusable uses only the automatic
+    # GITHUB_TOKEN (always available to a called workflow), so passing repository
+    # secrets would hand over more than it needs.
     uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
-    secrets: inherit

--- a/workflows/super-linter.yml
+++ b/workflows/super-linter.yml
@@ -18,5 +18,6 @@ concurrency:
 
 jobs:
   lint:
+    # No `secrets:` — least privilege. The reusable uses only the automatic
+    # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main
-    secrets: inherit


### PR DESCRIPTION
Closes #754

Fixes the fleet-wide least-privilege violation surfaced by the Semgrep SAST pilot (4 error-severity `secrets-inherit` alerts).

- **require-linked-issue / dependabot-auto-merge / super-linter** — verified they reference no secrets beyond the auto-provided `GITHUB_TOKEN`, so `secrets: inherit` is dropped outright.
- **auto-merge** — genuinely needs `REPO_SYNC_TOKEN`, so it is now declared as an **optional** `workflow_call` secret and passed explicitly. `required: false` preserves the `REPO_SYNC_TOKEN || GITHUB_TOKEN` fallback (repos without the PAT keep working) and the dual-mode direct-trigger path is unchanged — important, since a silently-empty token would downgrade merges to GITHUB_TOKEN and break auto-merge via recursion prevention.

actionlint + zizmor + yamllint clean. **This PR self-tests the merge path**: it must auto-merge using the updated auto-merge workflow.