### PR TITLE
docs: require proving the checkout is current before starting work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 
 ## Workflow
 
-- **Start from current.** Run `git fetch --prune` and confirm you are not behind `origin/<default-branch>` before you plan, branch, or edit. The git status injected at session start is a snapshot with no ahead/behind count — it shows a clean tree on a stale checkout, so it cannot tell you the code is current.
+- **Start from current.** `git fetch --prune` and confirm you are not behind `origin/<default-branch>` before you plan, branch, or edit; create branches from `origin/<default-branch>`, never from local `main`. The git status injected at session start is a snapshot with no ahead/behind count — a stale checkout still reports a clean tree.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 
 ## Workflow
 
+- **Start from current.** Run `git fetch --prune` and confirm you are not behind `origin/<default-branch>` before you plan, branch, or edit. The git status injected at session start is a snapshot with no ahead/behind count — it shows a clean tree on a stale checkout, so it cannot tell you the code is current.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.
@@ -53,7 +54,8 @@ The Claude Code review is a **required, merge-gating check** that can block. On 
 ## Worktrees
 
 - For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.
-- New worktrees branch fresh from the default branch (`worktree.baseRef` is set to `fresh` in `.claude/settings.json`). The `.claude/worktrees/` directory is already gitignored.
+- New worktrees branch from `origin/<default-branch>` (`worktree.baseRef` is set to `fresh` in `.claude/settings.json`). The `.claude/worktrees/` directory is already gitignored.
+- `fresh` means "from the cached remote ref", not "freshly fetched" — it only re-fetches when `FETCH_HEAD` is over 24 hours old. A worktree created after an earlier same-day fetch is born behind whatever merged since, so fetch before you create one.
 - If a repository's build needs gitignored inputs (`.env`, secrets, local config), add a repo-local `.worktreeinclude` listing them so new worktrees carry those files in.
 
 ## Engineering Standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,8 @@ clean.
 
 ```bash
 git fetch --prune        # if this fails, stop — do not branch from a stale guess
-git switch -c feature/42-add-rate-limiting origin/main
+git switch --no-track -c feature/42-add-rate-limiting origin/main
+git push -u origin HEAD  # on your first push — sets the branch's own upstream
 ```
 
 Branch from `origin/main`, not from local `main`. Local `main` can be *ahead* with unpushed commits,
@@ -84,6 +85,11 @@ which a "not behind" check does not catch, and those commits would silently ride
 Branching from the fetched ref also works when `main` is checked out in another worktree — there,
 `git checkout main` fails outright (`fatal: 'main' is already used by worktree at …`), and a pasted
 `git checkout -b` would quietly branch from whatever you were on instead.
+
+`--no-track` and the `-u` on first push matter together. Without `--no-track`, Git's default
+`branch.autoSetupMerge` makes a branch created from `origin/main` *track* `origin/main`: a bare
+`git pull` would then merge `main` into your feature branch, and the branch would never be marked
+`[gone]` once its own remote branch is deleted — silently defeating the cleanup procedure below.
 
 If you are editing an existing checkout rather than creating a branch, confirm it is current first —
 `git status -sb` should show `## main...origin/main` with no `[behind N]`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,12 +75,18 @@ its base. Do not infer freshness from a clean working tree; a checkout twenty co
 clean.
 
 ```bash
-git checkout main
-git fetch --prune
-git status -sb            # expect "## main...origin/main" with no [behind N]
-git pull --ff-only
-git checkout -b feature/42-add-rate-limiting
+git fetch --prune        # if this fails, stop — do not branch from a stale guess
+git switch -c feature/42-add-rate-limiting origin/main
 ```
+
+Branch from `origin/main`, not from local `main`. Local `main` can be *ahead* with unpushed commits,
+which a "not behind" check does not catch, and those commits would silently ride along into your PR.
+Branching from the fetched ref also works when `main` is checked out in another worktree — there,
+`git checkout main` fails outright (`fatal: 'main' is already used by worktree at …`), and a pasted
+`git checkout -b` would quietly branch from whatever you were on instead.
+
+If you are editing an existing checkout rather than creating a branch, confirm it is current first —
+`git status -sb` should show `## main...origin/main` with no `[behind N]`.
 
 A long-running session goes stale the same way, since nothing re-checks after start. Fetch again
 before branching a second time, and before creating a git worktree — a worktree inherits whatever

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,11 +68,26 @@ Branch from `main` using one of these naming conventions:
 
 Format: `<prefix>/<issue-number>-short-description`
 
+**Start from current.** Sync with the remote and confirm you are not behind before you branch — or
+plan, or edit. This is a rule, not a formality: a stale base does not announce itself. It surfaces
+later as an unrelated CI failure, and the instinct is then to debug the change's content rather than
+its base. Do not infer freshness from a clean working tree; a checkout twenty commits behind is also
+clean.
+
 ```bash
 git checkout main
-git pull origin main
+git fetch --prune
+git status -sb            # expect "## main...origin/main" with no [behind N]
+git pull --ff-only
 git checkout -b feature/42-add-rate-limiting
 ```
+
+A long-running session goes stale the same way, since nothing re-checks after start. Fetch again
+before branching a second time, and before creating a git worktree — a worktree inherits whatever
+the cached remote ref says, so it can be born behind (see CLAUDE.md).
+
+If a branch falls behind `main` while its PR is open, use the **Update branch** button on the PR
+(`allow_update_branch` is enabled fleet-wide) rather than merging `main` in by hand.
 
 ## Step 3: Make Changes and Commit
 

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -384,15 +384,21 @@ gh api repos/f5-sales-demo/<repo-name>/git/refs/heads/gh-pages --method DELETE
 
 ### Clean stale branches
 
-Remove merged feature branches and old automation branches:
+Prune remote-tracking references for branches deleted on the server:
 
 ```bash
-# Delete local branches already merged to main
-git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
-
-# Prune remote tracking references
 git fetch --prune
 ```
+
+To then remove the local branches themselves, follow **"After merge: clean up local branches"** in
+[CONTRIBUTING.md](https://github.com/f5-sales-demo/docs-control/blob/main/CONTRIBUTING.md) — it is
+the authoritative procedure and it is deliberately a confirm-then-delete flow.
+
+Do not use `git branch --merged main` to decide what to delete. Merges here are squash-merges, so a
+merged branch is not an ancestor of `main` and `--merged` silently omits it. Pruning marks those
+branches `[gone]` instead, which is what the CONTRIBUTING.md procedure keys on — and `[gone]` also
+covers a PR closed *without* merging, which is why the deletion step is gated on confirming the
+merge rather than piped straight into `git branch -D`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Sessions repeatedly began planning or editing from a stale base. The gap was almost entirely
undocumented, but the bigger problem was that two existing statements actively taught the wrong
assumption — so this corrects those, then states the rule.

**1. The injected session git status has no freshness signal.** Claude Code injects branch,
working-tree status, and recent commits at session start. No ahead/behind count, and it never
updates. A checkout twenty commits behind reports a clean tree on `main`, which reads as "current".

This matters for precedent: #678 chose prose over a hook because *"Claude Code already injects git
status … make the agent act on it rather than duplicating it with a script."* Sound for dirty-state
and branch identity; false for freshness — there is no freshness signal in that payload to act on.

**2. `worktree.baseRef: "fresh"` does not mean freshly fetched.** `CLAUDE.md` claimed worktrees
"branch fresh from the default branch". Disproven — `fresh` reuses the **cached** remote ref and only
re-fetches when `FETCH_HEAD` is over 24 h old:

| Arm | `FETCH_HEAD` age | Worktree base | |
| --- | --- | --- | --- |
| A | 0 s | `b6e7a45` (ONE) | **stale — missed an already-merged commit** |
| B | 48 h | `5099f3c` (TWO) | fetched, current |

Two clones of one scratch remote, identical stale cached ref, single variable. Not hypothetical:
PR #802's worktree was based on `c785ace` (#793) while #800 and #801 had merged ~18 min earlier.

## Related Issue

Closes #811

## Changes

- **`CLAUDE.md`** — "Start from current" bullet in `## Workflow` (3 → 4), including *why* the injected
  status cannot establish currency; worktree "fresh" claim corrected.
- **`CONTRIBUTING.md`** — narrate the Step 2 snippet that was already there but unexplained: the rule,
  the failure mode, `fetch --prune`, branching from the fetched ref, long-running sessions, and the
  **Update branch** button for mid-flight staleness.
- **`docs/onboarding.mdx`** — it recommended `git branch --merged main | xargs git branch -d`, which
  `CONTRIBUTING.md:304-306` documents as wrong under squash-merge. Now points at the confirm-then-delete
  procedure instead of restating it.

Prose only, no hook — honoring #678's portability precedent. See the honest negative result below.

## Verification evidence

**The 24-hour claim** — proven, not asserted; both arms in the table above, from a scratch remote.

**Two Codex review rounds, two CONFIRMED defects — both in guidance written in this PR, the second
caused by the fix to the first.** Both verified by execution:

Round 1 — *ahead* `main` contaminates the branch, and `checkout main` breaks in a worktree:
```
git status -sb                    ->  ## main...origin/main [ahead 1]   (no "[behind" — my check PASSED)
git log --oneline origin/main..HEAD  ->  5c315f1 UNPUSHED local commit  (contaminated)
git checkout main (2nd worktree)  ->  fatal: 'main' is already used by worktree at '/private/tmp/snip/w'
```
Round 2 — the fix made feature branches track `origin/main`, defeating this repo's own `[gone]` cleanup:
```
git switch -c feat/aaa origin/main            upstream -> origin/main
  delete remote + fetch -p   is it [gone]? -> NO ()          <- cleanup silently breaks
git switch --no-track -c feat/bbb origin/main upstream -> NONE, 0 commits vs origin/main
  git push -u origin HEAD                     upstream -> origin/feat/bbb
  delete remote + fetch -p   is it [gone]? -> YES            <- cleanup works
```

**Local gate** — `pre-commit run --all-files`: 0 failures. `textlint` exit 0 on all three changed
files, canary-checked (`"A Github pull request"` → flagged) so a silent no-op isn't read as a pass.
All 17 `tests/test-*.sh` suites pass.

**#678 invariants held** — Engineering Standards still exactly 11 bullets; `CLAUDE.md`'s "Clean
branches" bullet untouched; no duplication of the `[gone]` procedure (0 new lines matching it).

## Honest negative result — the behavioural half does not work

Tested against a deliberately stale checkout with an ordinary request ("add a `slugify` function"),
using ground truth (`.git/FETCH_HEAD` presence) rather than only parsing tool calls:

| Arm | Synced before editing? | Ground truth |
| --- | --- | --- |
| Baseline (old `CLAUDE.md`) | No | no `FETCH_HEAD` — never fetched |
| Treatment (new bullet, stub file) | No | no `FETCH_HEAD` — never fetched |
| Treatment (new bullet, full real file) | No | no `FETCH_HEAD` — never fetched |

Every run went `ls`/`cat` → edit. **On this evidence the "Start from current" bullet does not change
behaviour.** n=1 per arm and selection is sampled, but three runs produced no fetch at all.

So this PR should be read as: the accuracy fixes and the corrected branch-creation flow are solid and
independently worth having; the behavioural goal in #811 is **not** demonstrated. A SessionStart hook
remains the only mechanism that fires at the right moment, and the operator's prose-only choice was
made before this result existed — it is theirs to revisit.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met — **except** the
      behavioural criterion, which is reported as a negative result above rather than claimed
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions

Note: docs-control does not run `review / claude-review` on its own PRs (no `code-review.yml` caller;
`self_contexts` are `Check linked issues` + `Lint Code Base`), so this PR's green CI is not reviewer
evidence.
