### PR TITLE
fix(governance): always gate governed reads on Pages freshness (fixes silent drift-detection pass)

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -146,6 +146,28 @@ jobs:
             [ "$pages_sha" = "$source_sha" ]
           }
 
+          # Gate governed reads on Pages freshness. `fetch_governed` prefers the
+          # Pages-published governance mirror, which lags a docs-control merge by
+          # however long its deploy takes; reading a stale mirror means enforcing
+          # OUTDATED settings (and previously `revision_is_fresh` was defined here
+          # but never called, so this workflow had no staleness guard at all).
+          # Prefer the dispatching push's sha; otherwise use docs-control main HEAD.
+          expected_source_sha="${SOURCE_SHA:-}"
+          if [ -z "$expected_source_sha" ]; then
+            expected_source_sha=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha' 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$expected_source_sha" ]; then
+            echo "[WARN] Could not determine docs-control main HEAD — using API for governed reads" >&2
+            PAGES_BASE="https://invalid.pages.local"
+          elif ! revision_is_fresh "$expected_source_sha"; then
+            echo "[WARN] Pages revision lags source ${expected_source_sha:0:8} — this run will fall back to API for governed reads" >&2
+            PAGES_BASE="https://invalid.pages.local"
+          else
+            echo "[OK] Pages governance mirror is fresh at ${expected_source_sha:0:8}"
+          fi
+
           OWNER="${GITHUB_REPOSITORY_OWNER}"
           REPO="${GITHUB_REPOSITORY#*/}"
           CONFIG_REPO="${GITHUB_REPOSITORY_OWNER}/docs-control"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -224,6 +224,10 @@ jobs:
         if: hashFiles('tests/test-reviewer-comment-count.sh') != ''
         run: bash tests/test-reviewer-comment-count.sh
 
+      - name: Run pages-staleness-guard test
+        if: hashFiles('tests/test-pages-staleness-guard.sh') != ''
+        run: bash tests/test-pages-staleness-guard.sh
+
       - name: Run protect-managed-files hook test
         if: hashFiles('tests/test-protect-managed-files.sh') != ''
         run: bash tests/test-protect-managed-files.sh

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -117,6 +117,11 @@ jobs:
             printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
           }
 
+          # Freshness of the Pages-published governance mirror. When a source_sha is
+          # supplied (dispatch from a docs-control push) we require an EXACT match.
+          # Otherwise (schedule / manual workflow_dispatch, where source_sha is
+          # empty) we compare Pages' own revision marker against docs-control's live
+          # main HEAD — see expected_source_sha below.
           revision_is_fresh() {
             local source_sha="${1:-}" rev pages_sha
             [ -z "$source_sha" ] && return 1
@@ -129,13 +134,34 @@ jobs:
             [ "$pages_sha" = "$source_sha" ]
           }
 
-          # SOURCE_SHA is set via step env: above; empty when dispatch
-          # doesn't pass --field source_sha (current default until the
-          # downstream shim update propagates to all 25 repos).
-          if [ -n "${SOURCE_SHA:-}" ] && ! revision_is_fresh "$SOURCE_SHA"; then
-            echo "[WARN] Pages revision lags source ${SOURCE_SHA:0:8} — this run will fall back to API for governed reads" >&2
+          # The sha the Pages mirror must have published for governed reads to be
+          # trustworthy. Prefer the dispatching push's sha; when absent, fall back
+          # to docs-control's current main HEAD.
+          #
+          # WHY this must not be conditional on SOURCE_SHA: `fetch_governed` prefers
+          # the Pages mirror, and Pages lags a merge by however long its deploy
+          # takes. Previously the staleness check ran ONLY when SOURCE_SHA was
+          # non-empty, so schedule/manual runs (source_sha empty) silently read a
+          # STALE manifest. Drift detection then compared downstream files against
+          # OLD canonical SHAs, matched them, and reported "[OK] All managed files
+          # match canonical" — so governance changes never propagated and no sync PR
+          # was opened. Observed: a run read a manifest from a 1-day-old commit and
+          # passed four caller templates that had genuinely drifted.
+          expected_source_sha="${SOURCE_SHA:-}"
+          if [ -z "$expected_source_sha" ]; then
+            expected_source_sha=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha' 2>/dev/null || echo "")
+          fi
+
+          if [ -z "$expected_source_sha" ]; then
+            echo "[WARN] Could not determine docs-control main HEAD — using API for governed reads" >&2
+            PAGES_BASE="https://invalid.pages.local"
+          elif ! revision_is_fresh "$expected_source_sha"; then
+            echo "[WARN] Pages revision lags source ${expected_source_sha:0:8} — this run will fall back to API for governed reads" >&2
             # Force fallback by making Pages calls error.
             PAGES_BASE="https://invalid.pages.local"
+          else
+            echo "[OK] Pages governance mirror is fresh at ${expected_source_sha:0:8}"
           fi
 
           OWNER="${GITHUB_REPOSITORY_OWNER}"

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Hermetic regression test for the Pages-freshness guard in the governed-read
+# workflows (sync-managed-files.yml, enforce-repo-settings.yml).
+#
+# WHY: `fetch_governed` prefers the Pages-published governance mirror, which lags a
+# docs-control merge by however long its deploy takes. The guard must force an API
+# fallback whenever Pages is behind. It previously ran ONLY when a source_sha was
+# passed, so schedule/manual runs read a STALE manifest and drift detection reported
+# "[OK] All managed files match canonical" for files that had genuinely drifted —
+# governance changes silently never propagated. enforce-repo-settings.yml defined
+# revision_is_fresh but never called it at all.
+#
+# This test locks two properties, statically (no network):
+#   1. Both workflows CALL the guard, and do so UNCONDITIONALLY on SOURCE_SHA
+#      (i.e. an empty source_sha must still be checked, via a main-HEAD fallback).
+#   2. The revision_is_fresh comparison semantics stay exact-match.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+FAIL=0
+
+WORKFLOWS=(
+  "${REPO_ROOT}/.github/workflows/sync-managed-files.yml"
+  "${REPO_ROOT}/.github/workflows/enforce-repo-settings.yml"
+)
+
+ok() { echo "[OK] $1"; }
+bad() {
+  echo "[FAIL] $1"
+  FAIL=1
+}
+
+for wf in "${WORKFLOWS[@]}"; do
+  name=$(basename "$wf")
+
+  # 1. The guard must actually be invoked, not merely defined.
+  if grep -qE '^\s*(elif ! |if ! )?revision_is_fresh "' "$wf"; then
+    ok "$name calls revision_is_fresh"
+  else
+    bad "$name never calls revision_is_fresh (guard defined but unused = no protection)"
+  fi
+
+  # 2. The invocation must NOT be gated on a non-empty SOURCE_SHA. The old bug was
+  #    `if [ -n "${SOURCE_SHA:-}" ] && ! revision_is_fresh ...`, which skipped the
+  #    check entirely on schedule/manual runs.
+  if grep -qE '\[ -n "\$\{SOURCE_SHA:-\}" \][[:space:]]*&&[[:space:]]*! revision_is_fresh' "$wf"; then
+    bad "$name gates the freshness check on a non-empty SOURCE_SHA (stale reads on schedule/manual runs)"
+  else
+    ok "$name does not gate the freshness check on SOURCE_SHA"
+  fi
+
+  # 3. There must be a fallback that resolves the expected sha when SOURCE_SHA is
+  #    empty (docs-control main HEAD), so the guard has something to compare.
+  if grep -q 'expected_source_sha' "$wf" &&
+    grep -qE 'docs-control/commits/main' "$wf"; then
+    ok "$name resolves docs-control main HEAD when source_sha is empty"
+  else
+    bad "$name has no main-HEAD fallback for the expected sha"
+  fi
+
+  # 4. A failed/indeterminate freshness check must force the API fallback by
+  #    poisoning PAGES_BASE (that is how fetch_governed is made to error).
+  if grep -q 'PAGES_BASE="https://invalid.pages.local"' "$wf"; then
+    ok "$name forces API fallback when Pages is stale"
+  else
+    bad "$name does not force an API fallback on stale Pages"
+  fi
+
+  # 5. Freshness must be an EXACT sha match (no prefix/substring comparison).
+  if grep -qE '\[ "\$pages_sha" = "\$source_sha" \]' "$wf"; then
+    ok "$name compares pages_sha to source_sha exactly"
+  else
+    bad "$name freshness comparison is not an exact sha match"
+  fi
+done
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "pages-staleness-guard tests FAILED"
+  exit 1
+fi
+echo "pages-staleness-guard tests passed"


### PR DESCRIPTION
Closes #757

## Root cause
Governed reads (`fetch_governed`) prefer the Pages-published governance mirror, which lags a docs-control merge by its deploy time. The freshness guard was absent on the paths that matter:

- **`sync-managed-files.yml`** ran the check only when a `source_sha` was passed (`[ -n "${SOURCE_SHA:-}" ] && ! revision_is_fresh ...`). On `schedule` and manual `workflow_dispatch` (source_sha empty) it was **skipped entirely**, so the run read a **stale manifest**, compared downstream files against **old** canonical SHAs, matched them, and printed `[OK] All managed files match canonical`. Result: **no governance change ever propagated** and no sync PR was opened.
- **`enforce-repo-settings.yml`** *defined* `revision_is_fresh` but **never called it** — no staleness guard at all, so it could enforce outdated settings.

## Fix
Both workflows now resolve an expected sha (the dispatching push's, else docs-control `main` HEAD) and check freshness **unconditionally**, forcing the API fallback when Pages is behind or indeterminate. The inlined `revision_is_fresh` helper body is unchanged, so `test-inlined-helpers-match.sh`'s byte-identical invariant still holds.

## Evidence
- Observed: four caller templates on `vscode-xcsh` had genuinely drifted (downstream `4e8e4fb5…`/856 B vs canonical `c744c291…`/1210 B) yet were reported `[OK]`.
- The failing run logged `Using manifest from …@95ec758` — a **1-day-old** commit — while `main`'s manifest was at `2f1bb0c0`.
- New `tests/test-pages-staleness-guard.sh` **fails against the pre-fix workflows** (exit 1, 6 findings) and passes after, independently reproducing both defects. Wired into `shell-unit-tests`.
- shellcheck / shfmt / actionlint / yamllint clean.

## Follow-up
Once merged, re-run a downstream sync to confirm #755's least-privilege templates finally propagate (tracked separately).
