### PR TITLE
fix: enforce locale-lint, and let the canonical package pass it

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -52,6 +52,23 @@ jobs:
           fi
           git show "origin/${branch}:${script}" | bash -s
 
+      # Same trust boundary as the step above: the default-branch copy of the script
+      # is run against the head working tree, never the head's own copy. Repositories
+      # that opt out of this script via skip_files simply have nothing to enforce.
+      - name: Check for hardcoded locale lists
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          script=scripts/locale-lint.sh
+          branch="${DEFAULT_BRANCH:-main}"
+          git fetch --no-tags --quiet origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+          if ! git cat-file -e "origin/${branch}:${script}" 2>/dev/null; then
+            echo "The default branch does not carry ${script}; nothing to enforce."
+            exit 0
+          fi
+          git show "origin/${branch}:${script}" | bash -s
+
       # Biome runs OUTSIDE the Super-Linter container so we can track Biome
       # `latest` instead of being gated on Super-Linter's container release
       # cadence. Authority boundary: setup-biome owns JS/TS/JSON/JSX; the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,22 @@ repos:
         pass_filenames: false
 
   # ===========================================================================
+  # Locale lint — hardcoded locale lists should import from @f5-sales-demo/i18n-core.
+  # The script no-ops in repositories that do not carry it.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: locale-lint
+        name: Locale lint
+        entry: >-
+          bash -c
+          'if [ -f scripts/locale-lint.sh ];
+          then bash scripts/locale-lint.sh; fi'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+  # ===========================================================================
   # File size guard
   # ===========================================================================
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -236,6 +252,7 @@ ci:
   skip:
     - local-hooks
     - check-repo-hygiene
+    - locale-lint
     - yamllint
     - markdownlint
     - shellcheck

--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -41,6 +41,15 @@ check_pattern() {
   return 0
 }
 
+# The package that owns these definitions cannot import them from itself. The
+# exclusion below matches "i18n-core/src/", which only appears when i18n-core is a
+# dependency; inside its own repository the path is "./src/...", so the check used
+# to flag its own source of truth and could never pass there.
+if [ -f package.json ] && grep -qE '"name"[[:space:]]*:[[:space:]]*"@f5-sales-demo/i18n-core"' package.json; then
+  echo "Locale lint: this is the i18n-core package itself — its locale definitions are canonical."
+  exit 0
+fi
+
 echo "Locale lint: checking for hardcoded locale lists..."
 echo ""
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -199,7 +199,8 @@ done
 echo ""
 echo "=== Section 5f: repo-hygiene gate trust boundary ==="
 
-HYG_STEP=$(awk '/- name: Check repository hygiene/,/^      - name: Setup Biome/' "$SL_YML")
+HYG_STEP=$(awk '/- name: Check repository hygiene/,/- name: Check for hardcoded locale lists/' "$SL_YML")
+LOCALE_STEP=$(awk '/- name: Check for hardcoded locale lists/,/^      - name: Setup Biome/' "$SL_YML")
 
 if [ -n "$HYG_STEP" ]; then
   pass "5f.1 repo-hygiene step is present in the lint job"
@@ -223,6 +224,32 @@ if printf '%s' "$HYG_STEP" | grep -q "hashFiles('scripts/check-repo-hygiene.sh')
   fail "5f.4 enforcement cannot be skipped by deleting the file" "step is gated on the head's copy"
 else
   pass "5f.4 enforcement cannot be skipped by deleting the file"
+fi
+
+# Every governed script the lint job executes must come from the default branch,
+# never from the pull request head, and must not be skippable by deleting the file.
+if [ -n "$LOCALE_STEP" ]; then
+  pass "5f.5 locale-lint step is present in the lint job"
+else
+  fail "5f.5 locale-lint step is present in the lint job" "step not found"
+fi
+
+if printf '%s' "$LOCALE_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
+  pass "5f.6 locale-lint runs the default-branch copy"
+else
+  fail "5f.6 locale-lint runs the default-branch copy" "no git show of the default-branch copy"
+fi
+
+if printf '%s' "$LOCALE_STEP" | grep -qE '^[[:space:]]*run: bash scripts/locale-lint\.sh[[:space:]]*$'; then
+  fail "5f.7 locale-lint does not execute the head's copy" "step runs the head working-copy script"
+else
+  pass "5f.7 locale-lint does not execute the head's copy"
+fi
+
+if printf '%s' "$LOCALE_STEP" | grep -q "hashFiles('scripts/locale-lint.sh')"; then
+  fail "5f.8 locale-lint enforcement cannot be skipped by deleting the file" "gated on the head's copy"
+else
+  pass "5f.8 locale-lint enforcement cannot be skipped by deleting the file"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-locale-lint.sh
+++ b/tests/test-locale-lint.sh
@@ -156,6 +156,46 @@ else
   fail "8. test files excluded" "exit $EXIT_CODE"
 fi
 
+# The package that owns these definitions cannot import them from itself. Inside
+# i18n-core the path is ./src/..., with no "i18n-core/" prefix for the existing
+# exclusion to match, so the check flagged its own source of truth.
+setup_clean_repo
+cat >"$TMPDIR_BASE/repo/package.json" <<'JSON'
+{ "name": "@f5-sales-demo/i18n-core", "version": "1.0.0" }
+JSON
+cat >"$TMPDIR_BASE/repo/src/display-names.ts" <<'TS'
+import { LOCALE_REGISTRY } from './registry.js';
+
+export const LOCALE_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.fromEntries(
+  LOCALE_REGISTRY.map((entry) => [entry.slug, entry.labelEn]),
+);
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+  pass "i18n-core itself passes — its definitions are canonical"
+else
+  fail "i18n-core itself passes" "exit $EXIT_CODE: $OUTPUT"
+fi
+
+# A repo that merely depends on i18n-core is still held to the rule.
+setup_clean_repo
+cat >"$TMPDIR_BASE/repo/package.json" <<'JSON'
+{ "name": "@f5-sales-demo/docs-theme", "dependencies": { "@f5-sales-demo/i18n-core": "^1.0.0" } }
+JSON
+cat >"$TMPDIR_BASE/repo/src/bad.ts" <<'TS'
+export const LOCALE_DISPLAY_NAMES = { en: 'English' };
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -ne 0 ]; then
+  pass "a consumer of i18n-core is still checked"
+else
+  fail "a consumer of i18n-core is still checked" "expected non-zero exit"
+fi
+
 echo ""
 echo "════════════════════════════════════════════"
 echo "  Results: $PASS passed, $FAIL failed ($((PASS + FAIL)) total)"


### PR DESCRIPTION
Closes #785
**Depends on f5-sales-demo/docs-theme#1010 — do not merge before that lands.**

## The check was inert

`scripts/locale-lint.sh` is synced to every governed repository and `tests/test-locale-lint.sh` runs in `Shell Unit Tests` — but **nothing ever ran the script against a repository**. Grepping `locale-lint` outside its own test returns only the governance manifests.

An inert check is worse than no check: it implies the rule is covered when it isn't. Found while wiring the repo-hygiene gate (#779), where I deliberately did not copy this pattern.

## It also could not pass in the repository that owns the definitions

The exclusion is `i18n-core/(src|dist)/`, which only matches when i18n-core appears as a **dependency** path. Inside i18n-core itself the path is `./src/display-names.ts`, so the check flagged:

```ts
export const LOCALE_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.fromEntries(
  LOCALE_REGISTRY.map((entry) => [entry.slug, entry.labelEn]),
);
```

That is the canonical definition, derived from the registry — the very thing every other repository is told to import. Now detected by package name and skipped, with a companion test proving a mere **consumer** of i18n-core is still held to the rule.

## Measured before enforcing

Run against `origin/HEAD` of all 38 governed repositories:

| | Before the fix | After |
|---|---|---|
| clean | 36 | **37** |
| flagged | `docs-theme` (genuine), `i18n-core` (false positive) | `docs-theme` only |

`docs-theme#1010` fixes the genuine one, which is why this PR is sequenced behind it. Enabling enforcement first would turn that repository's gate red.

## Trust boundary, asserted for both steps

The step runs the **default-branch** copy of the script against the head working tree, per `REVIEWER-SPEC.md` invariant 3 — the `Lint Code Base` job holds `statuses: write` and `pull-requests: write`, and gating on the head's copy would let a pull request delete the file to skip the check.

`tests/test-linter-configs.sh` section 5f now covers **both** governed-script steps (5f.1–5f.4 repo-hygiene, 5f.5–5f.8 locale-lint), so a third cannot be added the unsafe way. 107 assertions, all green.

Kept as a separate step rather than folded into a loop with the hygiene check: the two differ (`terraform-provider-xcsh` opts out of locale-lint via `skip_files`; hygiene always applies), and the hygiene step is already verified running in production CI. Worth factoring if a third arrives — not before.

## Verification

- `tests/test-locale-lint.sh`: 10/10 (was 8; two added, both red before the fix).
- `tests/test-linter-configs.sh`: 107/107.
- All 14 shell suites pass; `pre-commit` clean with both new hooks visibly running; **`shfmt` clean** — it runs in the lint gate but not in pre-commit, which is how it failed me on #779.
- The real `i18n-core` repository now reports: *"this is the i18n-core package itself — its locale definitions are canonical."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)