### PR TITLE
feat(governance): classify governed repositories with repo_classes

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -67,5 +67,65 @@
     ".claude/settings.json",
     ".claude/governance.json",
     ".claude/hooks/protect-managed-files.sh"
-  ]
+  ],
+  "repo_classes": {
+    "_default": "developer",
+    "classes": {
+      "content": {
+        "authority": "author",
+        "description": "Demo, product and lab content. Documentation, Terraform plans, howtos and demo scripts are authored here directly through the governed path: linked issue, branch, pull request, auto-merge.",
+        "surfaces": ["docs/", "terraform/", "coverage/", "scripts/", "*.mdx", "*.md", "*.tf", "*.tftest.hcl"]
+      },
+      "developer": {
+        "authority": "delegate",
+        "description": "Compiled or tested code with its own build and test harness. Feature implementation is delegated to a dedicated development environment; contributions here take the form of verified issues, specifications, reviews and documentation.",
+        "delegate_to": "claude-code|codex"
+      },
+      "scaffolding": {
+        "authority": "governed",
+        "description": "Fleet plumbing: continuous integration, packaging, container images and governance itself. Changes propagate to every repository, so they go through the governed path only and are never made freehand."
+      }
+    },
+    "repos": {
+      "administration": "content",
+      "api-protection": "content",
+      "api-specs": "developer",
+      "api-specs-enriched": "developer",
+      "apt-repo": "scaffolding",
+      "bot-advanced": "content",
+      "bot-standard": "content",
+      "cdn": "content",
+      "cdn-simulator": "content",
+      "code-review": "scaffolding",
+      "console": "developer",
+      "csd": "content",
+      "ddos": "content",
+      "demo-resource-template": "scaffolding",
+      "demo-resources": "content",
+      "devcontainer": "scaffolding",
+      "dns": "content",
+      "docs": "content",
+      "docs-builder": "developer",
+      "docs-control": "scaffolding",
+      "docs-icons": "developer",
+      "docs-theme": "developer",
+      "i18n-core": "developer",
+      "marketplace": "developer",
+      "marketplace-claude-code": "developer",
+      "mcn": "content",
+      "nginx": "content",
+      "observability": "content",
+      "origin-server": "content",
+      "starlight-llms-txt": "developer",
+      "starlight-mega-menu": "developer",
+      "terraform-provider-xcsh": "developer",
+      "traffic-generator": "content",
+      "vscode-xcsh": "developer",
+      "waf": "content",
+      "was": "content",
+      "webapp-api-protection": "content",
+      "xcsh": "developer",
+      "xcsh-chrome-extension": "developer"
+    }
+  }
 }

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -16,7 +16,9 @@ This page covers the procedure to enroll a new repository in the docs-control go
 
 ### 1. Add to downstream-repos.json
 
-Add the repository's `owner/repo` string to `.github/config/downstream-repos.json` in docs-control. This registers it for dispatch and enforcement.
+Add the repository's bare name -- not `owner/repo` -- to `.github/config/downstream-repos.json` in docs-control. The owner is prepended at dispatch time from `GITHUB_REPOSITORY_OWNER`. This registers it for dispatch and enforcement.
+
+Then assign it a class in `repo_classes.repos` in `.claude/governance.json` (see [Repository classes](#repository-classes-repo_classes) below). This is not optional: the shell unit tests fail if a repository is registered for dispatch without a class assignment.
 
 ### 2. Optionally add to docs-sites.json
 
@@ -152,6 +154,58 @@ the check still runs on PRs (the workflow is installed) but does not
 gate merges. Once the codebase is compatible -- typically after a
 linter-compatibility audit -- remove the entry and the next enforcement
 run promotes the check to required.
+
+## Repository classes: repo_classes
+
+Not every repository in the fleet is the same kind of thing. Some hold demo
+and product content -- documentation, Terraform plans, howtos. Some hold
+compiled code with its own build and test harness. Some hold the fleet
+plumbing itself. Automated agents need to tell these apart before they act,
+so the distinction is declared rather than guessed.
+
+`repo_classes` in `.claude/governance.json` declares it, using the same
+two-level shape as `secrets_manifest` in `repo-settings.json`: a `classes`
+map defining each class, a `repos` map assigning one to every governed
+repository, and a `_default` naming the fail-safe for anything unlisted.
+
+```json
+"repo_classes": {
+  "_default": "developer",
+  "classes": {
+    "content": { "authority": "author", "surfaces": ["docs/", "terraform/"] },
+    "developer": { "authority": "delegate", "delegate_to": "claude-code|codex" },
+    "scaffolding": { "authority": "governed" }
+  },
+  "repos": { "mcn": "content", "xcsh": "developer", "docs-control": "scaffolding" }
+}
+```
+
+The three classes and what they mean for a consumer:
+
+- `content` -- author directly. Documentation, Terraform plans and demo
+  scripts are written here through the normal governed path: linked issue,
+  branch, pull request, auto-merge.
+- `developer` -- do not implement. Feature code belongs in a development
+  environment with the repository's own build and test harness. Contribute
+  verified issues, specifications, reviews and documentation instead.
+- `scaffolding` -- governed path only. Changes here propagate to every
+  repository in the fleet, so they are never made freehand.
+
+`_default` is `developer` deliberately: an unclassified repository is
+treated as the most restrictive case, so forgetting an assignment fails
+closed rather than granting authority by accident.
+
+It lives in `governance.json` rather than `repo-settings.json` because
+`governance.json` is itself a managed file, synced byte-identically into
+every downstream repository. A consumer can therefore read the
+classification offline from any checkout, with no API call. `repo-settings.json`
+is only ever fetched by workflows at run time and never lands in a clone.
+
+Two `jq` assertions in `tests/test-protect-managed-files.sh` keep the manifest
+honest: every assignment must name a defined class, and every entry in
+`downstream-repos.json` must have an assignment. Adding a repository to the
+fleet without classifying it therefore fails CI rather than silently
+inheriting the default.
 
 ## Setting up docs content
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -466,7 +466,7 @@ echo ""
 echo "=== Section 7b: onboarding.mdx regression net ==="
 
 ONBOARDING="$REPO_ROOT/docs/onboarding.mdx"
-for phrase in 'skip_files' 'excluded_required_contexts' 'Fork-fidelity' 'Linter-compatibility audit cadence' 'frontmatter titles containing colons' 'release PR pattern'; do
+for phrase in 'skip_files' 'excluded_required_contexts' 'Fork-fidelity' 'Linter-compatibility audit cadence' 'frontmatter titles containing colons' 'release PR pattern' 'Repository classes: repo_classes'; do
   if grep -qF "$phrase" "$ONBOARDING"; then
     pass "7b.x onboarding.mdx references '$phrase'"
   else

--- a/tests/test-protect-managed-files.sh
+++ b/tests/test-protect-managed-files.sh
@@ -274,6 +274,35 @@ else
     "_default=$(jq -r '.repo_classes._default // "<absent>"' "$GOVERNANCE_JSON")"
 fi
 
+# Test 3.9b: the default must stay fail-closed. 3.9 only proves _default names
+# a real class, so flipping it to "content" would keep CI green while silently
+# granting direct authoring authority over every unlisted repository — and this
+# manifest ships fleet-wide, so that drift would be broad and invisible. Pin
+# both the name and the authority it resolves to.
+DEFAULT_CLASS=$(jq -r '.repo_classes._default // ""' "$GOVERNANCE_JSON")
+DEFAULT_AUTHORITY=$(jq -r --arg c "$DEFAULT_CLASS" '.repo_classes.classes[$c].authority // ""' "$GOVERNANCE_JSON")
+if [ "$DEFAULT_CLASS" = "developer" ] && [ "$DEFAULT_AUTHORITY" = "delegate" ]; then
+  pass "3.9b repo_classes._default is fail-closed (developer/delegate)"
+else
+  fail "3.9b repo_classes._default is fail-closed (developer/delegate)" \
+    "got class='$DEFAULT_CLASS' authority='$DEFAULT_AUTHORITY'; an unlisted repo must never inherit authoring authority"
+fi
+
+# Test 3.9c: every class declares a recognized authority. An unrecognized or
+# missing value would leave a consumer to guess, which defeats the point of
+# declaring the classification at all.
+BAD_AUTHORITIES=$(jq -r '
+  .repo_classes.classes | to_entries[]
+  | select((.value.authority // "") | IN("author", "delegate", "governed") | not)
+  | "\(.key)=\(.value.authority // "<absent>")"
+' "$GOVERNANCE_JSON" 2>/dev/null || echo "PARSE_ERROR")
+if [ -z "$BAD_AUTHORITIES" ]; then
+  pass "3.9c every repo_classes class declares a recognized authority"
+else
+  fail "3.9c every repo_classes class declares a recognized authority" \
+    "unrecognized: $BAD_AUTHORITIES"
+fi
+
 # Test 3.10: every governed repo has a class assignment. The governed set is
 # downstream-repos.json plus docs-control itself, which is not in that list
 # because it is the source rather than a sync target.

--- a/tests/test-protect-managed-files.sh
+++ b/tests/test-protect-managed-files.sh
@@ -237,6 +237,85 @@ else
     "missing from managed_files:\n$MISSING_FROM_MANAGED"
 fi
 
+# ── repo_classes referential integrity ──────────────────────────────
+# governance.json is the manifest that ships into every downstream repo, so it
+# is where consumers read the repository classification from. These assertions
+# keep that classification honest: every assignment must name a defined class,
+# and every governed repo must have an assignment — otherwise the manifest
+# silently falls behind as the fleet grows and consumers fall back to guessing.
+DOWNSTREAM_REPOS="$REPO_ROOT/.github/config/downstream-repos.json"
+
+# Test 3.7: repo_classes block exists and is well-formed
+if jq -e '.repo_classes | (.classes | type == "object") and (.repos | type == "object") and has("_default")' \
+  "$GOVERNANCE_JSON" >/dev/null 2>&1; then
+  pass "3.7 governance.json defines repo_classes with classes, repos and _default"
+else
+  fail "3.7 governance.json defines repo_classes with classes, repos and _default" \
+    "missing or malformed .repo_classes"
+fi
+
+# Test 3.8: every class referenced in repos[] is defined in classes{}
+UNDEFINED_CLASSES=$(jq -r '
+  .repo_classes as $rc |
+  [$rc.repos | to_entries[] | select((.value as $c | $rc.classes | has($c)) | not) | "\(.key) -> \(.value)"] | .[]
+' "$GOVERNANCE_JSON" 2>/dev/null || echo "PARSE_ERROR")
+if [ -z "$UNDEFINED_CLASSES" ]; then
+  pass "3.8 every repo_classes.repos value names a defined class"
+else
+  fail "3.8 every repo_classes.repos value names a defined class" \
+    "undefined class references: $UNDEFINED_CLASSES"
+fi
+
+# Test 3.9: _default names a defined class (the fail-safe must be real)
+if jq -e '.repo_classes as $rc | $rc.classes | has($rc._default)' "$GOVERNANCE_JSON" >/dev/null 2>&1; then
+  pass "3.9 repo_classes._default names a defined class"
+else
+  fail "3.9 repo_classes._default names a defined class" \
+    "_default=$(jq -r '.repo_classes._default // "<absent>"' "$GOVERNANCE_JSON")"
+fi
+
+# Test 3.10: every governed repo has a class assignment. The governed set is
+# downstream-repos.json plus docs-control itself, which is not in that list
+# because it is the source rather than a sync target.
+UNCLASSIFIED_REPOS=""
+GOVERNED_REPOS=$(
+  {
+    jq -r '.[]' "$DOWNSTREAM_REPOS"
+    echo "docs-control"
+  } | sort -u
+)
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  if ! jq -e --arg r "$repo" '.repo_classes.repos | has($r)' "$GOVERNANCE_JSON" >/dev/null 2>&1; then
+    UNCLASSIFIED_REPOS="${UNCLASSIFIED_REPOS} ${repo}"
+  fi
+done <<<"$GOVERNED_REPOS"
+
+if [ -z "$UNCLASSIFIED_REPOS" ]; then
+  pass "3.10 every governed repo has a repo_classes assignment"
+else
+  fail "3.10 every governed repo has a repo_classes assignment" \
+    "unclassified:${UNCLASSIFIED_REPOS}"
+fi
+
+# Test 3.11: no assignment for a repo outside the governed set (catches typos,
+# which would otherwise sit in the manifest looking authoritative forever)
+UNKNOWN_ASSIGNMENTS=""
+ASSIGNED_REPOS=$(jq -r '.repo_classes.repos | keys[]' "$GOVERNANCE_JSON" 2>/dev/null || true)
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  if ! echo "$GOVERNED_REPOS" | grep -qxF "$repo"; then
+    UNKNOWN_ASSIGNMENTS="${UNKNOWN_ASSIGNMENTS} ${repo}"
+  fi
+done <<<"$ASSIGNED_REPOS"
+
+if [ -z "$UNKNOWN_ASSIGNMENTS" ]; then
+  pass "3.11 no repo_classes assignment outside the governed set"
+else
+  fail "3.11 no repo_classes assignment outside the governed set" \
+    "not in downstream-repos.json:${UNKNOWN_ASSIGNMENTS}"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 4: Hook Behavior — Self-Exclusion
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Adds a `repo_classes` block to `.claude/governance.json` declaring what kind of repository each governed repo is, so consumers stop guessing:

- **content** (19) — author directly through the governed path. `administration` `api-protection` `bot-advanced` `bot-standard` `cdn` `cdn-simulator` `csd` `ddos` `demo-resources` `dns` `docs` `mcn` `nginx` `observability` `origin-server` `traffic-generator` `waf` `was` `webapp-api-protection`
- **developer** (15) — do not implement; contribute verified issues, specs, reviews, docs. `api-specs` `api-specs-enriched` `console` `docs-builder` `docs-icons` `docs-theme` `i18n-core` `marketplace` `marketplace-claude-code` `starlight-llms-txt` `starlight-mega-menu` `terraform-provider-xcsh` `vscode-xcsh` `xcsh` `xcsh-chrome-extension`
- **scaffolding** (5) — governed path only. `apt-repo` `code-review` `demo-resource-template` `devcontainer` `docs-control`

Plus five `jq` referential-integrity assertions, a `Repository classes` section in `docs/onboarding.mdx`, and one phrase added to the Section 7b doc-coverage loop.

## Why

Three partial proxies existed, none of them a classification:

- `managed_files.files[].only_repos` — a hand-maintained allowlist whose own source comment (`workflows/semgrep.yml:6-9`) reads *"synced ONLY to code-bearing repos … Content/demo repos are excluded deliberately"*. That is a developer-vs-content split inlined into one file entry.
- `managed_files.skip_files` — a lint-exemption map that de facto enumerates the special repos.
- The `docs` repo's `llms-federated-site-categories.json` — a real six-category taxonomy, but it governs documentation federation, covers 30 repos, and never lands in a clone.

Consumers were compensating with private hardcoded lists. `f5-sales-demo/xcsh` carries an unexported, negative-only `INFRASTRUCTURE_SLUGS` set (`packages/coding-agent/src/services/xcsh-knowledge.ts:18-27`) that drifts every time the fleet changes. This PR gives it something declared to read instead.

The assignment deliberately agrees with `llms-federated-sites.json` where they overlap: `product-features` + `lab-infrastructure` + `portal` → content, `developer-tools` + `api-specifications` + most of `build-platform` → developer.

**Why `governance.json` rather than `repo-settings.json`:** `repo-settings.json` is fetched by workflows at run time and never lands in a clone. `governance.json` is a managed file synced byte-identically into all 39 repos, so the classification is readable offline from any checkout with no API call. No workflow consumes classes, so a second copy would be duplication plus a drift test. **Open to reviewer preference** — if `repo-settings.json` should be canonical with `governance.json` as the mirror, that needs a byte-identity test like the existing `skip_files` one.

## Testing

All 15 shell suites pass. `test-protect-managed-files.sh`: **124 passed, 0 failed**. `test-linter-configs.sh`: **110 passed, 0 failed**. `pre-commit` clean; `textlint --rule terminology` clean on the changed doc.

New assertions, each written before the manifest and confirmed red first:

| Test | Asserts |
|---|---|
| 3.7 | `repo_classes` exists with `classes`, `repos`, `_default` |
| 3.8 | every assignment names a defined class |
| 3.9 | `_default` names a defined class |
| 3.9b | `_default` is fail-closed — pins `developer` **and** its resolved authority `delegate` |
| 3.9c | every class declares an authority in `author\|delegate\|governed` |
| 3.10 | every entry in `downstream-repos.json` (plus `docs-control`) has an assignment |
| 3.11 | no assignment names a repo outside the governed set |

3.10 independently confirms the governed set is exactly 39 repos. Registering a repo for dispatch without classifying it now fails CI instead of silently inheriting the default.

**`skip_files` is untouched**, so test 3.5's byte-identity assertion passes unchanged. The insertion is textual rather than a JSON round-trip so existing formatting is preserved byte-for-byte — verified by diffing the manifest with `repo_classes` removed against the previous revision (identical). An earlier `json.dump` attempt was reverted because it silently reflowed the compact `skip_files` arrays, which would have propagated a whitespace-only change to 38 repos; test 3.5 did not catch that because it compares parsed JSON, not bytes.

### Second-opinion review

`codex:verified-code-review` returned **one medium finding, CONFIRMED and fixed**: test 3.9 pinned only that `_default` named a real class, so flipping it to `content` would keep CI green while granting authoring authority over every unlisted repo. Confirmed by mutation — with `_default: content` the suite reported `122 passed, 0 failed`. Fixed by 3.9b/3.9c; the same mutation is now red, and a second mutation setting `scaffolding.authority` to `bogus` is red via 3.9c. No findings were dismissed.

## Also

Corrects a stale onboarding instruction: `downstream-repos.json` holds bare repository names, not `owner/repo` strings. The live file has always held bare names and the owner is prepended at dispatch time.

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)