### PR TITLE
fix(governance): root-anchor the Go vendor rule in the gitignore template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,12 @@ wheels/
 *.dylib
 *.test
 *.out
-vendor/
+# Root-anchored: `go mod vendor` writes at the module root, whereas an unanchored
+# `vendor/` also swallows deliberately-committed vendored trees such as a browser
+# extension's src/vendor/. A repo with a NESTED Go module wanting its vendor tree
+# ignored should add that path locally; no such module exists in the fleet today
+# (the one Go repo has go.mod at its root and does not vendor). See #794.
+/vendor/
 
 # Terraform
 .terraform/

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -584,8 +584,8 @@ GI_TMP=$(mktemp -d /tmp/test-linter-configs-gitignore-XXXXXX)
 git -C "$GI_TMP" init -q
 cp "$REPO_ROOT/.gitignore" "$GI_TMP/.gitignore"
 mkdir -p "$GI_TMP/vendor" "$GI_TMP/src/vendor/chat-ui"
-: > "$GI_TMP/vendor/modules.txt"
-: > "$GI_TMP/src/vendor/chat-ui/index.ts"
+: >"$GI_TMP/vendor/modules.txt"
+: >"$GI_TMP/src/vendor/chat-ui/index.ts"
 
 # A top-level vendor/ tree must still be ignored — that is the rule's purpose.
 if git -C "$GI_TMP" check-ignore -q vendor/modules.txt; then

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -566,6 +566,43 @@ fi
 echo ""
 echo "=== Section 8: Idempotence ==="
 # We assert this by making sure no test mutates repo state.
+# ════════════════════════════════════════════════════════════════════
+# SECTION 8: .gitignore's Go vendor rule is root-anchored (#794)
+# ════════════════════════════════════════════════════════════════════
+# The rule exists for Go module vendoring, which always sits at the module
+# root. Unanchored, `vendor/` matches at ANY depth, so it silently swallowed
+# deliberately-committed vendored trees — xcsh-chrome-extension's
+# src/vendor/chat-ui (45 files) and xcsh's
+# packages/coding-agent/src/export/html/vendor. Every re-vendor needed
+# `git add -f`, and a forgotten force flag failed CI somewhere unrelated.
+# Asserted behaviourally via `git check-ignore` rather than by grepping the
+# file, because the pattern's semantics are the thing under test.
+echo ""
+echo "SECTION 8: .gitignore Go vendor rule is root-anchored"
+
+GI_TMP=$(mktemp -d /tmp/test-linter-configs-gitignore-XXXXXX)
+git -C "$GI_TMP" init -q
+cp "$REPO_ROOT/.gitignore" "$GI_TMP/.gitignore"
+mkdir -p "$GI_TMP/vendor" "$GI_TMP/src/vendor/chat-ui"
+: > "$GI_TMP/vendor/modules.txt"
+: > "$GI_TMP/src/vendor/chat-ui/index.ts"
+
+# A top-level vendor/ tree must still be ignored — that is the rule's purpose.
+if git -C "$GI_TMP" check-ignore -q vendor/modules.txt; then
+  pass "8.1 top-level vendor/ is still ignored (Go module vendoring)"
+else
+  fail "8.1 top-level vendor/ is still ignored (Go module vendoring)" "vendor/modules.txt is no longer ignored"
+fi
+
+# A nested vendored tree must NOT be ignored — it is committed deliberately.
+if git -C "$GI_TMP" check-ignore -q src/vendor/chat-ui/index.ts; then
+  fail "8.2 nested src/vendor/ is NOT ignored" "src/vendor/chat-ui/index.ts is ignored; the vendor rule needs a leading slash"
+else
+  pass "8.2 nested src/vendor/ is NOT ignored"
+fi
+
+rm -rf "$GI_TMP"
+
 # If a future assertion generates a temp file, it must clean up.
 TMPS_BEFORE=$(find /tmp -maxdepth 1 -name 'test-linter-configs-*' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$TMPS_BEFORE" = "0" ]; then


### PR DESCRIPTION
## Problem

The managed `.gitignore` ignored `vendor/` **unanchored**, so it matched a directory named `vendor` at *any* depth. Go module vendoring always sits at the module root, so the extra reach bought nothing — and it silently swallowed vendored trees the fleet commits on purpose:

| repo | tree | files |
|---|---|---|
| `xcsh-chrome-extension` | `src/vendor/chat-ui` | 45 |
| `xcsh` | `packages/coding-agent/src/export/html/vendor` | 2 |

Every re-vendor needed `git add -f`. A forgotten force flag doesn't fail where the mistake was made — it fails later in the consumer's CI as a confusing `TS2307`, which is exactly how it bit during the chat-UI parity work.

## Measured before changing anything

This template reaches 38 repos, so the risk was quantified rather than assumed:

- The fleet has exactly **one** Go repo, `terraform-provider-xcsh`, and it **does not vendor at all** — zero vendor paths, no `vendor/modules.txt`. The broad rule was protecting nothing.
- Its `go.mod` is at the **repository root**, so the root-anchored rule still covers it if it ever starts vendoring.
- There is **no nested `go.mod`** anywhere in the fleet.
- The only two vendor trees are the nested, intentionally-tracked ones above, and both are already committed — ignore rules don't affect tracked files, so neither changes state.

## Change

`vendor/` → `/vendor/`, plus a comment recording why and what a nested-module repo should do instead.

## Test first, per this harness's own contract

`tests/test-linter-configs.sh` states that every config change must land paired with an assertion, written red first. Section 8 asserts the **semantics** with `git check-ignore` against a scratch repo rather than grepping the file, because the pattern's behaviour is the thing under test:

- **8.1** a top-level `vendor/` is still ignored — the rule's actual purpose
- **8.2** a nested `src/vendor/` is **not** ignored

**8.2 confirmed red before the fix** (`Results: 111 passed, 1 failed`), both green after (`112 passed, 0 failed`). `tests/test-protect-managed-files.sh` also passes (124/124), shellcheck is clean, and the section cleans up its temp dir so the harness's own idempotency assertion 6.1 still holds.

## Local second-opinion review (codex, per CLAUDE.md)

First pass raised one **medium**, *"Nested Go module dependencies are no longer ignored"* — `go mod vendor` writes beside a `go.mod` that need not be at the repo root.

**REFUTED on reachability**, and the finding itself conceded it: *"the current fleet audit found no such tree … rather than a demonstrated current break."* Verified there is no nested `go.mod` in any fleet repo; the sole `go.mod` is `terraform-provider-xcsh/go.mod` at its root.

The trade-off is real but unavoidable — one shared pattern cannot both ignore nested vendor trees and track the two nested vendor trees this fleet deliberately commits. Per the no-backward-compat standard, not designing for a hypothetical future repo is the intended call, and the mitigation (that repo adds the path locally) is now documented in the file. The reviewer's alternative — an allowlist of explicit exceptions — was considered and rejected: it would hard-code two consumers' internal paths into a fleet-wide template.

Second pass after documenting the mitigation: **0 findings**. Gate: `done: true`, `findingsClear: true`, no escalation.

## Note

`managed-files-manifest.json` is deliberately **not** touched — `build-managed-files-manifest.yml` triggers on push to `main` with `.gitignore` in its paths and regenerates it, which is what #813 was.

Closes #794
