### PR TITLE
docs: add a verified second-opinion review gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,18 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.
 - The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. See CONTRIBUTING.md.
 
+## Second-opinion review (when available)
+
+When the `codex` plugin provides the `verified-code-review` skill, use it as a second-opinion reviewer at three points. When the skill is not installed, skip it and continue — this is an additive local layer, never a merge gate.
+
+- Before asking a human to review a written spec or an implementation plan.
+- Before pushing a branch that will open or update a pull request.
+- After each round of fixes, until no confirmed critical or high finding remains.
+
+Treat every second-opinion finding as external review feedback under `superpowers:receiving-code-review`: verify each claim against this codebase before acting on it, and push back with technical reasoning when it is wrong. Fix only confirmed findings, each with a test that fails before the fix and passes after.
+
+Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none. The required `review / claude-review` check remains the merge gate, and this local layer never replaces it.
+
 ## Worktrees
 
 - For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.

--- a/REVIEWER-SPEC.md
+++ b/REVIEWER-SPEC.md
@@ -58,6 +58,43 @@ non-blocking), and `low` (🟡, nit). `high` blocks; counts must match `findings
 *(Note: `medium` was historically present in the schema but never emitted by the
 rubric — WS1-PR1b activates it end-to-end.)*
 
+## Local pre-push layer (Codex second opinion)
+
+A second, **advisory** review layer runs on the engineer's machine before the pull
+request exists. It is not the gate described above and must not be confused with it.
+
+- **Advisory, not a gate.** It emits no `verdict.json`, posts no commit status, and
+  **Invariant 1 does not apply to it** — there is no required check for it to
+  deadlock. It never blocks work; if the tooling is absent it is skipped.
+- **Where it runs.** Locally, at the spec and plan review gates, before a push that
+  opens or updates a pull request, and after each round of fixes. Tooling:
+  `f5-sales-demo/codex-plugin-cc`, skill `verified-code-review`, subcommands
+  `review-doc` and `review-gate`.
+- **Read-only sandbox.** The reviewer runs with the `read-only` sandbox so it cannot
+  modify the tree it is judging. **This does not satisfy Invariant 3.** Read-only
+  prevents writes; it does not prevent command execution, network access, or reading
+  anything the user can read. Invariant 3 governs the CI reviewer, which faces
+  third-party pull-request content; this layer reviews the engineer's own branch
+  before a pull request exists. Do not describe read-only as an untrusted-content
+  boundary.
+- **Severity mapping.** Codex emits four severities against its own schema; they map
+  onto the three tiers above as `critical`/`high` → 🔴, `medium` → 🟠, `low` → 🟡.
+  A missing or unrecognized severity maps to 🔴 (fail-closed), because the plugin's
+  `parseStructuredOutput` performs no schema validation.
+- **Verification is mandatory.** A finding blocks the local loop only when a
+  verification pass CONFIRMED it against the codebase — for code, with a test that
+  fails today; for a document, with a quotation. This is not ceremony: an AI reviewer
+  misattributes findings to files that do not contain them, and a hallucinated
+  blocking finding can never be fixed, so treating it as blocking would prevent the
+  loop from ever terminating.
+- **Bounded.** Three iterations maximum, with no-progress detection when two
+  consecutive rounds produce the same blocking set. On either, the outstanding
+  findings go to a human rather than round four.
+
+The two layers are complementary: the local layer catches issues before the pull
+request exists and costs nothing when it is wrong, while CI remains the gate that
+decides whether a change merges.
+
 ## Planned work
 
 - **Trusted default-branch-pinned `verify.sh` pre-step (WS2) — BUILT** (workflow step


### PR DESCRIPTION
Closes #767

## What changes

Two content-only files. **No governance plumbing** — verified by grep, not assumed:

| Requirement | `CLAUDE.md` | `REVIEWER-SPEC.md` |
|---|---|---|
| `repo-settings.json` `managed_files.files[]` | present | n/a (not distributed) |
| `governance.json` `protected_files[]` | present | n/a |
| `build-managed-files-manifest.yml` `on.push.paths` | present | n/a |

**`CLAUDE.md`** gains a `## Second-opinion review (when available)` section directing the review at three moments: before asking a human to review a spec or plan, before a push that opens or updates a pull request, and after each round of fixes.

**`REVIEWER-SPEC.md`** gains a `## Local pre-push layer` section describing it as a distinct, advisory layer.

## Design decisions worth reviewing

**Availability is the first clause.** The tooling is a locally installed plugin, and this file reaches 38 repositories. "When the `codex` plugin provides the `verified-code-review` skill … When the skill is not installed, skip it and continue" means a machine without it gets a no-op, not a failing instruction.

**It cites `superpowers:receiving-code-review` instead of restating skepticism.** DRY, and it survives upstream skill version bumps — that plugin lives in a version-keyed marketplace cache where in-place edits are silently orphaned.

**The pre-push trigger is scoped to branches that open or update a pull request**, not every push, so throwaway and work-in-progress pushes are not reviewed.

**It says the CI gate is unchanged.** `review / claude-review` remains the merge gate; nobody should read this as a replacement.

**It requires dismissed findings to be reported with their evidence.** A review that produced two refuted findings is not the same result as one that produced none — that difference is how a human calibrates trust in the layer, and hiding it makes a wrong reviewer look like a clean one.

## Two corrections to the spec, not just additions

**Invariant 1 does not apply to the local layer.** The existing spec says "Every exit path MUST write `./verdict.json`" and "the gate treats a missing verdict as blocking". Applied to an advisory local pass, that would be nonsense — there is no required check for it to deadlock. Stated explicitly so a future reader does not try to enforce it.

**A read-only sandbox does not satisfy Invariant 3.** This one came out of the review of this work: it is tempting to describe the read-only reviewer as satisfying "untrusted PR content … never execute scripts carried in the PR head". It does not. Read-only prevents *writes*; it does not prevent command execution, network access (`web_search = "live"`), or reading anything the user can read. Invariant 3 governs the CI reviewer facing third-party pull requests; this layer reviews the engineer's own branch before a pull request exists. The spec now says so, so nobody claims the stronger property later.

## Severity mapping

Codex emits four severities; the fleet has three. `critical`/`high` → 🔴, `medium` → 🟠, `low` → 🟡, and **missing or unrecognized → 🔴 (fail-closed)**, because the plugin's `parseStructuredOutput` is a bare `JSON.parse` that never validates against its own schema.

Note the load-bearing rule: a finding blocks the local loop **only when verification confirmed it**. Without that, one hallucinated critical finding blocks forever — nothing can fix a defect that does not exist.

## Verification

- `pre-commit run --files CLAUDE.md REVIEWER-SPEC.md` — all hooks pass. (First run failed `MD013` at 593 characters against the 400 limit; the paragraph was split rather than the rule relaxed.)
- **textlint** (the prose/terminology pass that only the `Lint Code Base` gate runs) — exit 0 on both files. Confirmed the linter was genuinely active with a control file: it correctly flagged `website` → `site`.
- Governance plumbing re-grepped rather than asserted, per the table above.

## Tooling this refers to

`f5-sales-demo/codex-plugin-cc` PR #9 — the `verified-code-review` skill plus `review-doc` and `review-gate`. During its own development that loop found and confirmed five real defects in itself (a gate that silently cleared vanished blockers, colliding verification keys, a protocol that could never confirm a document omission, an off-by-one iteration cap, and review artifacts polluting the next review) and refuted one confident but incorrect finding. That is the behaviour this rule makes routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)