### PR TITLE
fix: separate the local Codex spec/plan review from the CI PR gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "worktree": {
     "baseRef": "fresh"
   },
+  "permissions": {
+    "deny": ["Skill(code-review:code-review)", "Skill(pr-review-toolkit:review-pr)"]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -285,6 +285,10 @@ jobs:
         if: hashFiles('tests/test-linter-configs.sh') != ''
         run: bash tests/test-linter-configs.sh
 
+      - name: Run review-layer-routing test
+        if: hashFiles('tests/test-review-layer-routing.sh') != ''
+        run: bash tests/test-review-layer-routing.sh
+
       - name: Run locale-lint test
         if: hashFiles('tests/test-locale-lint.sh') != ''
         run: bash tests/test-locale-lint.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ When the `codex` plugin provides the `verified-code-review` skill, use it as a s
 **Never review a spec, a plan, or a local branch with a PR-diff reviewer.** Do not invoke `code-review:code-review`, `code-review-f5:code-review`, `pr-review-toolkit:review-pr`, `/review`, or `/security-review` as your local review step.
 
 - They review a pull-request diff, which is the CI layer's job — and a spec has no diff to review.
-- `code-review-f5` is the CI reviewer's own plugin and runs only on the self-hosted runner. Never invoke it by hand.
-- `.claude/settings.json` denies the model-invocable ones outright, so a wrong choice fails loudly instead of quietly producing the wrong kind of review.
+- Enforced, not just documented: `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`, and `code-review-f5:code-review` is marked `disable-model-invocation` in the vendored plugin. A wrong choice fails loudly instead of quietly producing the wrong kind of review.
+- `/review` and `/security-review` are built-in commands that no rule can deny. Not selecting them for local spec, plan, or branch review is on you.
 
 Treat every second-opinion finding as external review feedback under `superpowers:receiving-code-review`: verify each claim against this codebase before acting on it, and push back with technical reasoning when it is wrong. Fix only confirmed findings, each with a test that fails before the fix and passes after.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,19 +18,37 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.
-- The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. See CONTRIBUTING.md.
 
-## Second-opinion review (when available)
+## Two review layers — never substitute one for the other
+
+Reviewing a **spec or plan** and reviewing a **pull-request diff** are different jobs, done by different tools, with different authority. Pick by what you are reviewing, not by the word "review".
+
+| Layer | What it reviews | When | Tool | Authority |
+| ----- | --------------- | ---- | ---- | --------- |
+| **Local, pre-PR** | A spec, an implementation plan, or your own unpushed branch | Before a human reviews the document; before a push that opens or updates a PR; after each round of fixes | `codex:verified-code-review` | Advisory. Never a merge gate. |
+| **CI** | The pull-request diff | Automatically, on every PR | Self-hosted `review / claude-review` workflow | **Required and merge-gating.** |
+
+### Local, pre-PR (Codex second opinion)
 
 When the `codex` plugin provides the `verified-code-review` skill, use it as a second-opinion reviewer at three points. When the skill is not installed, skip it and continue — this is an additive local layer, never a merge gate.
 
-- Before asking a human to review a written spec or an implementation plan.
-- Before pushing a branch that will open or update a pull request.
+- Before asking a human to review a written spec or an implementation plan. **This is the layer's primary use.** Review the document itself — `review-doc --kind spec` or `review-doc --kind plan` — not a diff.
+- Before pushing a branch that will open or update a pull request (`adversarial-review`, against the base ref or uncommitted work).
 - After each round of fixes, until no confirmed critical or high finding remains.
+
+**Never review a spec, a plan, or a local branch with a PR-diff reviewer.** Do not invoke `code-review:code-review`, `code-review-f5:code-review`, `pr-review-toolkit:review-pr`, `/review`, or `/security-review` as your local review step.
+
+- They review a pull-request diff, which is the CI layer's job — and a spec has no diff to review.
+- `code-review-f5` is the CI reviewer's own plugin and runs only on the self-hosted runner. Never invoke it by hand.
+- `.claude/settings.json` denies the model-invocable ones outright, so a wrong choice fails loudly instead of quietly producing the wrong kind of review.
 
 Treat every second-opinion finding as external review feedback under `superpowers:receiving-code-review`: verify each claim against this codebase before acting on it, and push back with technical reasoning when it is wrong. Fix only confirmed findings, each with a test that fails before the fix and passes after.
 
-Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none. The required `review / claude-review` check remains the merge gate, and this local layer never replaces it.
+Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none.
+
+### CI (the merge gate)
+
+The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. The local layer never replaces it. See CONTRIBUTING.md.
 
 ## Worktrees
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,15 @@ git checkout -b feature/42-add-rate-limiting
 
 ## Automated code review
 
+Review happens in two layers. They are not interchangeable, and neither substitutes for the other:
+
+| Layer | What it reviews | Authority |
+| ----- | --------------- | --------- |
+| **Local, pre-PR** | A spec, an implementation plan, or an unpushed branch | Advisory |
+| **CI** | The pull-request diff | **Required and merge-gating** |
+
+### CI review (the gate)
+
 Every downstream pull request is reviewed by a **Claude Code reviewer** running on a self-hosted
 runner. It is a **required status check** (`review / claude-review`) — auto-merge will not merge
 until it passes.
@@ -117,6 +126,29 @@ until it passes.
   and the linked-issue check — this is for machine-generated PRs only. The authoritative prefix
   list lives in `require-linked-issue.yml` and `code-review.yml`; never adopt such a prefix for
   human or agent work.
+
+### Local pre-PR review (advisory second opinion)
+
+A second review layer runs on your own machine **before the pull request exists**. It catches
+problems while they are still cheap to fix — in a spec or a plan, before any code is written.
+
+- **Advisory, never a gate.** It emits no verdict and posts no commit status, so it cannot block a
+  merge or deadlock a required check. When the tooling is absent it is skipped and work continues.
+- **Where it runs.** At the spec and plan review points, before a push that opens or updates a pull
+  request, and after each round of fixes. Reviewing a written spec or implementation plan is its
+  primary use — a document, not a diff.
+- **Verification is mandatory.** A finding counts only once it has been confirmed against the
+  codebase: for code, with a test that fails today; for a document, with a quotation. An AI reviewer
+  misattributes findings to files that do not contain them, and a hallucinated blocking finding can
+  never be fixed — treating it as blocking would stop the loop from ever terminating.
+- **Bounded.** Three iterations maximum, with no-progress detection when two consecutive rounds
+  produce the same blocking set. On either, the outstanding findings go to a human.
+- **Do not reach for a PR-diff reviewer instead.** Reviewing a spec, a plan, or a local branch with
+  a pull-request review tool is the wrong layer — a spec has no diff to review. `CLAUDE.md` names
+  the tool to use, the tools not to use, and the deny rules that enforce it.
+
+The two layers are complementary: the local layer catches issues before the pull request exists and
+costs nothing when it is wrong, while CI remains the gate that decides whether a change merges.
 
 ## Branch Protection Rules
 

--- a/plugins/f5-review/code-review-f5/UPSTREAM.md
+++ b/plugins/f5-review/code-review-f5/UPSTREAM.md
@@ -43,6 +43,18 @@ Marked with `F5-EXTENSION` comments in the command so a re-sync diff is obvious:
   before stopping, and a re-push re-reviews the current head and emits a fresh
   verdict (posting only new findings, no duplicates).
 
+- **E6 — CI-only invocation**: `disable-model-invocation: true` in the command
+  frontmatter. This reviewer is the merge gate and carries elevated `allowed-tools`
+  (`Write`, `gh pr comment`, `az`, `terraform`). Upstream leaves the command
+  model-invocable, which let a local agent auto-select the gate reviewer for a spec,
+  a plan, or an unpushed branch — the wrong layer, with authenticated side effects
+  outside the controlled workflow. A `permissions.deny` rule cannot express this:
+  verified A/B, `Skill(code-review-f5:code-review)` in `deny` blocks the workflow's
+  own invocation too, because CI passes the command through `prompt:` and the deny
+  rule does not distinguish that from model selection. `disable-model-invocation`
+  does: the prompt-level slash command still expands, while a `Skill` tool call is
+  refused with "cannot be used with Skill tool due to disable-model-invocation".
+
 ## Model tiers (E1)
 
 Upstream fans out to `haiku`/`sonnet`/`opus` subagents. The reusable workflow sets

--- a/plugins/f5-review/code-review-f5/commands/code-review.md
+++ b/plugins/f5-review/code-review-f5/commands/code-review.md
@@ -1,6 +1,10 @@
 ---
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(git diff:*), Bash(git log:*), Bash(az account show:*), Bash(az group:*), Bash(terraform init:*), Bash(terraform plan:*), Bash(terraform validate:*), mcp__github_inline_comment__create_inline_comment, Read, Write
 description: F5-extended multi-agent code review of a pull request
+# F5-EXTENSION E6: CI-only. The workflow invokes this as a prompt-level slash
+# command, which still works; this only stops an agent from auto-selecting the
+# merge-gate reviewer for local work. See UPSTREAM.md.
+disable-model-invocation: true
 ---
 
 Provide a code review for the given pull request.

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Regression harness for the two-layer review split (issue #799).
+#
+# The local layer reviews specs, plans, and unpushed branches and is advisory;
+# the CI layer reviews the pull-request diff and is the merge gate. An agent that
+# picks a PR-diff reviewer for a spec gets the wrong review, and in the case of
+# code-review-f5 also gets a write-capable, gh/az/terraform-capable tool pointed
+# at local work. These assertions keep the enforcement honest: every reviewer
+# CLAUDE.md prohibits must actually be blocked by a mechanism, and the one
+# carve-out must stay a carve-out for its stated reason.
+#
+# Run from repo root: bash tests/test-review-layer-routing.sh
+set -euo pipefail
+
+# ── Test framework (shared pattern with test-linter-configs.sh) ──
+PASS=0
+FAIL=0
+TESTS_RUN=0
+
+pass() {
+  PASS=$((PASS + 1))
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "  PASS: $1"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "  FAIL: $1 — $2"
+}
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+F5_CMD="$REPO_ROOT/plugins/f5-review/code-review-f5/commands/code-review.md"
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 1: deny rules for the model-invocable PR-diff reviewers
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 1: permissions.deny blocks the model-invocable PR-diff reviewers ==="
+
+if jq empty "$SETTINGS" 2>/dev/null; then
+  pass "1.1 .claude/settings.json is valid JSON"
+else
+  fail "1.1 .claude/settings.json is valid JSON" "jq parse failed"
+fi
+
+# Verified empirically: a deny rule of this shape yields
+# "Skill execution blocked by permission rules", even under
+# --dangerously-skip-permissions.
+for skill in "code-review:code-review" "pr-review-toolkit:review-pr"; do
+  if jq -e --arg s "Skill($skill)" '.permissions.deny // [] | index($s)' \
+    "$SETTINGS" >/dev/null 2>&1; then
+    pass "1.2 permissions.deny contains Skill($skill)"
+  else
+    fail "1.2 permissions.deny contains Skill($skill)" "rule missing from deny list"
+  fi
+done
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 2: the code-review-f5 carve-out
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 2: code-review-f5 is gated by disable-model-invocation, not deny ==="
+
+# A deny rule would break the merge gate: CI invokes the reviewer through the
+# workflow's `prompt:` as a slash command, and a deny rule does not distinguish
+# that from model selection. Verified A/B — with the deny rule in place the
+# CI-style prompt returned BLOCKED; without it, EXPANDED.
+if jq -e '.permissions.deny // [] | index("Skill(code-review-f5:code-review)")' \
+  "$SETTINGS" >/dev/null 2>&1; then
+  fail "2.1 code-review-f5 is NOT in permissions.deny" \
+    "denying it also blocks the CI workflow's own prompt-level invocation, breaking the required gate"
+else
+  pass "2.1 code-review-f5 is NOT in permissions.deny"
+fi
+
+# disable-model-invocation does distinguish the two: the prompt-level slash
+# command still expands, while a Skill tool call is refused.
+if [[ -f $F5_CMD ]]; then
+  pass "2.2 vendored f5 reviewer command exists"
+  if awk '/^---$/{n++; next} n==1' "$F5_CMD" |
+    grep -qE '^disable-model-invocation:[[:space:]]*true[[:space:]]*$'; then
+    pass "2.3 f5 reviewer command sets disable-model-invocation: true"
+  else
+    fail "2.3 f5 reviewer command sets disable-model-invocation: true" \
+      "frontmatter lacks the flag, so an agent can auto-select the merge-gate reviewer locally"
+  fi
+else
+  fail "2.2 vendored f5 reviewer command exists" "not found at $F5_CMD"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 3: CLAUDE.md routes to the local layer and names the exclusions
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 3: CLAUDE.md names the tool to use and the tools not to use ==="
+
+for token in "codex:verified-code-review" "review-doc"; do
+  if grep -qF "$token" "$CLAUDE_MD"; then
+    pass "3.1 CLAUDE.md names $token"
+  else
+    fail "3.1 CLAUDE.md names $token" "local-layer routing target missing"
+  fi
+done
+
+# Every prohibited reviewer must be named explicitly. Prose that says "do not use
+# a PR-diff reviewer" without naming them loses the routing contest to their own
+# terse, all-review skill descriptions.
+for reviewer in "code-review:code-review" "code-review-f5:code-review" \
+  "pr-review-toolkit:review-pr" "/review" "/security-review"; do
+  if grep -qF "$reviewer" "$CLAUDE_MD"; then
+    pass "3.2 CLAUDE.md names prohibited reviewer $reviewer"
+  else
+    fail "3.2 CLAUDE.md names prohibited reviewer $reviewer" "exclusion list is incomplete"
+  fi
+done
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo "Tests run: $TESTS_RUN | Passed: $PASS | Failed: $FAIL"
+echo "════════════════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Reviewing a **spec or plan** and reviewing a **pull-request diff** are different jobs, but Claude
conflated them: asked for an intermediate review of a spec, it selected a PR-diff reviewer instead of
`codex:verified-code-review`, and the CI reviewer read as the only review that exists.

Four reinforcing causes, all verified:

1. **Keyword collision, and the correct skill loses on brevity.** The competitors carry 4–8 word
   descriptions that are entirely about reviewing (`Code review a pull request`). The codex
   description is a 47-word sentence in which "spec or plan" sits in a subordinate clause.
2. **`code-review:code-review` explicitly opts into model routing** (`disable-model-invocation:
   false`) — the only one of the six that sets the flag affirmatively. Codex's two precisely-scoped
   commands both set it `true`, removing themselves from the pool and leaving the verbose omnibus one.
3. **The built-in `/review` advertises the competitor**: *"Review a GitHub pull request; for your
   working diff use /code-review"*.
4. **`CLAUDE.md` named what to use but never what not to use**, and `CONTRIBUTING.md` documented
   exactly one layer — no mention of codex — so "code review" mapped to CI by construction.

Prose alone cannot win that contest, so the routing is now enforced by a mechanism as well.

## Related Issue

Closes #799

## Changes

- **`CLAUDE.md`** — a two-layer section keyed on *what is being reviewed*, with a routing table, the
  `review-doc --kind spec|plan` subcommand named, and an explicit exclusion list naming every
  prohibited reviewer. The merge-gate sentence was duplicated in two sections; it is now stated once.
- **`CONTRIBUTING.md`** — the missing advisory local layer, so both layers are documented where the
  standards live. Deliberately does not link `REVIEWER-SPEC.md` (local to docs-control, not synced —
  downstream would get a dangling reference).
- **`.claude/settings.json`** — `permissions.deny` for the two model-invocable PR-diff reviewers.
- **`plugins/f5-review/code-review-f5`** — `disable-model-invocation: true`, documented as divergence
  E6 alongside the existing E1–E5. Found by the Codex second-opinion review; see below.
- **`tests/test-review-layer-routing.sh`** — 13 assertions covering every prohibited reviewer,
  registered in `super-linter.yml`.

## Verification evidence

**1. The deny mechanism blocks (A/B, executed).** `Skill(<plugin>:<name>)` in `permissions.deny`,
model asked to invoke the skill:

```
control (no deny):  TOOL_USE: Skill {"skill": "code-review:code-review"}
                    RESULT: Launching skill: code-review:code-review
with deny rule:     TOOL_USE: Skill {"skill": "code-review:code-review"}
                    RESULT: Skill execution blocked by permission rules
```

Deny wins even under `--dangerously-skip-permissions`.

**2. `code-review-f5` is NOT denied, deliberately — proven necessary.** CI invokes the reviewer
through the workflow's `prompt:` as a slash command (`claude-review.yml:229,288`), and a deny rule
does not distinguish that from model selection:

```
CI-style prompt, deny rule present:  BLOCKED
CI-style prompt, deny rule absent:   EXPANDED
```

Denying it would have broken the required gate in every repo. `disable-model-invocation` *does*
distinguish the two:

```
disable-model-invocation + CI-style prompt slash:  EXPANDED
disable-model-invocation + model Skill tool call:  refused
  ("cannot be used with Skill tool due to disable-model-invocation")
```

**3. Regression test, red then green.** Not just green — proven to fail:

```
remove disable-model-invocation -> FAIL: 2.3 ... (13 run, 12 passed, 1 failed, exit 1)
add the f5 deny rule            -> FAIL: 2.1 ... (13 run, 12 passed, 1 failed, exit 1)
final                           -> Tests run: 13 | Passed: 13 | Failed: 0
```

**4. Full local gate.** All 16 `tests/test-*.sh` suites PASS. `pre-commit run --all-files`: 0
failures. `textlint` (the prose/terminology rules `pre-commit` does not run) exit 0 on all three
changed markdown files — with a canary (`"A Github pull request"` → flagged) proving the rule was
live rather than silently no-opping.

**5. Codex second-opinion review** ran before this push, per the standard being sharpened. One
CONFIRMED high finding, fixed (item 2 above). Its *primary* recommendation was REFUTED with executed
evidence — see the A/B in item 2. Reported in full in the PR discussion rather than presented as a
clean review.

**6. CI.** Correction to an earlier claim in this PR: **docs-control does not run the
`review / claude-review` gate on its own PRs.** It has no `.github/workflows/code-review.yml` caller,
and its `self_contexts` in `repo-settings.json` are only `Check linked issues` and `Lint Code Base`.
The gate is required on the 38 *downstream* repos. So this PR cannot itself prove the deny rules left
the gate intact.

The CI-safety proof is therefore the local A/B in item 2, run against a copy of this repo's actual
vendored plugin with the shipped `disable-model-invocation` line, exercising the same prompt-level
slash command the workflow uses. The end-to-end confirmation comes from the first downstream PR after
propagation, which I will check rather than assume.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued) — docs-control's own required checks; the review gate does not run here (see item 6)
- [x] Follows project conventions

## Residual gap, stated plainly

`/review` and `/security-review` are compiled into the CLI binary. No settings rule can deny them, so
for those two the exclusion is prose-only and depends on the agent reading `CLAUDE.md`. This is called
out in the file itself rather than papered over.

