### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-25T04:27:07Z",
-  "source_commit": "e4ddcac1ae955df5c903a56c26067057642008a9",
+  "generated_at": "2026-07-25T13:23:44Z",
+  "source_commit": "dacb917cf54b39403e6438e553c6a3f52655ec21",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -83,8 +83,8 @@
     ".gitignore": {
       "src": ".gitignore",
       "dest": ".gitignore",
-      "sha": "445e3c172760d25e3a400fcb387b004c6fc31bfd",
-      "size": 2609
+      "sha": "cee6d64b8975d86ffa11a7d5bb292a71f7d25f50",
+      "size": 2761
     },
     "LICENSE": {
       "src": "LICENSE",
@@ -95,8 +95,8 @@
     ".pre-commit-config.yaml": {
       "src": ".pre-commit-config.yaml",
       "dest": ".pre-commit-config.yaml",
-      "sha": "02b977013430f4ae1fdd0d6deb73c3b228764298",
-      "size": 8846
+      "sha": "c707f674513cb0d3619b6cbfee9b1f948935d6d8",
+      "size": 9572
     },
     ".yamllint.yaml": {
       "src": ".yamllint.yaml",
@@ -224,11 +224,23 @@
       "sha": "5a0e66b0b5e05cf9da85f97976b2495081739399",
       "size": 1783
     },
+    "scripts/check-repo-hygiene.sh": {
+      "src": "scripts/check-repo-hygiene.sh",
+      "dest": "scripts/check-repo-hygiene.sh",
+      "sha": "5f3df07f0053ff38c7d1ac5d0fd2e1cdbeb2d7d4",
+      "size": 6930
+    },
+    "tests/test-check-repo-hygiene.sh": {
+      "src": "tests/test-check-repo-hygiene.sh",
+      "dest": "tests/test-check-repo-hygiene.sh",
+      "sha": "8a9c6ed71110c1b1f602ea6c218bce4453c5b129",
+      "size": 8518
+    },
     ".claude/governance.json": {
       "src": ".claude/governance.json",
       "dest": ".claude/governance.json",
-      "sha": "8027d05b9e0cf58a389647b6dfcda4a83060680e",
-      "size": 2237
+      "sha": "f015bb3cdcc761f46b10fcd2299ae83cce284846",
+      "size": 2314
     },
     ".claude/settings.json": {
       "src": ".claude/settings.json",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.