### PR TITLE
fix(sast): exclude inapplicable python3x-compatibility rules (triage result)

### DIFF
--- a/workflows/semgrep.yml
+++ b/workflows/semgrep.yml
@@ -40,10 +40,17 @@ jobs:
           # packs. A pack for a language a repo does not use simply yields no
           # findings, so one template serves every code-bearing repo.
           # `|| true` keeps the job green regardless of findings (advisory).
+          # Excluded rules (categorically inapplicable — exclude at config level
+          # rather than dismissing the same alert in every repo forever):
+          #   python3x-compatibility-* : flags Python 3.6+ APIs as "too new". Every
+          #     Python package in this fleet declares requires-python >= 3.11, so
+          #     these can only ever be false positives.
           pipx run semgrep scan \
             --config p/default \
             --config p/typescript \
             --config p/golang \
+            --exclude-rule python.lang.compatibility.python36.python36-compatibility-Popen1 \
+            --exclude-rule python.lang.compatibility.python36.python36-compatibility-Popen2 \
             --sarif --output semgrep.sarif || true
 
       - name: Upload SARIF to Code Scanning


### PR DESCRIPTION
Closes #769

Triage of the first fleet-wide Semgrep results: **7 error-severity findings, all false positives** (no real defects). Five were context-specific and dismissed in Code Scanning with written justifications; these two are an inapplicable **rule class** — `python3x-compatibility` flags Python 3.6+ APIs as "too new" while every Python package here requires >= 3.11.

**Uses the FULL rule ids, and I verified why that matters:** the short-suffix form is a silent no-op (finding still reported), while the full id suppresses. Proven end-to-end with the template flags against `xcsh/python/xcsh-rpc/src/xcsh_rpc/client.py`: **288 rules run, 0 findings** (previously 2 alerts).

yamllint/actionlint clean; managed-files tests 117/117.