### PR TITLE
fix(review)!: pin verify.sh pre-step to the DEFAULT branch, not the PR base

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -94,19 +94,22 @@ jobs:
           count=$(bash .review-tooling/scripts/reviewer-comment-count.sh "$ic" "$pc")
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
-      # Trusted, base-pinned authenticated verification (see REVIEWER-SPEC.md WS2).
+      # Trusted, default-branch-pinned authenticated verification (REVIEWER-SPEC.md WS2).
       # Runs the repo's own `.code-review/verify.sh` so the reviewer can prove the
       # change works against real internal APIs — something no diff-only reviewer
       # can do — WITHOUT ever executing PR-authored script bytes.
       #
       # TRUST BOUNDARY (non-negotiable): the PR HEAD copy of verify.sh is untrusted
       # (a PR could rewrite it to exfiltrate the operator's live az/gh/terraform
-      # credentials on this self-hosted runner). The PR BASE copy is trusted — it is
-      # already merged and reviewed. So we overwrite the head working copy with the
-      # BASE blob and execute that. Trusted script LOGIC against untrusted head CODE.
+      # credentials on this self-hosted runner). The DEFAULT-BRANCH copy is trusted —
+      # that branch is protected and review-required. So we overwrite the head working
+      # copy with the DEFAULT-BRANCH blob and execute that: trusted script LOGIC against
+      # untrusted head CODE. Pinning to the PR *base* would NOT be safe (a PR may target
+      # an unprotected branch the author controls).
       #
-      # No base copy (including a PR that ADDS verify.sh) => no-op: head's version is
-      # never run. Only repos that already carry a merged verify.sh are affected.
+      # No default-branch copy (including a PR that ADDS verify.sh) => no-op: head's
+      # version is never run. Only repos with a merged verify.sh are affected, and only
+      # for PRs that target the default branch.
       #
       # Never fails the job: the result (exit code + output) is handed to the review
       # agent via verify-output.txt, which decides whether the failure is caused by
@@ -114,33 +117,50 @@ jobs:
       # cannot flood the prompt. RESIDUAL RISK (documented, unchanged): `terraform
       # init` on head HCL can fetch a head-declared provider source — the same
       # surface the review agent's own allow-listed terraform commands already have.
-      - name: Trusted verification (base-pinned verify.sh)
+      - name: Trusted verification (default-branch-pinned verify.sh)
         id: verify
         timeout-minutes: 10
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -uo pipefail
           rel=".code-review/verify.sh"
-          # `fetch-depth: 0` normally lands the base commit, but don't rely on it.
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            git fetch --no-tags --depth=1 origin "${BASE_SHA}" 2>/dev/null || true
-          fi
-          if ! git cat-file -e "${BASE_SHA}:${rel}" 2>/dev/null; then
-            echo "::notice::No ${rel} on the PR base (or base commit unavailable) — skipping trusted verification."
+
+          # Pin to the DEFAULT branch, not the PR's base branch. The PR base is only
+          # as trustworthy as the branch it points at, and a PR may target ANY branch:
+          # a contributor could push a malicious verify.sh to an unprotected feature
+          # branch, open a PR targeting THAT branch, and have it executed here with the
+          # operator's live credentials. The default branch is protected and
+          # review-required, so it is the only safe pin. Also skip outright when the PR
+          # does not target the default branch, so such a PR gets no verification
+          # rather than the wrong repo's logic.
+          if [ "${BASE_REF}" != "${DEFAULT_BRANCH}" ]; then
+            echo "::notice::PR targets '${BASE_REF}', not the default branch '${DEFAULT_BRANCH}' — skipping trusted verification."
             exit 0
           fi
+
+          git fetch --no-tags --depth=1 origin "${DEFAULT_BRANCH}" 2>/dev/null || true
+          pin="origin/${DEFAULT_BRANCH}"
+          if ! git cat-file -e "${pin}:${rel}" 2>/dev/null; then
+            pin="FETCH_HEAD"
+          fi
+          if ! git cat-file -e "${pin}:${rel}" 2>/dev/null; then
+            echo "::notice::No ${rel} on ${DEFAULT_BRANCH} — skipping trusted verification."
+            exit 0
+          fi
+          pin_sha="$(git rev-parse "${pin}")"
           mkdir -p "$(dirname "$rel")"
-          # Overwrite any head-authored copy with the trusted base blob.
-          git show "${BASE_SHA}:${rel}" > "$rel"
+          # Overwrite any head-authored copy with the trusted default-branch blob.
+          git show "${pin}:${rel}" > "$rel"
           chmod +x "$rel"
-          echo "::notice::Running base-pinned ${rel} from ${BASE_SHA}"
+          echo "::notice::Running ${rel} pinned to ${DEFAULT_BRANCH}@${pin_sha}"
           set +e
           bash "$rel" > /tmp/verify-raw.txt 2>&1
           rc=$?
           set -e
           {
-            echo "# Trusted verification (.code-review/verify.sh, pinned to PR base ${BASE_SHA})"
+            echo "# Trusted verification (.code-review/verify.sh, pinned to ${DEFAULT_BRANCH}@${pin_sha})"
             echo "# exit_code=${rc}"
             echo "# NOTE: this script came from the PR BASE, not the PR head."
             echo "---"

--- a/REVIEWER-SPEC.md
+++ b/REVIEWER-SPEC.md
@@ -52,24 +52,28 @@ rubric — WS1-PR1b activates it end-to-end.)*
 
 ## Planned work
 
-- **Trusted base-pinned `verify.sh` pre-step (WS2) — BUILT** (workflow step
-  "Trusted verification (base-pinned verify.sh)" in `claude-review.yml`; results
+- **Trusted default-branch-pinned `verify.sh` pre-step (WS2) — BUILT** (workflow step
+  "Trusted verification (default-branch-pinned verify.sh)" in `claude-review.yml`; results
   consumed by the review agent via `./verify-output.txt`). Design as specified
   below. Consumer confirmed: `f5-sales-demo/dns` ships `.code-review/verify.sh`
   (terraform `fmt`/`init`/`validate` with a temporary local-backend override — no
-  credentials, self-cleaning) and its docstring already assumes the reviewer runs
-  it; the reusable workflow does **not** run it yet (Agent 5 only `Read`s it). So
-  the feature has real pull. Build it as follows:
+  credentials, self-cleaning) and its docstring always assumed the reviewer runs it.
+  Design:
   - **Trust boundary.** The PR head's `.code-review/verify.sh` is UNTRUSTED (a PR
-    could carry a malicious script). The PR **base** copy is trusted (already
-    merged + reviewed). The pre-step must run the base script's *logic* while
-    verifying the head's *code*.
-  - **Mechanism.** Before the Claude step, if the base ref has the file:
-    `git fetch` the base SHA, then `git show <base_sha>:.code-review/verify.sh`
-    and **overwrite the head working copy** at `.code-review/verify.sh` with it
-    (so relative paths like `../terraform` resolve in-tree), then
+    could carry a malicious script). The **default-branch** copy is trusted, having
+    been merged and reviewed on a protected branch. The pre-step must run that
+    script's *logic* while verifying the head's *code*.
+  - **Mechanism.** Before the Claude step, if the **default branch** has the file:
+    fetch that branch, then `git show origin/<default>:.code-review/verify.sh` and
+    **overwrite the head working copy** at `.code-review/verify.sh` with it (so
+    relative paths like `../terraform` resolve in-tree), then
     `bash .code-review/verify.sh`. This runs trusted script logic against head
     code — never the head's script bytes.
+  - **Pin to the DEFAULT branch, never the PR base.** A PR may target ANY branch, so
+    the base is only as trustworthy as that branch: a contributor could push a
+    malicious `verify.sh` to an unprotected feature branch, open a PR targeting it,
+    and have it executed with the operator's live credentials. The default branch is
+    protected and review-required. PRs not targeting the default branch are skipped.
   - **Residual risk (documented).** `terraform init` on head HCL can still fetch a
     head-declared provider source — the SAME surface Agent 5's allow-listed
     `terraform init/plan` already has; not widened by this step. Bound with a
@@ -77,10 +81,13 @@ rubric — WS1-PR1b activates it end-to-end.)*
   - **Output → Agent 5.** Capture stdout+exit code to `verify-output.txt`; the
     verification agent reads that file (not the raw script) and flags a 🔴 only
     when a should-succeed verification fails because of the PR.
-  - **UAT (must prove).** (1) base `verify.sh` present → it runs and its output is
-    surfaced; (2) a PR that REPLACES `verify.sh` with a malicious payload → the
-    payload's bytes are NEVER executed (base version is used); (3) repo with no
-    `.code-review/verify.sh` → pre-step is a no-op, review proceeds.
+  - **UAT (proven live on `dns` PR #581).** (1) default-branch `verify.sh` present →
+    it runs and its output is surfaced; (2) a PR that REPLACES `verify.sh` with a
+    payload → the payload's bytes are NEVER executed (the pinned version is used —
+    confirmed: the pinned script's exit code appeared, never the marker's, and the
+    reviewer independently reported the boundary held); (3) repo with no
+    `.code-review/verify.sh`, or a PR not targeting the default branch → pre-step is
+    a no-op and the review proceeds.
   - **Rollout.** Ship behind the existing dark-bake posture; validate on `dns`
     first. This is the safe closure of E4.
 - **Deterministic layers (WS3/WS4).** Cross-module dead-code (Knip, Python


### PR DESCRIPTION
Closes #761

## Problem (found by automated security review)
The WS2 pre-step pinned `.code-review/verify.sh` to `pull_request.base.sha`. **The PR base is only as trustworthy as the branch it points at**, and nothing restricts which branch a PR may target. Attack path:

1. Contributor pushes a malicious `.code-review/verify.sh` to an **unprotected feature branch**.
2. Opens a PR **targeting that branch** (same-repo, so the fork guard does not apply).
3. `base.sha` = that branch's tip → the pre-step executes the malicious script on the self-hosted runner **with the operator's live `az`/`gh`/`terraform` credentials**.

That is privilege escalation beyond what write access alone grants (main is protected and review-required; an unprotected feature branch is not).

## Fix
Pin to the repository's **default branch** (protected, review-required) via `git show origin/<default>:...`, and **skip entirely** when the PR does not target the default branch — so such a PR gets no verification rather than untrusted logic. Docs (`REVIEWER-SPEC.md`) updated to match.

## Verification
- Live-validated on `dns` PR #581 (pre-change): the pinned script ran — **its** exit code appeared, never the UAT marker's — and the reviewer independently reported *"the head marker payload never executed."*
- actionlint + yamllint + textlint + markdownlint clean.
- The same UAT surfaced an unrelated host problem (`terraform: Permission denied` on the runner) — filed separately.

Marked `!` because it narrows when the pre-step runs (default-branch-targeting PRs only).