### PR TITLE
feat(sast): govern Semgrep as a managed file scoped to code-bearing repos

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -26,6 +26,7 @@
     ".github/workflows/dependabot-auto-merge.yml",
     ".github/workflows/auto-merge.yml",
     ".github/workflows/code-review.yml",
+    ".github/workflows/semgrep.yml",
     ".github/workflows/translation-audit.yml",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/ISSUE_TEMPLATE/bug_report.md",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -359,6 +359,18 @@
       {
         "src": "workflows/code-review.yml",
         "dest": ".github/workflows/code-review.yml"
+      },
+      {
+        "src": "workflows/semgrep.yml",
+        "dest": ".github/workflows/semgrep.yml",
+        "only_repos": [
+          "vscode-xcsh",
+          "xcsh",
+          "console",
+          "xcsh-chrome-extension",
+          "i18n-core",
+          "terraform-provider-xcsh"
+        ]
       }
     ]
   },

--- a/workflows/semgrep.yml
+++ b/workflows/semgrep.yml
@@ -1,0 +1,54 @@
+---
+name: Semgrep
+
+# Dedicated SAST: semantic static analysis for logic/security defects that
+# Biome/tsc/Ruff cannot find (taint flow, injection classes, unsafe APIs).
+#
+# Managed by docs-control and synced ONLY to code-bearing repos — see the
+# managed_files entry with "only_repos" in .github/config/repo-settings.json.
+# Content/demo repos are excluded deliberately: they would produce noise, not signal.
+#
+# ADVISORY BY DESIGN: the scan never fails the build (`|| true`); findings surface in
+# the repository Security tab (Code Scanning) via the SARIF upload. Promote to a
+# required check per repo only AFTER its finding volume has been triaged — gating on
+# an untriaged SAST feed would block every merge on pre-existing findings.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write # required to upload SARIF to Code Scanning
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Semgrep scan (advisory)
+        run: |
+          # Registry rulesets: p/default (curated, cross-language) plus language
+          # packs. A pack for a language a repo does not use simply yields no
+          # findings, so one template serves every code-bearing repo.
+          # `|| true` keeps the job green regardless of findings (advisory).
+          pipx run semgrep scan \
+            --config p/default \
+            --config p/typescript \
+            --config p/golang \
+            --sarif --output semgrep.sarif || true
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('semgrep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep


### PR DESCRIPTION
Closes #764

Promotes the Semgrep pilot from one hand-placed workflow to a **governed managed file**, scoped via `managed_files.only_repos` to the six code-bearing repos (vscode-xcsh, xcsh, console, xcsh-chrome-extension, i18n-core, terraform-provider-xcsh). Content/demo repos excluded deliberately — SAST there is noise.

- `only_repos` was implemented in the sync but **never used**; I verified both branches (xcsh → SYNC, dns → SKIP) and that unscoped files still sync everywhere.
- Template generalized: `p/default` + `p/typescript` + `p/golang` (a pack for an unused language yields no findings, so one template serves all).
- **Advisory only** — never fails a build. Promoting a repo to a required check is a deliberate later step, per repo, AFTER triage.
- `repo-settings.json` change is a **5-line insertion** (I caught and reverted an accidental whole-file reformat first).

actionlint/yamllint/zizmor clean; linter-configs + shell unit tests pass.