### PR TITLE
feat: automate the fleet pre-flight for new governed checks

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -289,6 +289,10 @@ jobs:
         if: hashFiles('tests/test-locale-lint.sh') != ''
         run: bash tests/test-locale-lint.sh
 
+      - name: Run fleet pre-flight test
+        if: hashFiles('tests/test-preflight-fleet.sh') != ''
+        run: bash tests/test-preflight-fleet.sh
+
       - name: Run check-repo-hygiene test
         if: hashFiles('tests/test-check-repo-hygiene.sh') != ''
         run: bash tests/test-check-repo-hygiene.sh

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -122,6 +122,41 @@ Each downstream repository receives a generated `README.md` built from two sourc
 
 The workflow matches the repository name against docs-sites.json URLs to find the label and description. It falls back to a capitalized repository name for the title and the GitHub API repository description if no match is found.
 
+## Pre-flight a new governed check
+
+A check added to the `Lint Code Base` gate becomes a **required** check in every
+governed repository the moment it syncs. Measure the blast radius before enforcing
+it, never after:
+
+```bash
+bash scripts/preflight-fleet.sh --check scripts/my-new-check.sh
+```
+
+The tool runs the check against each repository's **live default branch**
+(`origin/HEAD`) in a throwaway worktree, and exits non-zero if any repository would
+break. It is `skip_files`-aware, so a repository that opts out of the script is
+reported as skipped rather than as a phantom failure.
+
+Two checks in this repository needed this answer before they shipped:
+
+| Check | What the pre-flight found |
+| --- | --- |
+| `check-repo-hygiene.sh` home-path scan | would fail 10 of 38 repositories, only 2 findings real — the scan was made opt-in as a result |
+| `locale-lint.sh` | flagged `i18n-core`, the package that owns the data it tells everyone else to import |
+
+Neither was visible from the diff, so no amount of code review would have surfaced
+them.
+
+Read the coverage line, not just the verdict. A repository with no local clone is
+reported as `uncloned` and is **not** counted as clean — a repository nobody
+checked is not a repository known to be fine. Do not read a clean result as
+fleet-wide safety while that count is above zero.
+
+Reading the operator's working tree instead of `origin/HEAD` is the specific trap
+this tool exists to avoid: local clones are routinely stale or dirty, and they
+produce confident, wrong answers. The suite in `tests/test-preflight-fleet.sh`
+asserts both directions of that trap.
+
 ## Drift resolution
 
 When drift is detected in any static or dynamic file, the workflow:

--- a/scripts/preflight-fleet.sh
+++ b/scripts/preflight-fleet.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Answers one question before a check is enforced fleet-wide: which governed
+# repositories would it break?
+#
+# A check added to the Lint Code Base gate becomes a REQUIRED check in every
+# governed repository the moment it syncs. Two checks written in this repository
+# were measured this way first, and both needed the answer: one would have failed
+# 10 of 38 repositories with only 2 real findings, and one flagged the very package
+# that owns the data it tells everyone else to import. Neither was visible from the
+# diff, so no amount of review would have surfaced them.
+#
+# Judges each repository's LIVE default branch (origin/HEAD) in a throwaway
+# worktree, never the operator's working tree. A local clone is usually stale or
+# dirty, and reading it produces confident, wrong answers.
+#
+# Usage:
+#   bash scripts/preflight-fleet.sh --check scripts/check-repo-hygiene.sh
+#   bash scripts/preflight-fleet.sh --check scripts/locale-lint.sh --json
+#   bash scripts/preflight-fleet.sh --check ./my-check.sh --args "--include-paths"
+#
+# Options:
+#   --check <path>            The check to trial. Required. Run with the repository
+#                             root as its working directory.
+#   --args "<string>"         Arguments forwarded to the check, word-split.
+#   --repos-file <path>       Repository list. Default .github/config/downstream-repos.json
+#   --governance-file <path>  skip_files source. Default .claude/governance.json
+#   --search-path <dir>       Where to look for local clones. Repeatable.
+#                             Default: $HOME/GIT and $HOME/GIT/security
+#   --no-fetch                Skip `git fetch`. Offline and for tests; results are
+#                             then only as current as the last fetch.
+#   --json                    Emit machine-readable results.
+#
+# Exit 0 = no governed repository would break. Exit 1 = at least one would, or the
+# invocation was invalid. Repositories that are not cloned locally are reported as a
+# coverage gap rather than counted as clean: a repository nobody checked is not a
+# repository known to be fine.
+set -euo pipefail
+
+CHECK=""
+CHECK_ARGS=""
+REPOS_FILE=".github/config/downstream-repos.json"
+GOVERNANCE_FILE=".claude/governance.json"
+NO_FETCH=0
+AS_JSON=0
+SEARCH_PATHS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --check)
+    CHECK="${2:-}"
+    shift 2
+    ;;
+  --args)
+    CHECK_ARGS="${2:-}"
+    shift 2
+    ;;
+  --repos-file)
+    REPOS_FILE="${2:-}"
+    shift 2
+    ;;
+  --governance-file)
+    GOVERNANCE_FILE="${2:-}"
+    shift 2
+    ;;
+  --search-path)
+    SEARCH_PATHS+=("${2:-}")
+    shift 2
+    ;;
+  --no-fetch)
+    NO_FETCH=1
+    shift
+    ;;
+  --json)
+    AS_JSON=1
+    shift
+    ;;
+  -h | --help)
+    sed -n '2,40p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "::error::unknown argument: $1" >&2
+    exit 1
+    ;;
+  esac
+done
+
+if [ -z "$CHECK" ]; then
+  echo "::error::--check <path> is required." >&2
+  exit 1
+fi
+if [ ! -f "$CHECK" ]; then
+  echo "::error::check script not found: ${CHECK}" >&2
+  exit 1
+fi
+CHECK=$(cd "$(dirname "$CHECK")" && pwd)/$(basename "$CHECK")
+
+if [ ! -f "$REPOS_FILE" ]; then
+  echo "::error::repository list not found: ${REPOS_FILE}" >&2
+  exit 1
+fi
+
+if [ ${#SEARCH_PATHS[@]} -eq 0 ]; then
+  SEARCH_PATHS=("${HOME}/GIT" "${HOME}/GIT/security")
+fi
+
+CHECK_BASENAME=$(basename "$CHECK")
+
+# A while-read loop rather than `mapfile`: this is an operator tool, and macOS
+# ships bash 3.2, which has no mapfile.
+REPOS=()
+while IFS= read -r repo_name; do
+  [ -n "$repo_name" ] && REPOS+=("$repo_name")
+done < <(python3 -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+names = data if isinstance(data, list) else data.get("repos", data.get("repositories", []))
+for entry in names:
+    name = entry if isinstance(entry, str) else (entry.get("name") or entry.get("repo") or "")
+    if name:
+        print(name.split("/")[-1])
+' "$REPOS_FILE")
+
+if [ ${#REPOS[@]} -eq 0 ]; then
+  echo "::error::no repositories parsed from ${REPOS_FILE}" >&2
+  exit 1
+fi
+
+# A repository that opts out of the check never receives it, so a finding there
+# would be a phantom.
+skips_check() {
+  local repo="$1"
+  [ -f "$GOVERNANCE_FILE" ] || return 1
+  python3 -c '
+import json, os, sys
+repo, basename, path = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    skip = json.load(open(path)).get("skip_files", {}).get(repo, [])
+except Exception:
+    sys.exit(1)
+sys.exit(0 if any(os.path.basename(entry) == basename for entry in skip) else 1)
+' "$repo" "$CHECK_BASENAME" "$GOVERNANCE_FILE"
+}
+
+find_clone() {
+  local repo="$1" base
+  for base in "${SEARCH_PATHS[@]}"; do
+    if [ -d "${base}/${repo}/.git" ]; then
+      echo "${base}/${repo}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# origin/HEAD is the honest target, but not every clone has it set.
+default_ref() {
+  local clone="$1" ref
+  for ref in origin/HEAD origin/main origin/master; do
+    if git -C "$clone" rev-parse --verify -q "$ref" >/dev/null; then
+      echo "$ref"
+      return 0
+    fi
+  done
+  return 1
+}
+
+CLEAN=()
+BROKEN=()
+SKIPPED=()
+UNCLONED=()
+ERRORED=()
+
+for repo in "${REPOS[@]}"; do
+  if skips_check "$repo"; then
+    SKIPPED+=("$repo")
+    continue
+  fi
+
+  clone=$(find_clone "$repo" || true)
+  if [ -z "$clone" ]; then
+    UNCLONED+=("$repo")
+    continue
+  fi
+
+  if [ "$NO_FETCH" -eq 0 ]; then
+    git -C "$clone" fetch --quiet --no-tags origin 2>/dev/null || true
+  fi
+
+  ref=$(default_ref "$clone" || true)
+  if [ -z "$ref" ]; then
+    ERRORED+=("${repo}: no origin/HEAD, origin/main or origin/master")
+    continue
+  fi
+
+  worktree=$(mktemp -d "${TMPDIR:-/tmp}/preflight-${repo}-XXXXXX")
+  rm -rf "$worktree"
+  if ! git -C "$clone" worktree add -q --detach "$worktree" "$ref" 2>/dev/null; then
+    ERRORED+=("${repo}: could not check out ${ref}")
+    rm -rf "$worktree"
+    continue
+  fi
+
+  rc=0
+  output=$(
+    cd "$worktree" || exit 1
+    # Word splitting of CHECK_ARGS is the point: they are the check's own flags.
+    # shellcheck disable=SC2086
+    bash "$CHECK" ${CHECK_ARGS} 2>&1
+  ) || rc=$?
+
+  # Always give the clone back exactly as it was found.
+  git -C "$clone" worktree remove --force "$worktree" 2>/dev/null || true
+  git -C "$clone" worktree prune 2>/dev/null || true
+  rm -rf "$worktree"
+
+  if [ "$rc" -eq 0 ]; then
+    CLEAN+=("$repo")
+  else
+    BROKEN+=("$repo")
+    if [ "$AS_JSON" -eq 0 ]; then
+      echo "WOULD BREAK: ${repo} (at ${ref})"
+      printf '%s\n' "$output" | grep -E '::error|FAIL|error' | head -3 | sed 's/^/    /'
+    fi
+  fi
+done
+
+if [ "$AS_JSON" -eq 1 ]; then
+  python3 -c '
+import json, sys
+keys = ["clean", "broken", "skipped", "uncloned", "errored"]
+payload = {k: [v for v in sys.argv[i + 1].split("\n") if v] for i, k in enumerate(keys)}
+payload["counts"] = {k: len(v) for k, v in payload.items()}
+payload["would_break"] = bool(payload["broken"]) or bool(payload["errored"])
+print(json.dumps(payload, indent=2))
+' "$(printf '%s\n' "${CLEAN[@]+"${CLEAN[@]}"}")" \
+    "$(printf '%s\n' "${BROKEN[@]+"${BROKEN[@]}"}")" \
+    "$(printf '%s\n' "${SKIPPED[@]+"${SKIPPED[@]}"}")" \
+    "$(printf '%s\n' "${UNCLONED[@]+"${UNCLONED[@]}"}")" \
+    "$(printf '%s\n' "${ERRORED[@]+"${ERRORED[@]}"}")"
+else
+  echo ""
+  echo "Pre-flight: ${CHECK_BASENAME} against ${#REPOS[@]} governed repositories"
+  echo "  clean=${#CLEAN[@]} would_break=${#BROKEN[@]} skipped=${#SKIPPED[@]} uncloned=${#UNCLONED[@]} errored=${#ERRORED[@]}"
+  [ ${#SKIPPED[@]} -gt 0 ] && echo "  skipped (opted out): ${SKIPPED[*]}"
+  [ ${#UNCLONED[@]} -gt 0 ] && echo "  NOT CHECKED (no local clone): ${UNCLONED[*]}"
+  for entry in ${ERRORED[@]+"${ERRORED[@]}"}; do
+    echo "  ERROR: ${entry}"
+  done
+  if [ ${#UNCLONED[@]} -gt 0 ]; then
+    echo "  Coverage is incomplete: a repository nobody checked is not a repository known to be fine."
+  fi
+fi
+
+if [ ${#BROKEN[@]} -gt 0 ] || [ ${#ERRORED[@]} -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test-preflight-fleet.sh
+++ b/tests/test-preflight-fleet.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Hermetic test for scripts/preflight-fleet.sh — the tool that answers "would this
+# check break any governed repository?" before a check is enforced fleet-wide.
+# Builds throwaway repositories and never touches the network (--no-fetch).
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/preflight-fleet.sh"
+
+PASS=0
+FAIL=0
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: $1 — $2"
+}
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# A fake governed repo whose default branch (origin/HEAD) content is what matters.
+# The working tree is deliberately left DIRTY and divergent, so a tool that reads
+# the working tree instead of origin/HEAD gets the wrong answer and the test fails.
+make_repo() {
+  local name="$1" committed="$2" worktree_override="${3:-}"
+  local dir="${WORK}/clones/${name}"
+  local origin="${WORK}/origins/${name}.git"
+  mkdir -p "$(dirname "$origin")"
+  git init -q --bare -b main "$origin"
+  mkdir -p "$dir"
+  git init -q -b main "$dir"
+  git -C "$dir" config user.email pf@test
+  git -C "$dir" config user.name "Preflight Test"
+  printf '%s\n' "$committed" >"${dir}/content.txt"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm baseline
+  git -C "$dir" remote add origin "$origin"
+  git -C "$dir" push -q origin main
+  git -C "$dir" remote set-head origin main
+  if [ -n "$worktree_override" ]; then
+    printf '%s\n' "$worktree_override" >"${dir}/content.txt"
+  fi
+}
+
+# The check under test: fails when content.txt contains BAD.
+CHECK="${WORK}/bad-check.sh"
+cat >"$CHECK" <<'CHK'
+#!/usr/bin/env bash
+set -euo pipefail
+if grep -q BAD content.txt 2>/dev/null; then
+  echo "::error::found BAD"
+  exit 1
+fi
+echo "clean"
+CHK
+chmod +x "$CHECK"
+
+run_preflight() {
+  local rc=0
+  # shellcheck disable=SC2086
+  bash "$SCRIPT" --check "$CHECK" --repos-file "$WORK/repos.json" \
+    --search-path "$WORK/clones" --no-fetch "$@" >"$WORK/out.txt" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+echo ""
+echo "=== Fleet Pre-flight Tests ==="
+
+# --- all clean -----------------------------------------------------------------
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha GOOD
+make_repo beta GOOD
+printf '["alpha","beta"]\n' >"$WORK/repos.json"
+RC=$(run_preflight)
+if [ "$RC" -eq 0 ]; then pass "clean fleet exits 0"; else fail "clean fleet exits 0" "rc=$RC: $(cat "$WORK/out.txt")"; fi
+if grep -q "clean=2" "$WORK/out.txt"; then pass "counts both repositories as clean"; else fail "counts both clean" "$(cat "$WORK/out.txt")"; fi
+
+# --- one would break ------------------------------------------------------------
+rm -rf "$WORK/clones" "$WORK/origins"
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha GOOD
+make_repo beta BAD
+printf '["alpha","beta"]\n' >"$WORK/repos.json"
+RC=$(run_preflight)
+if [ "$RC" -ne 0 ]; then pass "a repository that would break exits non-zero"; else fail "would-break exits non-zero" "rc=0"; fi
+if grep -q "beta" "$WORK/out.txt"; then pass "names the repository that would break"; else fail "names the repository" "$(cat "$WORK/out.txt")"; fi
+
+# --- THE STALE-CLONE TRAP: origin/HEAD is clean, working tree is dirty ----------
+# A tool that inspects the working tree reports a false break here.
+rm -rf "$WORK/clones" "$WORK/origins"
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha GOOD BAD
+printf '["alpha"]\n' >"$WORK/repos.json"
+RC=$(run_preflight)
+if [ "$RC" -eq 0 ]; then pass "judges origin/HEAD, not the dirty working tree"; else fail "judges origin/HEAD" "rc=$RC: $(cat "$WORK/out.txt")"; fi
+
+# --- the inverse: origin/HEAD is bad, working tree looks clean ------------------
+rm -rf "$WORK/clones" "$WORK/origins"
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha BAD GOOD
+printf '["alpha"]\n' >"$WORK/repos.json"
+RC=$(run_preflight)
+if [ "$RC" -ne 0 ]; then pass "a stale clean working tree does not hide a broken origin/HEAD"; else fail "stale tree hides breakage" "rc=0"; fi
+
+# --- repositories not cloned locally are reported, never silently ignored -------
+rm -rf "$WORK/clones" "$WORK/origins"
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha GOOD
+printf '["alpha","never-cloned"]\n' >"$WORK/repos.json"
+RC=$(run_preflight)
+if grep -qE "uncloned=1|never-cloned" "$WORK/out.txt"; then pass "reports coverage gaps explicitly"; else fail "reports coverage gaps" "$(cat "$WORK/out.txt")"; fi
+
+# --- a repository that opts out of the check is skipped, not counted as broken --
+rm -rf "$WORK/clones" "$WORK/origins"
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha BAD
+printf '["alpha"]\n' >"$WORK/repos.json"
+cat >"$WORK/governance.json" <<JSON
+{ "skip_files": { "alpha": ["$(basename "$CHECK")"] } }
+JSON
+RC=$(run_preflight --governance-file "$WORK/governance.json")
+if [ "$RC" -eq 0 ]; then pass "a repository opting out of the check is skipped"; else fail "opt-out is skipped" "rc=$RC: $(cat "$WORK/out.txt")"; fi
+if grep -q "skipped=1" "$WORK/out.txt"; then pass "counts the opt-out as skipped"; else fail "counts opt-out" "$(cat "$WORK/out.txt")"; fi
+
+# --- arguments reach the check ---------------------------------------------------
+rm -rf "$WORK/clones" "$WORK/origins"
+mkdir -p "$WORK/clones" "$WORK/origins"
+make_repo alpha GOOD
+printf '["alpha"]\n' >"$WORK/repos.json"
+ARGCHECK="${WORK}/argcheck.sh"
+cat >"$ARGCHECK" <<'CHK'
+#!/usr/bin/env bash
+[ "${1:-}" = "--include-paths" ] || exit 1
+echo "got flag"
+CHK
+chmod +x "$ARGCHECK"
+RC=0
+bash "$SCRIPT" --check "$ARGCHECK" --repos-file "$WORK/repos.json" --search-path "$WORK/clones" \
+  --no-fetch --args "--include-paths" >"$WORK/out.txt" 2>&1 || RC=$?
+if [ "$RC" -eq 0 ]; then pass "passes --args through to the check"; else fail "passes --args through" "rc=$RC: $(cat "$WORK/out.txt")"; fi
+
+# --- it must not leave worktrees behind in the operator's clones ----------------
+if [ -z "$(git -C "$WORK/clones/alpha" worktree list | tail -n +2)" ]; then
+  pass "leaves no worktrees behind"
+else
+  fail "leaves no worktrees behind" "$(git -C "$WORK/clones/alpha" worktree list)"
+fi
+
+# --- a missing check script is an error, not a silent pass ----------------------
+RC=0
+bash "$SCRIPT" --check "$WORK/does-not-exist.sh" --repos-file "$WORK/repos.json" \
+  --search-path "$WORK/clones" --no-fetch >"$WORK/out.txt" 2>&1 || RC=$?
+if [ "$RC" -ne 0 ]; then pass "a missing check script fails loudly"; else fail "missing check fails loudly" "rc=0"; fi
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed ($((PASS + FAIL)) total)"
+echo "════════════════════════════════════════════"
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0


### PR DESCRIPTION
Closes #790

## Why

A check added to the `Lint Code Base` gate becomes **required** in all 38 governed repositories the moment it syncs. Nothing measured that, and **the agentic reviewer structurally cannot**: it reviews a diff, not the diff's effect on 38 other repositories.

Two checks this month needed the answer:

| Check | What measuring found |
| --- | --- |
| `check-repo-hygiene.sh` home-path scan | would fail **10 of 38** with only **2** real findings — API routes (`/Users/1`), URL paths (`/home/index`), variables (`/home/${USERNAME}`), placeholders, generated swagger. Made opt-in as a result. |
| `locale-lint.sh` | flagged `i18n-core`, the package that owns the data it tells everyone else to import |

I measured both with an ad-hoc shell loop, and **the first attempt was wrong**: it read local working trees, all 38 clones were stale, so "38/38 clean" was a statement about outdated content. It also ignored `skip_files`, so an opted-out repository would have shown as a phantom failure. That is precisely the "deterministic, re-runnable automation, not one-off manual steps" standard going unmet.

## What it does

```bash
bash scripts/preflight-fleet.sh --check scripts/my-new-check.sh
bash scripts/preflight-fleet.sh --check scripts/locale-lint.sh --json
```

- Judges each repository's **live `origin/HEAD`** in a throwaway worktree — never the operator's working tree.
- **`skip_files`-aware**: a repository that opts out is skipped, not failed.
- Reports repositories with no local clone as a **coverage gap**, never as clean. A repository nobody checked is not a repository known to be fine.
- Returns every clone exactly as found, including on failure.
- Exit non-zero if any repository would break.

Docs-control-local operator tooling — deliberately **not** distributed, so no managed-files plumbing.

## Verification

**12 hermetic tests, no network.** The two that matter most assert both directions of the trap I actually fell into:

- `origin/HEAD` clean + working tree dirty → must **not** report a false break.
- `origin/HEAD` broken + working tree stale-clean → must **not** hide it.

**Reproduces both real measurements:**

```
check-repo-hygiene.sh   clean=38 would_break=0 skipped=0 uncloned=0
locale-lint.sh          clean=37 would_break=0 skipped=1 uncloned=0
                        skipped (opted out): terraform-provider-xcsh
```

**Detects the original near-miss** — the opt-in path scan, exit 1:

```
counts: {"clean": 32, "broken": 6, "skipped": 0, "uncloned": 0, "errored": 0}
would break: terraform-provider-xcsh devcontainer marketplace xcsh vscode-xcsh console
```

Six rather than the ten I first measured, because the allowlist has since been widened *and* because the earlier figure came from stale trees. The tool's number is the accurate one — which is the whole point.

**bash 3.2.** My first draft used `mapfile`, a bash 4 builtin. It would have passed in CI on ubuntu and failed on the macOS machine that actually runs this tool. Caught by running the suite locally; replaced with a `while read` loop.

`shellcheck` clean, `shfmt` clean, all 15 shell suites pass, `pre-commit` clean, and **textlint** clean on the changed doc — the prose gate that only runs in CI.

## Docs

`docs/file-sync.mdx` gains a "Pre-flight a new governed check" section, including the instruction to read the coverage line rather than just the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)