### PR TITLE
fix(review): dependency preflight so authenticated verification can never silently no-op

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -94,6 +94,29 @@ jobs:
           count=$(bash .review-tooling/scripts/reviewer-comment-count.sh "$ic" "$pc")
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
+      # Dependency preflight. The reviewer's reason to exist is proving a change works
+      # against real internal APIs with the operator's live CLIs — a leg that can break
+      # WITHOUT any review failing, so reviews look complete while silently skipping it
+      # (observed: a non-executable terraform shim was the only terraform on the
+      # launchd PATH, so every call died "Permission denied" for an unknown period).
+      # Deliberately NON-blocking: a broken CLI must not deadlock every PR. Instead the
+      # result is written to ./review-deps.txt, which the reviewer MUST read and, when
+      # degraded, state plainly in its summary rather than implying it verified.
+      - name: Reviewer dependency preflight
+        id: deps
+        continue-on-error: true
+        timeout-minutes: 3
+        run: |
+          set -uo pipefail
+          bash .review-tooling/scripts/check-review-deps.sh --probe > review-deps.txt 2>&1
+          rc=$?
+          cat review-deps.txt
+          echo "deps_ok=${rc}" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::Reviewer dependencies DEGRADED — authenticated verification is unavailable or partial. See review-deps.txt; the review must not claim it verified with the affected tools."
+          fi
+          exit 0
+
       # Trusted, default-branch-pinned authenticated verification (REVIEWER-SPEC.md WS2).
       # Runs the repo's own `.code-review/verify.sh` so the reviewer can prove the
       # change works against real internal APIs — something no diff-only reviewer

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -228,6 +228,10 @@ jobs:
         if: hashFiles('tests/test-pages-staleness-guard.sh') != ''
         run: bash tests/test-pages-staleness-guard.sh
 
+      - name: Run check-review-deps test
+        if: hashFiles('tests/test-check-review-deps.sh') != ''
+        run: bash tests/test-check-review-deps.sh
+
       - name: Run protect-managed-files hook test
         if: hashFiles('tests/test-protect-managed-files.sh') != ''
         run: bash tests/test-protect-managed-files.sh

--- a/REVIEWER-SPEC.md
+++ b/REVIEWER-SPEC.md
@@ -42,6 +42,14 @@ referenced "the reviewer spec" before this file existed
    both caller and reusable workflow).
 5. **Fail-safe reliability.** Machine-wide slot semaphore; per-PR concurrency
    cancel; a single safe retry only when nothing was posted and no verdict exists.
+6. **Never claim an unverified check.** The authenticated-verification leg depends on
+   the operator's CLIs on the self-hosted runner, which can break without any review
+   failing. A preflight (`scripts/check-review-deps.sh`, run per review into
+   `./review-deps.txt`) records whether each CLI is usable; when DEGRADED the review
+   MUST say which capability was unavailable instead of reporting that it checked it.
+   Deliberately non-blocking — a broken CLI must not deadlock every PR — but never
+   silent. *(Added after a non-executable `terraform` shim was the only terraform on
+   the launchd PATH, so verification silently no-op'd while reviews reported success.)*
 
 ## Severity taxonomy
 

--- a/plugins/f5-review/code-review-f5/commands/code-review.md
+++ b/plugins/f5-review/code-review-f5/commands/code-review.md
@@ -125,6 +125,17 @@ To do this, follow these steps precisely:
      head); if such a script exists, `Read` it and review its intent, but do not
      run it. Never print secrets.
 
+     **Toolchain honesty (non-negotiable).** FIRST `Read` `./review-deps.txt` if it
+     exists. It records whether the CLIs this verification depends on are actually
+     usable on this runner. If its verdict is `DEGRADED`, you MUST NOT claim or imply
+     that you verified anything with the affected tools: skip those checks, and state
+     explicitly in the summary comment which capability was unavailable (e.g.
+     "authenticated verification unavailable: terraform not usable on the runner").
+     Never report "Checked … authenticated verification" when it could not run — a
+     silently-skipped check is worse than a reported gap. Do not flag the degraded
+     toolchain as a 🔴 against the PR: it is an environment problem, not a defect in
+     the change.
+
      **Trusted verification results.** If `./verify-output.txt` exists, the
      workflow already ran the repo's `.code-review/verify.sh` **pinned to the PR
      base** (trusted script logic against head code) before this session started.

--- a/scripts/check-review-deps.sh
+++ b/scripts/check-review-deps.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# check-review-deps.sh — assert the CLIs the agentic reviewer depends on are
+# actually usable in THIS process's environment (not merely installed somewhere).
+#
+#   check-review-deps.sh [--probe]
+#     --probe : also run each tool's cheap version command (catches a resolvable
+#               but broken tool, e.g. a shim pointing at a missing binary).
+#
+# Prints one line per tool (OK / MISSING / NOEXEC / BROKEN) and a final verdict.
+# Exit 0 = every dependency usable. Exit 1 = at least one is not.
+#
+# WHY THIS EXISTS: the reviewer's stated reason to exist is proving a change works
+# against real internal APIs using the operator's live CLIs on the self-hosted
+# runner. That leg can break WITHOUT any review failing — a review then looks
+# complete while having silently skipped the one check no diff-only reviewer can
+# do. That happened: a non-executable `terraform` shim in ~/.local/bin was the ONLY
+# terraform on the runner's PATH (~/.tfenv/bin is added by interactive rc files only),
+# so every `terraform` call died with "Permission denied" while reviews kept reporting
+# success. This check exists so that degradation is always VISIBLE.
+#
+# NOTE on PATH semantics (verified, not assumed): bash SKIPS a non-executable match
+# and uses a later executable one, so a non-executable entry only breaks things when
+# it is the sole match. This check reports exactly that condition.
+#
+# The runner is started by launchd, whose environment differs from an interactive
+# shell, so this must be evaluated in the runner's own environment to be truthful.
+set -uo pipefail
+
+PROBE=0
+[ "${1:-}" = "--probe" ] && PROBE=1
+
+# Tools the reviewer cannot function without at all.
+CORE="git jq gh"
+# Tools the AUTHENTICATED VERIFICATION leg needs. Missing these does not stop a
+# review, but it must be reported so the review never implies it verified.
+VERIFY="terraform az"
+
+fail=0
+degraded=""
+
+probe_cmd() { # <tool> -> cheap, offline-ish version invocation
+  case "$1" in
+  terraform) terraform version ;;
+  az) az version ;;
+  gh) gh --version ;;
+  git) git --version ;;
+  jq) jq --version ;;
+  *) "$1" --version ;;
+  esac
+}
+
+check_one() { # <tool> <class>
+  local c="$1" class="$2" p
+  if ! p=$(command -v "$c" 2>/dev/null) || [ -z "$p" ]; then
+    echo "MISSING  ${c} (${class}) — not on PATH"
+    return 1
+  fi
+  if [ ! -x "$p" ]; then
+    echo "NOEXEC   ${c} (${class}) -> ${p} — resolves to a NON-EXECUTABLE file and no working copy exists later on PATH; every invocation fails with \"Permission denied\""
+    return 1
+  fi
+  if [ "$PROBE" -eq 1 ]; then
+    if ! probe_cmd "$c" >/dev/null 2>&1; then
+      echo "BROKEN   ${c} (${class}) -> ${p} — resolves but its version command failed"
+      return 1
+    fi
+  fi
+  echo "OK       ${c} (${class}) -> ${p}"
+  return 0
+}
+
+for c in $CORE; do
+  check_one "$c" core || {
+    fail=1
+    degraded="${degraded} ${c}"
+  }
+done
+for c in $VERIFY; do
+  check_one "$c" verification || {
+    fail=1
+    degraded="${degraded} ${c}"
+  }
+done
+
+echo "---"
+if [ "$fail" -eq 0 ]; then
+  echo "VERDICT: all reviewer dependencies usable"
+  exit 0
+fi
+echo "VERDICT: DEGRADED — unusable:${degraded}"
+echo "IMPACT: any review relying on these must NOT claim it verified anything with them."
+exit 1

--- a/tests/test-check-review-deps.sh
+++ b/tests/test-check-review-deps.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/check-review-deps.sh — the reviewer dependency preflight.
+#
+# Fully self-contained: every tool is a FAKE executable in a temp dir, so the test
+# behaves identically on a GitHub-hosted runner (no terraform/az installed) and on
+# the self-hosted macOS runner.
+#
+# Locks the failure mode that motivated the check: a PRESENT-BUT-NOT-EXECUTABLE tool
+# earlier on PATH shadows a working copy and makes every invocation fail with
+# "Permission denied" — while reviews kept reporting success.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/check-review-deps.sh"
+FAIL=0
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+mkfake() { # <dir> <name> <mode>
+  mkdir -p "$1"
+  printf '#!/bin/sh\nexit 0\n' >"$1/$2"
+  chmod "$3" "$1/$2"
+}
+
+# A directory with every dependency present and working.
+GOOD="$WORK/good"
+for t in git jq gh terraform az; do mkfake "$GOOD" "$t" 755; done
+
+run() { # <PATH> [args...] -> prints output, sets RC
+  local p="$1"
+  shift
+  # Absolute interpreter path: the fake PATH deliberately has no `bash`, so the
+  # interpreter must not be resolved through it.
+  OUT=$(env -i HOME="$WORK" PATH="$p" /bin/bash -c "/bin/bash '$SCRIPT' $*" 2>&1)
+  RC=$?
+}
+
+ok() { echo "[OK] $1"; }
+bad() {
+  echo "[FAIL] $1"
+  FAIL=1
+}
+
+# --- healthy -------------------------------------------------------------
+run "$GOOD" --probe
+if [ "$RC" -eq 0 ] && echo "$OUT" | grep -q 'all reviewer dependencies usable'; then
+  ok "healthy env → exit 0"
+else
+  bad "healthy env — expected exit 0 + OK verdict, got rc=$RC"
+fi
+
+# --- the motivating bug: a non-executable tool is the ONLY copy on PATH ----
+# (Verified bash semantics: a non-executable match is SKIPPED when a working copy
+# exists later on PATH, so the break happens only when it is the sole match — which
+# is exactly the runner case, where ~/.tfenv/bin is not on the non-interactive PATH.)
+SOLE="$WORK/sole"
+for t in git jq gh az; do mkfake "$SOLE" "$t" 755; done
+mkfake "$SOLE" terraform 644 # present, NOT executable, and the only terraform
+run "$SOLE"
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'NOEXEC   terraform'; then
+  ok "sole non-executable tool → NOEXEC, exit non-zero"
+else
+  bad "sole-non-executable NOEXEC not detected (rc=$RC)"
+fi
+
+# A non-executable entry FOLLOWED by a working copy is genuinely fine — bash skips
+# it — so the check must NOT cry wolf.
+SHADOW="$WORK/shadow"
+mkfake "$SHADOW" terraform 644
+run "$SHADOW:$GOOD"
+if [ "$RC" -eq 0 ]; then
+  ok "non-executable entry with a working copy later → correctly OK (no false alarm)"
+else
+  bad "false alarm: a usable terraform was reported broken (rc=$RC)"
+fi
+
+# --- missing verification tool -------------------------------------------
+CORE_ONLY="$WORK/coreonly"
+for t in git jq gh; do mkfake "$CORE_ONLY" "$t" 755; done
+run "$CORE_ONLY"
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'MISSING  terraform'; then
+  ok "missing verification tool → MISSING, exit non-zero"
+else
+  bad "missing verification tool not detected (rc=$RC)"
+fi
+
+# --- missing core tool ---------------------------------------------------
+NO_GH="$WORK/nogh"
+for t in git jq terraform az; do mkfake "$NO_GH" "$t" 755; done
+run "$NO_GH"
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'MISSING  gh'; then
+  ok "missing core tool → MISSING, exit non-zero"
+else
+  bad "missing core tool not detected (rc=$RC)"
+fi
+
+# --- --probe catches a resolvable but broken tool -------------------------
+BROKEN="$WORK/broken"
+for t in git jq gh az; do mkfake "$BROKEN" "$t" 755; done
+mkdir -p "$BROKEN"
+printf '#!/bin/sh\nexit 7\n' >"$BROKEN/terraform" # executable but always fails
+chmod 755 "$BROKEN/terraform"
+run "$BROKEN" --probe
+if [ "$RC" -ne 0 ] && echo "$OUT" | grep -q 'BROKEN   terraform'; then
+  ok "--probe catches an executable-but-failing tool"
+else
+  bad "--probe did not catch a failing tool (rc=$RC)"
+fi
+# ...and WITHOUT --probe that same tool passes (probe is the deeper check)
+run "$BROKEN"
+if [ "$RC" -eq 0 ]; then
+  ok "without --probe, presence+exec is sufficient"
+else
+  bad "non-probe run should pass on a present+executable tool (rc=$RC)"
+fi
+
+# --- the degraded verdict must state the impact --------------------------
+run "$CORE_ONLY"
+if echo "$OUT" | grep -q 'must NOT claim it verified'; then
+  ok "degraded verdict states the no-unverified-claims impact"
+else
+  bad "degraded verdict missing the impact statement"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "check-review-deps tests FAILED"
+  exit 1
+fi
+echo "check-review-deps tests passed"


### PR DESCRIPTION
Closes #762

Follow-up to code-review#123. The runner host is fixed (terraform now resolves and dns `.code-review/verify.sh` exits 0); this closes the hole that let the breakage go unnoticed.

- `scripts/check-review-deps.sh` — presence + executability + optional `--probe` smoke test, split into **core** (git/jq/gh) and **verification** (terraform/az) classes.
- Runs per review into `./review-deps.txt`. **Non-blocking** so a broken CLI cannot deadlock every PR.
- Rubric now REQUIRES the reviewer to read it and, when `DEGRADED`, state which capability was unavailable rather than reporting it checked. New spec invariant: *never claim an unverified check*.
- PATH semantics **verified, not assumed**: bash skips a non-executable match when a working copy exists later, so the break only occurs when it is the sole match — the test includes a no-false-alarm case for exactly this.

Hermetic 8-case test (all fake tools, identical behavior on hosted and self-hosted runners) wired into shell-unit-tests. All linters clean.