### PR TITLE
feat: gate on repository hygiene fleet-wide

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -60,6 +60,8 @@
     ".python-lint",
     ".mypy.ini",
     "scripts/locale-lint.sh",
+    "scripts/check-repo-hygiene.sh",
+    "tests/test-check-repo-hygiene.sh",
     "trivy.yaml",
     ".claude/settings.json",
     ".claude/governance.json",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -341,6 +341,14 @@
         "dest": "scripts/locale-lint.sh"
       },
       {
+        "src": "scripts/check-repo-hygiene.sh",
+        "dest": "scripts/check-repo-hygiene.sh"
+      },
+      {
+        "src": "tests/test-check-repo-hygiene.sh",
+        "dest": "tests/test-check-repo-hygiene.sh"
+      },
+      {
         "src": ".claude/governance.json",
         "dest": ".claude/governance.json"
       },

--- a/.github/workflows/build-managed-files-manifest.yml
+++ b/.github/workflows/build-managed-files-manifest.yml
@@ -43,6 +43,8 @@ on:
       - '.mypy.ini'
       - '.claude/governance.json'
       - '.claude/settings.json'
+      - 'scripts/**'
+      - 'tests/**'
       - '.claude/hooks/**'
   workflow_dispatch:
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,6 +24,34 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Deterministic portability guard, run natively on the runner (Super-Linter
+      # cannot see git object modes from inside its container). Cheap and first, so
+      # a committed absolute symlink or hardcoded home directory fails fast.
+      #
+      # Runs the DEFAULT-BRANCH copy of the script against the HEAD working tree,
+      # per REVIEWER-SPEC.md invariant 3 ("never execute scripts carried in the PR
+      # head") and the trust boundary documented there. Two reasons:
+      #   1. This job holds statuses:write and pull-requests:write, so executing a
+      #      PR's own copy of the script would hand those scopes to PR-authored code.
+      #   2. Gating on the head's copy would let a PR delete the file to skip the
+      #      gate entirely.
+      # The script only reads git metadata and tracked file contents, so trusted
+      # logic over untrusted data is safe. Absent on the default branch, there is
+      # nothing to enforce yet — that is the rollout path, not a bypass.
+      - name: Check repository hygiene
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          script=scripts/check-repo-hygiene.sh
+          branch="${DEFAULT_BRANCH:-main}"
+          git fetch --no-tags --quiet origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+          if ! git cat-file -e "origin/${branch}:${script}" 2>/dev/null; then
+            echo "The default branch does not carry ${script} yet; nothing to enforce."
+            exit 0
+          fi
+          git show "origin/${branch}:${script}" | bash -s
+
       # Biome runs OUTSIDE the Super-Linter container so we can track Biome
       # `latest` instead of being gated on Super-Linter's container release
       # cadence. Authority boundary: setup-biome owns JS/TS/JSON/JSX; the
@@ -243,6 +271,10 @@ jobs:
       - name: Run locale-lint test
         if: hashFiles('tests/test-locale-lint.sh') != ''
         run: bash tests/test-locale-lint.sh
+
+      - name: Run check-repo-hygiene test
+        if: hashFiles('tests/test-check-repo-hygiene.sh') != ''
+        run: bash tests/test-check-repo-hygiene.sh
 
       # Consumer repos: auto-run their OWN tests/test-*.sh so a caller repo (e.g.
       # code-review) gets shell-unit-test coverage through this reusable workflow

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,7 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
+
+# Verified-review working artifacts (findings and verification evidence).
+# No trailing slash, so a symlink of this name is matched too.
+.codex-review

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,23 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
+  # Repository hygiene — rejects tracked symlinks with absolute targets and
+  # hardcoded home directories. A `.gitignore` pattern ending in `/` matches
+  # only directories, so a symlink of an ignored name is still staged.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: check-repo-hygiene
+        name: Repository hygiene
+        entry: >-
+          bash -c
+          'if [ -f scripts/check-repo-hygiene.sh ];
+          then bash scripts/check-repo-hygiene.sh; fi'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+  # ===========================================================================
   # File size guard
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -218,6 +235,7 @@ ci:
   # They run locally and in GitHub Actions CI where tools are pre-installed.
   skip:
     - local-hooks
+    - check-repo-hygiene
     - yamllint
     - markdownlint
     - shellcheck

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Rejects two classes of committed content that break on any machine but the one
+# that produced them:
+#
+#   1. Tracked symlinks with an absolute target. A clone lands a dangling link,
+#      and tooling that follows it fails in ways that look unrelated to the cause.
+#   2. A user's home directory hardcoded in a tracked file.
+#
+# Both slip past the usual gates: `.gitignore` patterns ending in `/` match only
+# directories, so a symlink of an ignored name is still staged, and CI often
+# masks a dangling link by creating the real thing (npm ci, pip install).
+#
+# Run from any repo root: bash scripts/check-repo-hygiene.sh
+# Exit 0 = clean, Exit 1 = violations found.
+#
+# To allow a deliberate example path, put `repo-hygiene:allow` on the same line.
+set -euo pipefail
+
+VIOLATIONS=0
+
+# Placeholder user names are portable documentation, not a machine-specific path.
+PLACEHOLDERS='you|user|username|your-user|your_username|me|example|USERNAME|\$USER|\$\{USER\}|<user>|<username>|\.\.\.'
+
+# Home directories owned by a CI runner are the same on every machine.
+CI_USERS='runner|circleci|travis|vsts|ubuntu|node|jenkins|gitpod|vscode'
+
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "::error::not a git repository — cannot inspect tracked files"
+  exit 1
+fi
+
+# Absolute targets, and relative targets that climb out of the repository, both
+# break on a fresh clone. Resolved lexically: no filesystem access, so a dangling
+# link is judged the same as a live one.
+symlink_escapes() {
+  local link_path="$1" target="$2" dir depth=0 segment
+  case "$target" in
+    /* | [A-Za-z]:[\\/]* | \\\\*) return 0 ;;
+  esac
+  dir=$(dirname "$link_path")
+  [ "$dir" = "." ] && dir=""
+  if [ -n "$dir" ]; then
+    local IFS=/
+    for segment in $dir; do
+      [ -n "$segment" ] && depth=$((depth + 1))
+    done
+  fi
+  local IFS=/
+  for segment in $target; do
+    case "$segment" in
+      "" | .) ;;
+      ..)
+        depth=$((depth - 1))
+        [ "$depth" -lt 0 ] && return 0
+        ;;
+      *) depth=$((depth + 1)) ;;
+    esac
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# 1. Tracked symlinks with an absolute target (git mode 120000; the blob's
+#    contents are the link target).
+#
+#    `git ls-files -s -z` emits "<mode> <sha> <stage>\t<path>\0", so the path is
+#    everything after the first tab and survives spaces verbatim. Splitting on
+#    whitespace instead would corrupt such a path, and the lookup would then fail
+#    silently — reporting a real violation as clean.
+# ---------------------------------------------------------------------------
+while IFS= read -r -d '' entry; do
+  [ -n "$entry" ] || continue
+  case "$entry" in 120000\ *) ;; *) continue ;; esac
+  path=${entry#*$'\t'}
+  if ! target=$(git cat-file blob ":${path}" 2>/dev/null); then
+    # Fail closed: a symlink we cannot read is not a symlink we can clear.
+    echo "::error file=${path}::tracked symlink could not be read — cannot verify its target"
+    VIOLATIONS=$((VIOLATIONS + 1))
+    continue
+  fi
+  if symlink_escapes "$path" "$target"; then
+    echo "::error file=${path}::tracked symlink points outside the repository: ${target}"
+    echo "  A clone lands a dangling link here. Remove it (git rm --cached '${path}') and"
+    echo "  ignore it with a pattern that has no trailing slash, so a symlink is matched too."
+    VIOLATIONS=$((VIOLATIONS + 1))
+  fi
+done < <(git ls-files -s -z)
+
+# ---------------------------------------------------------------------------
+# 2. Home directories hardcoded in tracked files.
+#
+#    Each matched path is judged on its own. Judging a whole line would let an
+#    allowed path launder a real one beside it, e.g.
+#    "PATH=/home/runner/bin:/home/alice/bin".
+# ---------------------------------------------------------------------------
+CANDIDATE='(/Users/|/home/|[A-Za-z]:\\+Users\\+|\\\\+[A-Za-z0-9._-]+\\+Users\\+)[A-Za-z0-9._${}<>-]+'
+
+path_is_allowed() {
+  local candidate="$1" user
+  user=${candidate##*/}
+  user=${user##*\\}
+  user=${user##*\\}
+  printf '%s' "$user" | grep -qE "^(${PLACEHOLDERS}|${CI_USERS})$"
+}
+
+while IFS= read -r hit; do
+  [ -n "$hit" ] || continue
+  file=${hit%%:*}
+  rest=${hit#*:}
+  line=${rest%%:*}
+  text=${rest#*:}
+  case "$text" in *repo-hygiene:allow*) continue ;; esac
+
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    if path_is_allowed "$candidate"; then
+      continue
+    fi
+    echo "::error file=${file},line=${line}::hardcoded home directory in a tracked file: ${candidate}"
+    echo "  ${text}"
+    echo "  Use a relative path, an environment variable, or a placeholder such as /Users/you/."
+    echo "  If the literal path is intentional, add repo-hygiene:allow to that line."
+    VIOLATIONS=$((VIOLATIONS + 1))
+  done < <(printf '%s' "$text" | grep -oE "$CANDIDATE" || true)
+done < <(
+  # --cached searches the index, so the working tree is never read: a symlink is
+  # matched on its own target text rather than dereferenced, and a dangling link
+  # cannot make the scan fail open. Pathspec exclusions keep this script and its
+  # test — which necessarily contain the patterns — out of the results.
+  git grep --cached --no-color -nIE -e "$CANDIDATE" -- \
+    ':!scripts/check-repo-hygiene.sh' \
+    ':!tests/test-check-repo-hygiene.sh' \
+    || true
+)
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "::error::repo hygiene: ${VIOLATIONS} violation(s) found."
+  exit 1
+fi
+
+echo "repo hygiene: clean (no tracked absolute symlinks, no hardcoded home directories)."

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -10,20 +10,46 @@
 # directories, so a symlink of an ignored name is still staged, and CI often
 # masks a dangling link by creating the real thing (npm ci, pip install).
 #
-# Run from any repo root: bash scripts/check-repo-hygiene.sh
+# The symlink check runs by default. The home-directory scan is opt-in via
+# --include-paths, because measuring it across all 38 governed repositories flagged
+# 10 of them and only 2 findings were real: the rest were API routes (/Users/1),
+# URL paths (/home/index), shell variables (/home/${USERNAME}), placeholder names,
+# and upstream-generated specification examples. A gate that is ~80% false positives
+# gets switched off, which is worse than not having it.
+#
+# Run from any repo root:
+#   bash scripts/check-repo-hygiene.sh                  # symlinks only (the gate)
+#   bash scripts/check-repo-hygiene.sh --include-paths   # also scan for home dirs
 # Exit 0 = clean, Exit 1 = violations found.
 #
 # To allow a deliberate example path, put `repo-hygiene:allow` on the same line.
 set -euo pipefail
 
 VIOLATIONS=0
+INCLUDE_PATHS=0
+
+for arg in "$@"; do
+  case "$arg" in
+  --include-paths) INCLUDE_PATHS=1 ;;
+  -h | --help)
+    sed -n '2,20p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "::error::unknown argument: ${arg}" >&2
+    exit 1
+    ;;
+  esac
+done
 
 # Placeholder user names are portable documentation, not a machine-specific path.
-PLACEHOLDERS='you|user|username|your-user|your_username|me|example|USERNAME|\$USER|\$\{USER\}|<user>|<username>|\.\.\.'
+PLACEHOLDERS='you|user|users|username|userid|your-user|your_username|me|example|alice|bob|USERNAME|<user>|<username>|<you>|<your-user>|\.\.\.'
+
+# Any path built from a variable is portable by construction.
+VARIABLE_FORMS='^\$|^\{|\$\{|^%[A-Za-z_]+%$'
 
 # Home directories owned by a CI runner are the same on every machine.
 CI_USERS='runner|circleci|travis|vsts|ubuntu|node|jenkins|gitpod|vscode'
-
 
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo "::error::not a git repository — cannot inspect tracked files"
@@ -36,7 +62,7 @@ fi
 symlink_escapes() {
   local link_path="$1" target="$2" dir depth=0 segment
   case "$target" in
-    /* | [A-Za-z]:[\\/]* | \\\\*) return 0 ;;
+  /* | [A-Za-z]:[\\/]* | \\\\*) return 0 ;;
   esac
   dir=$(dirname "$link_path")
   [ "$dir" = "." ] && dir=""
@@ -49,12 +75,12 @@ symlink_escapes() {
   local IFS=/
   for segment in $target; do
     case "$segment" in
-      "" | .) ;;
-      ..)
-        depth=$((depth - 1))
-        [ "$depth" -lt 0 ] && return 0
-        ;;
-      *) depth=$((depth + 1)) ;;
+    "" | .) ;;
+    ..)
+      depth=$((depth - 1))
+      [ "$depth" -lt 0 ] && return 0
+      ;;
+    *) depth=$((depth + 1)) ;;
     esac
   done
   return 1
@@ -100,43 +126,57 @@ path_is_allowed() {
   local candidate="$1" user
   user=${candidate##*/}
   user=${user##*\\}
-  user=${user##*\\}
+  # A purely numeric segment is an identifier in a URL or API path, not a person.
+  case "$user" in
+  '' | *[!0-9]*) ;;
+  *) return 0 ;;
+  esac
+  # A path built from a variable is portable by construction.
+  if printf '%s' "$user" | grep -qE "$VARIABLE_FORMS"; then
+    return 0
+  fi
   printf '%s' "$user" | grep -qE "^(${PLACEHOLDERS}|${CI_USERS})$"
 }
 
-while IFS= read -r hit; do
-  [ -n "$hit" ] || continue
-  file=${hit%%:*}
-  rest=${hit#*:}
-  line=${rest%%:*}
-  text=${rest#*:}
-  case "$text" in *repo-hygiene:allow*) continue ;; esac
+if [ "$INCLUDE_PATHS" -eq 1 ]; then
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    file=${hit%%:*}
+    rest=${hit#*:}
+    line=${rest%%:*}
+    text=${rest#*:}
+    case "$text" in *repo-hygiene:allow*) continue ;; esac
 
-  while IFS= read -r candidate; do
-    [ -n "$candidate" ] || continue
-    if path_is_allowed "$candidate"; then
-      continue
-    fi
-    echo "::error file=${file},line=${line}::hardcoded home directory in a tracked file: ${candidate}"
-    echo "  ${text}"
-    echo "  Use a relative path, an environment variable, or a placeholder such as /Users/you/."
-    echo "  If the literal path is intentional, add repo-hygiene:allow to that line."
-    VIOLATIONS=$((VIOLATIONS + 1))
-  done < <(printf '%s' "$text" | grep -oE "$CANDIDATE" || true)
-done < <(
-  # --cached searches the index, so the working tree is never read: a symlink is
-  # matched on its own target text rather than dereferenced, and a dangling link
-  # cannot make the scan fail open. Pathspec exclusions keep this script and its
-  # test — which necessarily contain the patterns — out of the results.
-  git grep --cached --no-color -nIE -e "$CANDIDATE" -- \
-    ':!scripts/check-repo-hygiene.sh' \
-    ':!tests/test-check-repo-hygiene.sh' \
-    || true
-)
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if path_is_allowed "$candidate"; then
+        continue
+      fi
+      echo "::error file=${file},line=${line}::hardcoded home directory in a tracked file: ${candidate}"
+      echo "  ${text}"
+      echo "  Use a relative path, an environment variable, or a placeholder such as /Users/you/."
+      echo "  If the literal path is intentional, add repo-hygiene:allow to that line."
+      VIOLATIONS=$((VIOLATIONS + 1))
+    done < <(printf '%s' "$text" | grep -oE "$CANDIDATE" || true)
+  done < <(
+    # --cached searches the index, so the working tree is never read: a symlink is
+    # matched on its own target text rather than dereferenced, and a dangling link
+    # cannot make the scan fail open. Pathspec exclusions keep this script and its
+    # test — which necessarily contain the patterns — out of the results.
+    git grep --cached --no-color -nIE -e "$CANDIDATE" -- \
+      ':!scripts/check-repo-hygiene.sh' \
+      ':!tests/test-check-repo-hygiene.sh' ||
+      true
+  )
+fi
 
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "::error::repo hygiene: ${VIOLATIONS} violation(s) found."
   exit 1
 fi
 
-echo "repo hygiene: clean (no tracked absolute symlinks, no hardcoded home directories)."
+if [ "$INCLUDE_PATHS" -eq 1 ]; then
+  echo "repo hygiene: clean (no escaping symlinks, no hardcoded home directories)."
+else
+  echo "repo hygiene: clean (no escaping symlinks)."
+fi

--- a/tests/test-check-repo-hygiene.sh
+++ b/tests/test-check-repo-hygiene.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/check-repo-hygiene.sh — the guard that rejects
+# committed content which only works on the machine that produced it.
+# Builds throwaway repositories, so it never inspects the repository it lives in.
+# No network.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/check-repo-hygiene.sh"
+
+FAIL=0
+WORK=$(mktemp -d)
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+new_repo() {
+  local dir="${WORK}/$1"
+  mkdir -p "$dir"
+  git -C "$dir" init -q -b main
+  git -C "$dir" config user.email hygiene@test
+  git -C "$dir" config user.name "Hygiene Test"
+  printf 'ok\n' > "${dir}/README.md"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm baseline
+  echo "$dir"
+}
+
+_run() {
+  local rc=0
+  ( cd "$1" && bash "$SCRIPT" ) >/dev/null 2>&1 || rc=$?
+  echo "$rc"
+}
+
+assert_clean() {
+  local label="$1" rc
+  rc=$(_run "$2")
+  if [ "$rc" -eq 0 ]; then echo "[OK] $label -> clean"; else
+    echo "[FAIL] $label — expected clean (0), got $rc"; FAIL=1
+  fi
+}
+
+assert_violation() {
+  local label="$1" rc
+  rc=$(_run "$2")
+  if [ "$rc" -eq 1 ]; then echo "[OK] $label -> rejected"; else
+    echo "[FAIL] $label — expected rejection (1), got $rc"; FAIL=1
+  fi
+}
+
+# --- a clean repository passes -------------------------------------------------
+repo=$(new_repo clean)
+assert_clean "baseline repository" "$repo"
+
+# --- the defect this check exists for: an absolute symlink named node_modules ---
+repo=$(new_repo abs-symlink)
+ln -s /some/other/checkout/node_modules "${repo}/node_modules"
+git -C "$repo" add -A --force
+assert_violation "tracked symlink with an absolute target" "$repo"
+
+# --- relative in-repo symlinks are legitimate and must not be flagged ----------
+# Note the target is resolved relative to the LINK's directory: `../docs/shared.md`
+# from a link at the repository root would resolve above the root, which is why the
+# root-level link below has no leading `../`.
+repo=$(new_repo rel-symlink)
+mkdir -p "${repo}/docs"
+printf 'shared\n' > "${repo}/docs/shared.md"
+ln -s docs/shared.md "${repo}/link.md"
+git -C "$repo" add -A
+assert_clean "relative symlink inside the repository" "$repo"
+
+repo=$(new_repo rel-symlink-updir)
+mkdir -p "${repo}/docs"
+printf 'shared\n' > "${repo}/shared.md"
+ln -s ../shared.md "${repo}/docs/link.md"
+git -C "$repo" add -A
+assert_clean "relative symlink using ../ that stays inside the repository" "$repo"
+
+# --- hardcoded home directories ------------------------------------------------
+repo=$(new_repo home-macos)
+printf 'cache=/Users/rmordasiewicz/.cache/thing\n' > "${repo}/config.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded /Users/<name>/ path" "$repo"
+
+repo=$(new_repo home-linux)
+printf 'export DATA=/home/rmordasiewicz/data\n' > "${repo}/env.sh"
+git -C "$repo" add -A
+assert_violation "hardcoded /home/<name>/ path" "$repo"
+
+repo=$(new_repo home-windows)
+printf 'path=C:\\Users\\rmordasiewicz\\AppData\n' > "${repo}/win.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded C:\\Users\\<name>\\ path" "$repo"
+
+# --- placeholders are portable documentation, not violations -------------------
+repo=$(new_repo placeholder)
+printf 'Put the token in /Users/you/.config/token and /home/username/.netrc\n' > "${repo}/README.md"
+git -C "$repo" add -A
+assert_clean "placeholder home paths in documentation" "$repo"
+
+# --- CI home directories are not machine-specific ------------------------------
+repo=$(new_repo ci-home)
+printf 'workspace: /home/runner/work/repo/repo\n' > "${repo}/ci.yml"
+git -C "$repo" add -A
+assert_clean "CI runner home directory" "$repo"
+
+# --- the explicit escape hatch -------------------------------------------------
+repo=$(new_repo allow-marker)
+printf 'example=/Users/rmordasiewicz/thing  # repo-hygiene:allow\n' > "${repo}/notes.md"
+git -C "$repo" add -A
+assert_clean "line carrying repo-hygiene:allow" "$repo"
+
+# --- untracked files are out of scope: the check gates what is committed -------
+repo=$(new_repo untracked)
+printf 'cache=/Users/rmordasiewicz/.cache\n' > "${repo}/scratch.txt"
+assert_clean "untracked file with a home path" "$repo"
+
+# --- binary files must not produce noise ---------------------------------------
+repo=$(new_repo binary)
+printf '\x00\x01/Users/rmordasiewicz/x\x00' > "${repo}/blob.bin"
+git -C "$repo" add -A
+assert_clean "binary file is skipped" "$repo"
+
+# --- an exact home directory, with no trailing slash ---------------------------
+repo=$(new_repo home-exact)
+printf 'HOME=/home/rmordasiewicz\n' > "${repo}/env.sh"
+git -C "$repo" add -A
+assert_violation "hardcoded /home/<name> with no trailing slash" "$repo"
+
+repo=$(new_repo home-exact-macos)
+printf 'root=/Users/rmordasiewicz\n' > "${repo}/conf.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded /Users/<name> with no trailing slash" "$repo"
+
+# --- an allowed path must not launder a real one on the same line --------------
+repo=$(new_repo mixed-ci)
+printf 'PATH=/home/runner/bin:/home/rmordasiewicz/bin\n' > "${repo}/paths.sh"
+git -C "$repo" add -A
+assert_violation "real home alongside a CI home on one line" "$repo"
+
+repo=$(new_repo mixed-placeholder)
+printf 'see /Users/you/notes and /Users/rmordasiewicz/notes\n' > "${repo}/README.md"
+git -C "$repo" add -A
+assert_violation "real home alongside a placeholder on one line" "$repo"
+
+# --- a pathname containing spaces must not evade the symlink guard -------------
+repo=$(new_repo spaced-symlink)
+ln -s /some/other/checkout/x "${repo}/bad  link"
+git -C "$repo" add -A --force
+assert_violation "absolute symlink whose name contains repeated spaces" "$repo"
+
+# --- an option-like filename must not be handed to grep as an option -----------
+repo=$(new_repo dash-filename)
+printf 'cache=/Users/rmordasiewicz/.cache\n' > "${repo}/real.ini"
+printf 'placeholder\n' > "${repo}/-q"
+git -C "$repo" add -A
+assert_violation "home path still found when a file is named -q" "$repo"
+
+# --- backslash-escaped Windows paths, as they appear inside JSON ----------------
+repo=$(new_repo json-windows)
+printf '{"path": "C:\\\\Users\\\\rmordasiewicz\\\\data"}\n' > "${repo}/settings.json"
+git -C "$repo" add -A
+assert_violation "JSON-escaped C:\\\\Users\\\\<name> path" "$repo"
+
+# --- a relative symlink that escapes the repository ----------------------------
+repo=$(new_repo escaping-symlink)
+ln -s ../../home/rmordasiewicz/project "${repo}/outside"
+git -C "$repo" add -A --force
+assert_violation "relative symlink whose target escapes the repository" "$repo"
+
+# --- a dangling symlink must not silently disable the content scan -------------
+repo=$(new_repo dangling-symlink)
+printf 'cache=/Users/rmordasiewicz/.cache\n' > "${repo}/real.ini"
+ln -s ./nowhere-at-all "${repo}/dangling"
+git -C "$repo" add -A --force
+assert_violation "home path still found alongside a dangling symlink" "$repo"
+
+# --- Windows profiles outside C: ------------------------------------------------
+repo=$(new_repo windows-other-drive)
+printf 'path=D:\\Users\\rmordasiewicz\\data\n' > "${repo}/d.ini"
+git -C "$repo" add -A
+assert_violation "hardcoded D:\\Users\\<name> path" "$repo"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "check-repo-hygiene tests FAILED"
+  exit 1
+fi
+echo "check-repo-hygiene tests passed"

--- a/tests/test-check-repo-hygiene.sh
+++ b/tests/test-check-repo-hygiene.sh
@@ -19,31 +19,38 @@ new_repo() {
   git -C "$dir" init -q -b main
   git -C "$dir" config user.email hygiene@test
   git -C "$dir" config user.name "Hygiene Test"
-  printf 'ok\n' > "${dir}/README.md"
+  printf 'ok\n' >"${dir}/README.md"
   git -C "$dir" add -A
   git -C "$dir" commit -qm baseline
   echo "$dir"
 }
 
 _run() {
-  local rc=0
-  ( cd "$1" && bash "$SCRIPT" ) >/dev/null 2>&1 || rc=$?
+  local rc=0 dir="$1"
+  shift
+  (cd "$dir" && bash "$SCRIPT" "$@") >/dev/null 2>&1 || rc=$?
   echo "$rc"
 }
 
 assert_clean() {
-  local label="$1" rc
-  rc=$(_run "$2")
+  local label="$1" dir="$2"
+  shift 2
+  local rc
+  rc=$(_run "$dir" "$@")
   if [ "$rc" -eq 0 ]; then echo "[OK] $label -> clean"; else
-    echo "[FAIL] $label — expected clean (0), got $rc"; FAIL=1
+    echo "[FAIL] $label — expected clean (0), got $rc"
+    FAIL=1
   fi
 }
 
 assert_violation() {
-  local label="$1" rc
-  rc=$(_run "$2")
+  local label="$1" dir="$2"
+  shift 2
+  local rc
+  rc=$(_run "$dir" "$@")
   if [ "$rc" -eq 1 ]; then echo "[OK] $label -> rejected"; else
-    echo "[FAIL] $label — expected rejection (1), got $rc"; FAIL=1
+    echo "[FAIL] $label — expected rejection (1), got $rc"
+    FAIL=1
   fi
 }
 
@@ -63,84 +70,84 @@ assert_violation "tracked symlink with an absolute target" "$repo"
 # root-level link below has no leading `../`.
 repo=$(new_repo rel-symlink)
 mkdir -p "${repo}/docs"
-printf 'shared\n' > "${repo}/docs/shared.md"
+printf 'shared\n' >"${repo}/docs/shared.md"
 ln -s docs/shared.md "${repo}/link.md"
 git -C "$repo" add -A
 assert_clean "relative symlink inside the repository" "$repo"
 
 repo=$(new_repo rel-symlink-updir)
 mkdir -p "${repo}/docs"
-printf 'shared\n' > "${repo}/shared.md"
+printf 'shared\n' >"${repo}/shared.md"
 ln -s ../shared.md "${repo}/docs/link.md"
 git -C "$repo" add -A
 assert_clean "relative symlink using ../ that stays inside the repository" "$repo"
 
 # --- hardcoded home directories ------------------------------------------------
 repo=$(new_repo home-macos)
-printf 'cache=/Users/rmordasiewicz/.cache/thing\n' > "${repo}/config.ini"
+printf 'cache=/Users/rmordasiewicz/.cache/thing\n' >"${repo}/config.ini"
 git -C "$repo" add -A
-assert_violation "hardcoded /Users/<name>/ path" "$repo"
+assert_violation "hardcoded /Users/<name>/ path" "$repo" --include-paths
 
 repo=$(new_repo home-linux)
-printf 'export DATA=/home/rmordasiewicz/data\n' > "${repo}/env.sh"
+printf 'export DATA=/home/rmordasiewicz/data\n' >"${repo}/env.sh"
 git -C "$repo" add -A
-assert_violation "hardcoded /home/<name>/ path" "$repo"
+assert_violation "hardcoded /home/<name>/ path" "$repo" --include-paths
 
 repo=$(new_repo home-windows)
-printf 'path=C:\\Users\\rmordasiewicz\\AppData\n' > "${repo}/win.ini"
+printf 'path=C:\\Users\\rmordasiewicz\\AppData\n' >"${repo}/win.ini"
 git -C "$repo" add -A
-assert_violation "hardcoded C:\\Users\\<name>\\ path" "$repo"
+assert_violation "hardcoded C:\\Users\\<name>\\ path" "$repo" --include-paths
 
 # --- placeholders are portable documentation, not violations -------------------
 repo=$(new_repo placeholder)
-printf 'Put the token in /Users/you/.config/token and /home/username/.netrc\n' > "${repo}/README.md"
+printf 'Put the token in /Users/you/.config/token and /home/username/.netrc\n' >"${repo}/README.md"
 git -C "$repo" add -A
-assert_clean "placeholder home paths in documentation" "$repo"
+assert_clean "placeholder home paths in documentation" "$repo" --include-paths
 
 # --- CI home directories are not machine-specific ------------------------------
 repo=$(new_repo ci-home)
-printf 'workspace: /home/runner/work/repo/repo\n' > "${repo}/ci.yml"
+printf 'workspace: /home/runner/work/repo/repo\n' >"${repo}/ci.yml"
 git -C "$repo" add -A
-assert_clean "CI runner home directory" "$repo"
+assert_clean "CI runner home directory" "$repo" --include-paths
 
 # --- the explicit escape hatch -------------------------------------------------
 repo=$(new_repo allow-marker)
-printf 'example=/Users/rmordasiewicz/thing  # repo-hygiene:allow\n' > "${repo}/notes.md"
+printf 'example=/Users/rmordasiewicz/thing  # repo-hygiene:allow\n' >"${repo}/notes.md"
 git -C "$repo" add -A
-assert_clean "line carrying repo-hygiene:allow" "$repo"
+assert_clean "line carrying repo-hygiene:allow" "$repo" --include-paths
 
 # --- untracked files are out of scope: the check gates what is committed -------
 repo=$(new_repo untracked)
-printf 'cache=/Users/rmordasiewicz/.cache\n' > "${repo}/scratch.txt"
-assert_clean "untracked file with a home path" "$repo"
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/scratch.txt"
+assert_clean "untracked file with a home path" "$repo" --include-paths
 
 # --- binary files must not produce noise ---------------------------------------
 repo=$(new_repo binary)
-printf '\x00\x01/Users/rmordasiewicz/x\x00' > "${repo}/blob.bin"
+printf '\x00\x01/Users/rmordasiewicz/x\x00' >"${repo}/blob.bin"
 git -C "$repo" add -A
-assert_clean "binary file is skipped" "$repo"
+assert_clean "binary file is skipped" "$repo" --include-paths
 
 # --- an exact home directory, with no trailing slash ---------------------------
 repo=$(new_repo home-exact)
-printf 'HOME=/home/rmordasiewicz\n' > "${repo}/env.sh"
+printf 'HOME=/home/rmordasiewicz\n' >"${repo}/env.sh"
 git -C "$repo" add -A
-assert_violation "hardcoded /home/<name> with no trailing slash" "$repo"
+assert_violation "hardcoded /home/<name> with no trailing slash" "$repo" --include-paths
 
 repo=$(new_repo home-exact-macos)
-printf 'root=/Users/rmordasiewicz\n' > "${repo}/conf.ini"
+printf 'root=/Users/rmordasiewicz\n' >"${repo}/conf.ini"
 git -C "$repo" add -A
-assert_violation "hardcoded /Users/<name> with no trailing slash" "$repo"
+assert_violation "hardcoded /Users/<name> with no trailing slash" "$repo" --include-paths
 
 # --- an allowed path must not launder a real one on the same line --------------
 repo=$(new_repo mixed-ci)
-printf 'PATH=/home/runner/bin:/home/rmordasiewicz/bin\n' > "${repo}/paths.sh"
+printf 'PATH=/home/runner/bin:/home/rmordasiewicz/bin\n' >"${repo}/paths.sh"
 git -C "$repo" add -A
-assert_violation "real home alongside a CI home on one line" "$repo"
+assert_violation "real home alongside a CI home on one line" "$repo" --include-paths
 
 repo=$(new_repo mixed-placeholder)
-printf 'see /Users/you/notes and /Users/rmordasiewicz/notes\n' > "${repo}/README.md"
+printf 'see /Users/you/notes and /Users/rmordasiewicz/notes\n' >"${repo}/README.md"
 git -C "$repo" add -A
-assert_violation "real home alongside a placeholder on one line" "$repo"
+assert_violation "real home alongside a placeholder on one line" "$repo" --include-paths
 
 # --- a pathname containing spaces must not evade the symlink guard -------------
 repo=$(new_repo spaced-symlink)
@@ -150,16 +157,16 @@ assert_violation "absolute symlink whose name contains repeated spaces" "$repo"
 
 # --- an option-like filename must not be handed to grep as an option -----------
 repo=$(new_repo dash-filename)
-printf 'cache=/Users/rmordasiewicz/.cache\n' > "${repo}/real.ini"
-printf 'placeholder\n' > "${repo}/-q"
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/real.ini"
+printf 'placeholder\n' >"${repo}/-q"
 git -C "$repo" add -A
-assert_violation "home path still found when a file is named -q" "$repo"
+assert_violation "home path still found when a file is named -q" "$repo" --include-paths
 
 # --- backslash-escaped Windows paths, as they appear inside JSON ----------------
 repo=$(new_repo json-windows)
-printf '{"path": "C:\\\\Users\\\\rmordasiewicz\\\\data"}\n' > "${repo}/settings.json"
+printf '{"path": "C:\\\\Users\\\\rmordasiewicz\\\\data"}\n' >"${repo}/settings.json"
 git -C "$repo" add -A
-assert_violation "JSON-escaped C:\\\\Users\\\\<name> path" "$repo"
+assert_violation "JSON-escaped C:\\\\Users\\\\<name> path" "$repo" --include-paths
 
 # --- a relative symlink that escapes the repository ----------------------------
 repo=$(new_repo escaping-symlink)
@@ -169,16 +176,37 @@ assert_violation "relative symlink whose target escapes the repository" "$repo"
 
 # --- a dangling symlink must not silently disable the content scan -------------
 repo=$(new_repo dangling-symlink)
-printf 'cache=/Users/rmordasiewicz/.cache\n' > "${repo}/real.ini"
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/real.ini"
 ln -s ./nowhere-at-all "${repo}/dangling"
 git -C "$repo" add -A --force
-assert_violation "home path still found alongside a dangling symlink" "$repo"
+assert_violation "home path still found alongside a dangling symlink" "$repo" --include-paths
 
 # --- Windows profiles outside C: ------------------------------------------------
 repo=$(new_repo windows-other-drive)
-printf 'path=D:\\Users\\rmordasiewicz\\data\n' > "${repo}/d.ini"
+printf 'path=D:\\Users\\rmordasiewicz\\data\n' >"${repo}/d.ini"
 git -C "$repo" add -A
-assert_violation "hardcoded D:\\Users\\<name> path" "$repo"
+assert_violation "hardcoded D:\\Users\\<name> path" "$repo" --include-paths
+
+# --- the home-directory scan is opt-in ------------------------------------------
+repo=$(new_repo opt-in)
+printf 'cache=/Users/rmordasiewicz/.cache\n' >"${repo}/config.ini"
+git -C "$repo" add -A
+assert_clean "home paths are ignored without --include-paths" "$repo"
+assert_violation "home paths are reported with --include-paths" "$repo" --include-paths
+
+# --- forms measured across the fleet that must NOT be flagged ------------------
+repo=$(new_repo fleet-false-positives)
+# A URL route such as /home/index is NOT covered: it is indistinguishable from a
+# home directory belonging to a user called "index". That is a documented limit of
+# the opt-in scan, which is why it is opt-in.
+{
+  printf 'ENV HOME=/home/${USERNAME}\n'
+  printf 'curl http://api/Users/1 http://api/Users/2\n'
+  printf 'see /Users/<you>/notes and /Users/userid/example\n'
+  printf 'win=%%USERPROFILE%%\n'
+} >"${repo}/mixed.txt"
+git -C "$repo" add -A
+assert_clean "variables, URL routes, numeric ids and placeholders" "$repo" --include-paths
 
 if [ "$FAIL" -ne 0 ]; then
   echo "check-repo-hygiene tests FAILED"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -189,6 +189,43 @@ for v in POWERSHELL HTML CPP RUST_2015 DOCKERFILE_HADOLINT BASH_EXEC EDITORCONFI
 done
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 5f: the repo-hygiene gate never executes PR-head code
+#             (REVIEWER-SPEC.md invariant 3). The Lint Code Base job holds
+#             statuses:write and pull-requests:write, so running a PR's own
+#             copy of the script would hand those scopes to PR-authored code,
+#             and gating on the head's copy would let a PR delete the file to
+#             skip the gate.
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 5f: repo-hygiene gate trust boundary ==="
+
+HYG_STEP=$(awk '/- name: Check repository hygiene/,/^      - name: Setup Biome/' "$SL_YML")
+
+if [ -n "$HYG_STEP" ]; then
+  pass "5f.1 repo-hygiene step is present in the lint job"
+else
+  fail "5f.1 repo-hygiene step is present in the lint job" "step not found"
+fi
+
+if printf '%s' "$HYG_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
+  pass "5f.2 runs the default-branch copy of the script"
+else
+  fail "5f.2 runs the default-branch copy of the script" "no git show of the default-branch copy"
+fi
+
+if printf '%s' "$HYG_STEP" | grep -qE '^[[:space:]]*run: bash scripts/check-repo-hygiene\.sh[[:space:]]*$'; then
+  fail "5f.3 does not execute the PR head's copy" "step runs the head working-copy script directly"
+else
+  pass "5f.3 does not execute the PR head's copy"
+fi
+
+if printf '%s' "$HYG_STEP" | grep -q "hashFiles('scripts/check-repo-hygiene.sh')"; then
+  fail "5f.4 enforcement cannot be skipped by deleting the file" "step is gated on the head's copy"
+else
+  pass "5f.4 enforcement cannot be skipped by deleting the file"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 6: zizmor.yaml suppressions are complete enough for caller
 #            workflows + typical downstream CI patterns to scan clean
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #778

## Why

A machine-specific `node_modules` symlink reached `codex-plugin-cc` `main` and **neither existing layer caught it**: CI runs `npm ci`, which creates the real directory and masks the dangling link; the agentic reviewer treated an added symlink as unremarkable. It surfaced only during post-merge git hygiene.

Root cause of the escape: `.gitignore` said `node_modules/`, and **a trailing slash matches only directories** — a symlink of that name is not one, so `git add -A` staged it. That is why `.codex-review` is ignored here *without* a trailing slash.

`REVIEWER-SPEC.md` already says deterministic checks belong in the lint gate rather than the judgment layer. This adds the missing one, for the class rather than the instance.

## What it rejects, and what it deliberately does not

| Rejected | Accepted |
|---|---|
| absolute symlink targets | relative symlinks that stay in-repo, including via `../` |
| relative targets that climb out of the repo | placeholder paths (`/Users/you/`, `/home/username/`) |
| `/Users/<name>`, `/home/<name>` (slash optional) | CI runner homes (`/home/runner/…`) |
| `<any-drive>:\Users\<name>`, UNC profile paths | lines carrying `repo-hygiene:allow` |
| JSON-escaped `C:\\Users\\<name>` | untracked and binary files |

## Wired to actually run

Both places that matter: a step in the `Lint Code Base` job, and a `pre-commit` hook — the hook matters because **`xcsh` opts out of the super-linter workflow entirely**, so a workflow-only check would miss it.

Worth flagging: `scripts/locale-lint.sh` is distributed and unit-tested but **never executed by any workflow or hook**. It is an orphaned check. I did not replicate that pattern, and did not fix it here either — it belongs to a separate concern. Raising it as a follow-up.

## The trust boundary (a `high` finding on my own first draft)

My first version ran `bash scripts/check-repo-hygiene.sh` from the checked-out head. The pre-push review flagged it as `high`, and it was right — it violated `REVIEWER-SPEC.md` **invariant 3** ("never execute scripts carried in the PR head") in a job holding `statuses: write` and `pull-requests: write`, and gating on `hashFiles` of the head meant **a pull request could delete the file to skip the gate**.

The fix is the one this repository already documents for `verify.sh`: run the **default-branch** copy's logic against the head's code. The script only reads git metadata and tracked content, so trusted logic over untrusted data is safe. `tests/test-linter-configs.sh` section 5f now asserts all four properties of that boundary so it cannot regress.

## Index-based scanning

The content scan uses `git grep --cached`, so the working tree is never read. A symlink is matched on its own target text instead of being dereferenced, and a dangling link cannot make the scan fail open.

## A pre-existing bug fixed in passing

`scripts/**` and `tests/**` were **both absent** from the manifest workflow's `on.push.paths`. Editing `scripts/locale-lint.sh` on `main` therefore never rebuilt `managed-files-manifest.json`, so drift detection silently passed. My new files would have inherited that; adding both patterns fixes it for everything under those trees.

## Verification

- **22 assertions** in `tests/test-check-repo-hygiene.sh`; all **14** shell suites pass; `pre-commit` clean (including `actionlint` and `zizmor` on the edited workflow).
- **Flags the real historical defect**: run against `codex-plugin-cc@c41cf85` it exits 1 naming the symlink and its target; against that repo's fixed `main` it exits 0.
- `tests/test-linter-configs.sh` now 103 assertions, `tests/test-protect-managed-files.sh` 117 — both green with the new protected entries.

Four review iterations found nine confirmed defects in this change, every one a **false negative** in a gate whose entire value is catching what slips through: line-level allowlisting laundering a real path, `/home/<user>` without a trailing slash, whitespace-mangled symlink paths, option-injection via a file named `-q`, JSON-escaped backslashes, non-`C:` drives, dereferenced symlinks, escaping relative targets, and the head-execution hole above. One was my own test fixture asserting that an escaping symlink was clean — the new logic caught the bad test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)