### PR TITLE
fix(governance): audit docs-control with its own workflow-security audit

### DIFF
--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -1,0 +1,64 @@
+---
+name: Workflow Security Audit
+
+# Scheduled zizmor audit over ALL workflow files in this repo.
+#
+# WHY THIS EXISTS: the `Lint Code Base` gate runs super-linter with
+# VALIDATE_ALL_CODEBASE=false, so its zizmor pass only audits workflow files a PR
+# actually CHANGED. A workflow that is never edited is therefore never audited, and
+# its findings can sit indefinitely. That is not hypothetical: vscode-xcsh's ci.yml
+# carried 4 high-severity `template-injection` vectors (attacker-controlled
+# `repository_dispatch` client_payload interpolated into a `run:` body) plus 5
+# `excessive-permissions` findings, invisible until an unrelated PR happened to touch
+# the file. This job closes that blind spot by auditing every workflow on a schedule.
+#
+# The PR-time gate is unchanged and still catches regressions in changed files; this
+# is the backstop for the files nobody is touching.
+on:
+  schedule:
+    # Weekly, off-peak, deliberately not on the hour.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - 'zizmor.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: workflow-security-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit workflows (zizmor)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # Full report first (all severities) into the run summary, so low and
+      # informational findings are visible and countable without failing the job.
+      - name: Report all findings
+        run: |
+          set -uo pipefail
+          {
+            echo '## Workflow security audit (zizmor)'
+            echo
+            echo 'Full report — every severity. The job only FAILS on medium or higher.'
+            echo
+            echo '```'
+            pipx run zizmor --config zizmor.yaml .github/workflows/ 2>&1 || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Gate on what actually matters. Low/informational findings (e.g. ad-hoc
+      # package installs) are reported above but do not fail the audit, so a repo is
+      # not permanently red over hygiene items. Medium and high — excessive
+      # permissions, template injection, credential persistence — do fail, because
+      # those are exploitable and someone needs to look.
+      - name: Fail on medium or higher
+        run: pipx run zizmor --config zizmor.yaml --min-severity medium .github/workflows/


### PR DESCRIPTION
## Problem

docs-control distributes `workflow-security-audit.yml` (#775) to every repo in the fleet but
never installed it into its own `.github/workflows/`. The repository holding every workflow
template and all the governance logic was the one repo the audit did not cover.

## Why this is an omission rather than a deliberate exclusion

I checked before assuming:

- Already in `managed_files.files` (entry 44) **and** `.claude/governance.json`
  `protected_files`, so the pairing `tests/test-protect-managed-files.sh` 3.1 enforces is
  already satisfied — nothing to add there.
- **No `skip_files` entry for docs-control at all**, and nothing excludes this file anywhere.
- **Seven** managed workflow templates are already self-applied here:
  `github-pages-deploy.yml`, `enforce-repo-settings.yml`, `require-linked-issue.yml`,
  `super-linter.yml`, `translation-audit.yml`, `dependabot-auto-merge.yml`, `auto-merge.yml`.
  `translation-audit.yml` is the same shape — a scheduled audit — so this follows existing
  precedent rather than inventing a pattern.

## Change

One file added: `.github/workflows/workflow-security-audit.yml`, **byte-identical** to
`workflows/workflow-security-audit.yml` (`diff -q` clean), so the next managed-files sync is
a no-op rather than a conflict.

## Severity — latent, not active

Worth being precise: **docs-control is already clean.** zizmor 1.25.2 reports no findings at
any severity across all of its workflows, including the new one. Nothing was hiding.

What was missing is the backstop. The premise of #775 is that `Lint Code Base` runs
super-linter with `VALIDATE_ALL_CODEBASE=false`, so a workflow nobody edits is never
audited. That blind spot applied in full to the repo the fleet's templates originate from.
This sweep is exactly why that matters — vscode-xcsh#976 and xcsh#2360 were both findings in
files no PR had touched.

## Verification

| Check | Result |
|---|---|
| `zizmor 1.25.2 .github/workflows/` | exit **0**, no findings, any severity |
| `actionlint` | exit **0** |
| `bash tests/test-protect-managed-files.sh` | **117 passed, 0 failed** |
| every script in `tests/` | all pass |
| `diff -q` vs template | identical |

Biome does not apply — it ignores `.github/workflows/`.

Post-merge this needs confirming by effect, not by the green check on this PR: the audit
should start appearing in `gh run list -R f5-sales-demo/docs-control --workflow "Workflow
Security Audit"`, which currently returns nothing at all.

Closes #783
