### PR TITLE
feat(governance): scheduled workflow-security audit for every repo

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -26,6 +26,7 @@
     ".github/workflows/dependabot-auto-merge.yml",
     ".github/workflows/auto-merge.yml",
     ".github/workflows/code-review.yml",
+    ".github/workflows/workflow-security-audit.yml",
     ".github/workflows/semgrep.yml",
     ".github/workflows/translation-audit.yml",
     ".github/PULL_REQUEST_TEMPLATE.md",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -361,6 +361,10 @@
         "dest": ".github/workflows/code-review.yml"
       },
       {
+        "src": "workflows/workflow-security-audit.yml",
+        "dest": ".github/workflows/workflow-security-audit.yml"
+      },
+      {
         "src": "workflows/semgrep.yml",
         "dest": ".github/workflows/semgrep.yml",
         "only_repos": [

--- a/workflows/workflow-security-audit.yml
+++ b/workflows/workflow-security-audit.yml
@@ -1,0 +1,64 @@
+---
+name: Workflow Security Audit
+
+# Scheduled zizmor audit over ALL workflow files in this repo.
+#
+# WHY THIS EXISTS: the `Lint Code Base` gate runs super-linter with
+# VALIDATE_ALL_CODEBASE=false, so its zizmor pass only audits workflow files a PR
+# actually CHANGED. A workflow that is never edited is therefore never audited, and
+# its findings can sit indefinitely. That is not hypothetical: vscode-xcsh's ci.yml
+# carried 4 high-severity `template-injection` vectors (attacker-controlled
+# `repository_dispatch` client_payload interpolated into a `run:` body) plus 5
+# `excessive-permissions` findings, invisible until an unrelated PR happened to touch
+# the file. This job closes that blind spot by auditing every workflow on a schedule.
+#
+# The PR-time gate is unchanged and still catches regressions in changed files; this
+# is the backstop for the files nobody is touching.
+on:
+  schedule:
+    # Weekly, off-peak, deliberately not on the hour.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'zizmor.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-security-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit workflows (zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Full report first (all severities) into the run summary, so low and
+      # informational findings are visible and countable without failing the job.
+      - name: Report all findings
+        run: |
+          set -uo pipefail
+          {
+            echo '## Workflow security audit (zizmor)'
+            echo
+            echo 'Full report — every severity. The job only FAILS on medium or higher.'
+            echo
+            echo '```'
+            pipx run zizmor --config zizmor.yaml .github/workflows/ 2>&1 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Gate on what actually matters. Low/informational findings (e.g. ad-hoc
+      # package installs) are reported above but do not fail the audit, so a repo is
+      # not permanently red over hygiene items. Medium and high — excessive
+      # permissions, template injection, credential persistence — do fail, because
+      # those are exploitable and someone needs to look.
+      - name: Fail on medium or higher
+        run: pipx run zizmor --config zizmor.yaml --min-severity medium .github/workflows/


### PR DESCRIPTION
Closes #774

Closes the blind spot behind vscode-xcsh#965: super-linter runs `VALIDATE_ALL_CODEBASE=false`, so zizmor only audits workflow files a PR **changed**. A workflow nobody edits is never audited.

**Sampling 10 repos found 2 with hidden medium-or-higher findings — including 24 HIGH in `terraform-provider-xcsh`.**

The audit runs weekly + on demand + on workflow pushes; reports **every** severity to the run summary, but **fails only on medium or higher** so hygiene items do not leave repos permanently red. **Not a required check** — it never blocks a merge.

Verified gating in both directions before shipping: pre-fix `vscode-xcsh/ci.yml` exits non-zero at `--min-severity medium`, a clean workflow exits 0, and docs-control own workflows pass. Registered in `managed_files` **and** `governance.json` protected_files (CI enforces that pairing); Biome-clean; 117/117 shell tests.