### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-26T23:23:55Z",
-  "source_commit": "c0135c5fcf42d29c7d559875cf3b79608748a17c",
+  "generated_at": "2026-07-27T11:42:33Z",
+  "source_commit": "4a3c76ee65860b94315ce1268a4dc3887d4c04d5",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -83,8 +83,8 @@
     ".gitignore": {
       "src": ".gitignore",
       "dest": ".gitignore",
-      "sha": "cee6d64b8975d86ffa11a7d5bb292a71f7d25f50",
-      "size": 2761
+      "sha": "50389fae0520ce1f8cb350d7757c3b47de2c7411",
+      "size": 3163
     },
     "LICENSE": {
       "src": "LICENSE",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.