### PR TITLE
fix(governance): run governed lint scripts from canonical, not the local copy

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -61,19 +61,26 @@ jobs:
           # would deliver the fix could never pass the stale gate it replaces — that is
           # what stranded i18n-core (issue #815). Still never the head's copy.
           remote="${GOVERNANCE_REMOTE:-https://github.com/f5-sales-demo/docs-control}"
-          if ! git fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
+          # Fetch into a throwaway repository, never this workspace. A --depth=1 fetch
+          # into the checkout writes .git/shallow, which breaks Super-Linter's
+          # GIT_MERGE_BASE calculation and fails the whole job; and it would clobber
+          # FETCH_HEAD for anything else in the workspace.
+          gov_dir=$(mktemp -d)
+          trap 'rm -rf "$gov_dir"' EXIT
+          git init --quiet "$gov_dir"
+          if ! git -C "$gov_dir" fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
             echo "::error::cannot reach canonical governance at ${remote} -- refusing to run a stale gate"
             exit 1
           fi
-          canonical_sha=$(git rev-parse FETCH_HEAD)
-          if ! git cat-file -e "${canonical_sha}:${script}" 2>/dev/null; then
+          canonical_sha=$(git -C "$gov_dir" rev-parse FETCH_HEAD)
+          if ! git -C "$gov_dir" cat-file -e "${canonical_sha}:${script}" 2>/dev/null; then
             # Absent from canonical. Distinguish a deliberate retirement from an
             # accident by asking canonical's own manifest, not this repo's copy of the
             # script: the sync only ever adds and updates blobs, never deletes them, so
             # a retired script lingers downstream forever and cannot be used as the
             # signal. Retirement = drop the managed_files entry; the orphaned
             # downstream copy is then simply unmanaged.
-            if git show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
+            if git -C "$gov_dir" show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
               jq -e --arg s "$script" '[.managed_files.files[]?.dest] | index($s) == null' >/dev/null 2>&1; then
               echo "${script} has been retired from canonical governance; nothing to enforce."
               exit 0
@@ -84,7 +91,7 @@ jobs:
           # Log the exact commit whose bytes run, so a run is reproducible and any
           # behaviour change is attributable to a specific governance commit.
           echo "Enforcing ${script} from canonical governance @ ${canonical_sha}"
-          git show "${canonical_sha}:${script}" | bash -s
+          git -C "$gov_dir" show "${canonical_sha}:${script}" | bash -s
 
       # Same trust boundary and same canonical source as the step above: never the
       # head's own copy, and never a possibly-stale local copy. Repositories that opt
@@ -107,19 +114,26 @@ jobs:
           # would deliver the fix could never pass the stale gate it replaces — that is
           # what stranded i18n-core (issue #815). Still never the head's copy.
           remote="${GOVERNANCE_REMOTE:-https://github.com/f5-sales-demo/docs-control}"
-          if ! git fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
+          # Fetch into a throwaway repository, never this workspace. A --depth=1 fetch
+          # into the checkout writes .git/shallow, which breaks Super-Linter's
+          # GIT_MERGE_BASE calculation and fails the whole job; and it would clobber
+          # FETCH_HEAD for anything else in the workspace.
+          gov_dir=$(mktemp -d)
+          trap 'rm -rf "$gov_dir"' EXIT
+          git init --quiet "$gov_dir"
+          if ! git -C "$gov_dir" fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
             echo "::error::cannot reach canonical governance at ${remote} -- refusing to run a stale gate"
             exit 1
           fi
-          canonical_sha=$(git rev-parse FETCH_HEAD)
-          if ! git cat-file -e "${canonical_sha}:${script}" 2>/dev/null; then
+          canonical_sha=$(git -C "$gov_dir" rev-parse FETCH_HEAD)
+          if ! git -C "$gov_dir" cat-file -e "${canonical_sha}:${script}" 2>/dev/null; then
             # Absent from canonical. Distinguish a deliberate retirement from an
             # accident by asking canonical's own manifest, not this repo's copy of the
             # script: the sync only ever adds and updates blobs, never deletes them, so
             # a retired script lingers downstream forever and cannot be used as the
             # signal. Retirement = drop the managed_files entry; the orphaned
             # downstream copy is then simply unmanaged.
-            if git show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
+            if git -C "$gov_dir" show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
               jq -e --arg s "$script" '[.managed_files.files[]?.dest] | index($s) == null' >/dev/null 2>&1; then
               echo "${script} has been retired from canonical governance; nothing to enforce."
               exit 0
@@ -130,7 +144,7 @@ jobs:
           # Log the exact commit whose bytes run, so a run is reproducible and any
           # behaviour change is attributable to a specific governance commit.
           echo "Enforcing ${script} from canonical governance @ ${canonical_sha}"
-          git show "${canonical_sha}:${script}" | bash -s
+          git -C "$gov_dir" show "${canonical_sha}:${script}" | bash -s
 
       # Biome runs OUTSIDE the Super-Linter container so we can track Biome
       # `latest` instead of being gated on Super-Linter's container release

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -80,8 +80,16 @@ jobs:
             # a retired script lingers downstream forever and cannot be used as the
             # signal. Retirement = drop the managed_files entry; the orphaned
             # downstream copy is then simply unmanaged.
-            if git -C "$gov_dir" show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
-              jq -e --arg s "$script" '[.managed_files.files[]?.dest] | index($s) == null' >/dev/null 2>&1; then
+            manifest=$(git -C "$gov_dir" show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null || true)
+            # Require a well-formed manifest before believing "retired". Absent or
+            # malformed managed_files must not read as an empty list, or a schema
+            # migration or partial merge would silently stand the gate down.
+            if ! printf '%s' "$manifest" | jq -e '.managed_files.files | type == "array"' >/dev/null 2>&1; then
+              echo "::error::cannot read managed_files from canonical governance @ ${canonical_sha} -- refusing to guess whether ${script} was retired"
+              exit 1
+            fi
+            if printf '%s' "$manifest" |
+              jq -e --arg s "$script" '[.managed_files.files[].dest] | index($s) == null' >/dev/null 2>&1; then
               echo "${script} has been retired from canonical governance; nothing to enforce."
               exit 0
             fi
@@ -133,8 +141,16 @@ jobs:
             # a retired script lingers downstream forever and cannot be used as the
             # signal. Retirement = drop the managed_files entry; the orphaned
             # downstream copy is then simply unmanaged.
-            if git -C "$gov_dir" show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
-              jq -e --arg s "$script" '[.managed_files.files[]?.dest] | index($s) == null' >/dev/null 2>&1; then
+            manifest=$(git -C "$gov_dir" show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null || true)
+            # Require a well-formed manifest before believing "retired". Absent or
+            # malformed managed_files must not read as an empty list, or a schema
+            # migration or partial merge would silently stand the gate down.
+            if ! printf '%s' "$manifest" | jq -e '.managed_files.files | type == "array"' >/dev/null 2>&1; then
+              echo "::error::cannot read managed_files from canonical governance @ ${canonical_sha} -- refusing to guess whether ${script} was retired"
+              exit 1
+            fi
+            if printf '%s' "$manifest" |
+              jq -e --arg s "$script" '[.managed_files.files[].dest] | index($s) == null' >/dev/null 2>&1; then
               echo "${script} has been retired from canonical governance; nothing to enforce."
               exit 0
             fi

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,16 +28,21 @@ jobs:
       # cannot see git object modes from inside its container). Cheap and first, so
       # a committed absolute symlink or hardcoded home directory fails fast.
       #
-      # Runs the DEFAULT-BRANCH copy of the script against the HEAD working tree,
-      # per REVIEWER-SPEC.md invariant 3 ("never execute scripts carried in the PR
-      # head") and the trust boundary documented there. Two reasons:
+      # Runs the CANONICAL copy of the script (docs-control main) against the HEAD
+      # working tree, per REVIEWER-SPEC.md invariant 3 ("never execute scripts carried
+      # in the PR head") and the trust boundary documented there. Two reasons:
       #   1. This job holds statuses:write and pull-requests:write, so executing a
       #      PR's own copy of the script would hand those scopes to PR-authored code.
       #   2. Gating on the head's copy would let a PR delete the file to skip the
       #      gate entirely.
       # The script only reads git metadata and tracked file contents, so trusted
-      # logic over untrusted data is safe. Absent on the default branch, there is
-      # nothing to enforce yet — that is the rollout path, not a bypass.
+      # logic over untrusted data is safe.
+      #
+      # Canonical rather than this repo's default branch: the default branch is a sync
+      # target and can lag docs-control, in which case the pull request carrying the
+      # fix is blocked by the stale copy it would replace (issue #815). Whether the
+      # script applies here is still decided by the default branch carrying it, so the
+      # skip_files opt-out is unchanged; absent there, nothing to enforce.
       - name: Check repository hygiene
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -46,15 +51,44 @@ jobs:
           script=scripts/check-repo-hygiene.sh
           branch="${DEFAULT_BRANCH:-main}"
           git fetch --no-tags --quiet origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+          # Opt-out is still "the repo does not carry the script" (skip_files), unchanged.
           if ! git cat-file -e "origin/${branch}:${script}" 2>/dev/null; then
             echo "The default branch does not carry ${script} yet; nothing to enforce."
             exit 0
           fi
-          git show "origin/${branch}:${script}" | bash -s
+          # Execute the CANONICAL bytes, not this repo's copy. A downstream default
+          # branch is a sync target and can lag docs-control, and a pull request that
+          # would deliver the fix could never pass the stale gate it replaces — that is
+          # what stranded i18n-core (issue #815). Still never the head's copy.
+          remote="${GOVERNANCE_REMOTE:-https://github.com/f5-sales-demo/docs-control}"
+          if ! git fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
+            echo "::error::cannot reach canonical governance at ${remote} -- refusing to run a stale gate"
+            exit 1
+          fi
+          canonical_sha=$(git rev-parse FETCH_HEAD)
+          if ! git cat-file -e "${canonical_sha}:${script}" 2>/dev/null; then
+            # Absent from canonical. Distinguish a deliberate retirement from an
+            # accident by asking canonical's own manifest, not this repo's copy of the
+            # script: the sync only ever adds and updates blobs, never deletes them, so
+            # a retired script lingers downstream forever and cannot be used as the
+            # signal. Retirement = drop the managed_files entry; the orphaned
+            # downstream copy is then simply unmanaged.
+            if git show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
+              jq -e --arg s "$script" '[.managed_files.files[]?.dest] | index($s) == null' >/dev/null 2>&1; then
+              echo "${script} has been retired from canonical governance; nothing to enforce."
+              exit 0
+            fi
+            echo "::error::${script} is still listed in canonical managed_files but missing from canonical governance @ ${canonical_sha} -- refusing to pass an unenforced gate. Retire it by removing its managed_files entry."
+            exit 1
+          fi
+          # Log the exact commit whose bytes run, so a run is reproducible and any
+          # behaviour change is attributable to a specific governance commit.
+          echo "Enforcing ${script} from canonical governance @ ${canonical_sha}"
+          git show "${canonical_sha}:${script}" | bash -s
 
-      # Same trust boundary as the step above: the default-branch copy of the script
-      # is run against the head working tree, never the head's own copy. Repositories
-      # that opt out of this script via skip_files simply have nothing to enforce.
+      # Same trust boundary and same canonical source as the step above: never the
+      # head's own copy, and never a possibly-stale local copy. Repositories that opt
+      # out of this script via skip_files simply have nothing to enforce.
       - name: Check for hardcoded locale lists
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -63,11 +97,40 @@ jobs:
           script=scripts/locale-lint.sh
           branch="${DEFAULT_BRANCH:-main}"
           git fetch --no-tags --quiet origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"
+          # Opt-out is still "the repo does not carry the script" (skip_files), unchanged.
           if ! git cat-file -e "origin/${branch}:${script}" 2>/dev/null; then
             echo "The default branch does not carry ${script}; nothing to enforce."
             exit 0
           fi
-          git show "origin/${branch}:${script}" | bash -s
+          # Execute the CANONICAL bytes, not this repo's copy. A downstream default
+          # branch is a sync target and can lag docs-control, and a pull request that
+          # would deliver the fix could never pass the stale gate it replaces — that is
+          # what stranded i18n-core (issue #815). Still never the head's copy.
+          remote="${GOVERNANCE_REMOTE:-https://github.com/f5-sales-demo/docs-control}"
+          if ! git fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
+            echo "::error::cannot reach canonical governance at ${remote} -- refusing to run a stale gate"
+            exit 1
+          fi
+          canonical_sha=$(git rev-parse FETCH_HEAD)
+          if ! git cat-file -e "${canonical_sha}:${script}" 2>/dev/null; then
+            # Absent from canonical. Distinguish a deliberate retirement from an
+            # accident by asking canonical's own manifest, not this repo's copy of the
+            # script: the sync only ever adds and updates blobs, never deletes them, so
+            # a retired script lingers downstream forever and cannot be used as the
+            # signal. Retirement = drop the managed_files entry; the orphaned
+            # downstream copy is then simply unmanaged.
+            if git show "${canonical_sha}:.github/config/repo-settings.json" 2>/dev/null |
+              jq -e --arg s "$script" '[.managed_files.files[]?.dest] | index($s) == null' >/dev/null 2>&1; then
+              echo "${script} has been retired from canonical governance; nothing to enforce."
+              exit 0
+            fi
+            echo "::error::${script} is still listed in canonical managed_files but missing from canonical governance @ ${canonical_sha} -- refusing to pass an unenforced gate. Retire it by removing its managed_files entry."
+            exit 1
+          fi
+          # Log the exact commit whose bytes run, so a run is reproducible and any
+          # behaviour change is attributable to a specific governance commit.
+          echo "Enforcing ${script} from canonical governance @ ${canonical_sha}"
+          git show "${canonical_sha}:${script}" | bash -s
 
       # Biome runs OUTSIDE the Super-Linter container so we can track Biome
       # `latest` instead of being gated on Super-Linter's container release
@@ -296,6 +359,10 @@ jobs:
       - name: Run locale-lint test
         if: hashFiles('tests/test-locale-lint.sh') != ''
         run: bash tests/test-locale-lint.sh
+
+      - name: Run governed-script source test
+        if: hashFiles('tests/test-governed-script-source.sh') != ''
+        run: bash tests/test-governed-script-source.sh
 
       - name: Run fleet pre-flight test
         if: hashFiles('tests/test-preflight-fleet.sh') != ''

--- a/tests/test-governed-script-source.sh
+++ b/tests/test-governed-script-source.sh
@@ -85,7 +85,9 @@ make_canonical() {
       chmod +x scripts/locale-lint.sh
     fi
     mkdir -p .github/config
-    if [ "$manifest" = "retired" ]; then
+    if [ "$manifest" = "nomanifest" ]; then
+      : # deliberately no repo-settings.json
+    elif [ "$manifest" = "retired" ]; then
       echo '{"managed_files":{"files":[{"src":"other.sh","dest":"other.sh"}]}}' \
         >.github/config/repo-settings.json
     else
@@ -163,6 +165,10 @@ else
   # or rename, not a retirement.
   CANON_ACCIDENT="${TMPDIR_BASE}/canonical-accident"
   make_canonical "$CANON_ACCIDENT" "" "listed"
+
+  # Script gone AND no manifest to consult: an anomaly, not a retirement.
+  CANON_NOMANIFEST="${TMPDIR_BASE}/canonical-nomanifest"
+  make_canonical "$CANON_NOMANIFEST" "" "nomanifest"
 
   # 1. THE DEADLOCK. Canonical carries the guard; the downstream default branch does
   #    not. The old behaviour ran the stale guardless copy and failed, blocking the
@@ -243,6 +249,19 @@ exit 0
     pass "accidental removal from canonical fails closed, not open"
   else
     fail "accidental removal from canonical fails closed, not open" \
+      "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+
+  # 6b. An unreadable or malformed manifest must not read as an empty file list, or a
+  #     schema migration would silently stand the gate down fleet-wide.
+  d6b="${TMPDIR_BASE}/d6b"
+  make_downstream "$d6b" "$GUARDLESS_SCRIPT" "$GUARDLESS_SCRIPT"
+  rc=0
+  out=$(run_step "$d6b" "$CANON_NOMANIFEST" "$STEP") || rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "cannot read managed_files"; then
+    pass "unreadable canonical manifest fails closed, not open"
+  else
+    fail "unreadable canonical manifest fails closed, not open" \
       "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
   fi
 

--- a/tests/test-governed-script-source.sh
+++ b/tests/test-governed-script-source.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Behavioural tests for where the lint job sources governed scripts from (issue #815).
+#
+# The lint job executes governed scripts against the PR head working tree. Which
+# COPY of the script it executes is a trust decision with two failure modes:
+#
+#   - Running the head's copy would hand statuses:write / pull-requests:write to
+#     PR-authored code, and would let a PR delete the file to skip the gate
+#     (REVIEWER-SPEC.md invariant 3).
+#   - Running the downstream default branch's copy deadlocks: when that copy lags
+#     docs-control, the pull request that would deliver the fix is blocked by the
+#     stale copy it is trying to replace. This is what stranded i18n-core.
+#
+# Canonical bytes satisfy both. These tests drive the real step, extracted from the
+# workflow, against local git repositories via the GOVERNANCE_REMOTE seam — no
+# network, no GitHub.
+set -uo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+WORKFLOW="${REPO_ROOT}/.github/workflows/super-linter.yml"
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL: $1 — $2"
+}
+
+TMPDIR_BASE=$(cd "$(mktemp -d)" && pwd -P)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# Extract a step's `run:` body from the workflow so the test exercises shipped bytes.
+# Keyed on the step name, then the run block, de-indented to column 0.
+extract_step() {
+  local name="$1"
+  awk -v want="$name" '
+    $0 ~ ("^[[:space:]]*- name: " want "[[:space:]]*$") { found = 1; next }
+    found && /^[[:space:]]*run: \|/ { inrun = 1; next }
+    inrun && /^[[:space:]]*- name: / { exit }
+    inrun { print }
+  ' "$WORKFLOW" | sed -e 's/^[[:space:]]\{10\}//' -e '/^[[:space:]]*$/d'
+}
+
+GUARDED_SCRIPT='#!/usr/bin/env bash
+set -euo pipefail
+if [ -f package.json ] && grep -q "@f5-sales-demo/i18n-core" package.json; then
+  echo "canonical: this is i18n-core itself — definitions are canonical"
+  exit 0
+fi
+if grep -rqE "export const LOCALE_DISPLAY_NAMES" --include="*.ts" .; then
+  echo "FAIL: hardcoded locale data"
+  exit 1
+fi
+'
+
+GUARDLESS_SCRIPT='#!/usr/bin/env bash
+set -euo pipefail
+if grep -rqE "export const LOCALE_DISPLAY_NAMES" --include="*.ts" .; then
+  echo "FAIL: hardcoded locale data"
+  exit 1
+fi
+'
+
+git_quiet() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t "$@" >/dev/null 2>&1; }
+
+# A canonical governance repo. `with_script` empty means canonical retired the script.
+# $3 = "listed" (default) to keep scripts/locale-lint.sh in managed_files, or
+# "retired" to drop it. The sync never deletes downstream blobs, so the manifest --
+# not the presence of the file downstream -- is what marks a script retired.
+make_canonical() {
+  local dir="$1" body="${2:-}" manifest="${3:-listed}"
+  mkdir -p "$dir"
+  (
+    cd "$dir" || exit 1
+    git_quiet init
+    if [ -n "$body" ]; then
+      mkdir -p scripts
+      printf '%s' "$body" >scripts/locale-lint.sh
+      chmod +x scripts/locale-lint.sh
+    fi
+    mkdir -p .github/config
+    if [ "$manifest" = "retired" ]; then
+      echo '{"managed_files":{"files":[{"src":"other.sh","dest":"other.sh"}]}}' \
+        >.github/config/repo-settings.json
+    else
+      echo '{"managed_files":{"files":[{"src":"scripts/locale-lint.sh","dest":"scripts/locale-lint.sh"}]}}' \
+        >.github/config/repo-settings.json
+    fi
+    echo "canonical" >MARKER
+    git_quiet add -A
+    git_quiet commit -m canonical
+  )
+}
+
+# A downstream repo: `main` carries $main_body (empty = opts out via skip_files), and
+# the checked-out head is i18n-core-shaped, with $head_body as its own copy.
+make_downstream() {
+  local dir="$1" main_body="${2:-}" head_body="${3:-}"
+  mkdir -p "$dir"
+  (
+    cd "$dir" || exit 1
+    git_quiet init
+    mkdir -p src
+    echo '{ "name": "@f5-sales-demo/i18n-core", "version": "1.0.0" }' >package.json
+    cat >src/display-names.ts <<'TS'
+import { LOCALE_REGISTRY } from './registry.js';
+
+export const LOCALE_DISPLAY_NAMES: Readonly<Record<string, string>> = Object.fromEntries(
+  LOCALE_REGISTRY.map((entry) => [entry.slug, entry.labelEn]),
+);
+TS
+    if [ -n "$main_body" ]; then
+      mkdir -p scripts
+      printf '%s' "$main_body" >scripts/locale-lint.sh
+      chmod +x scripts/locale-lint.sh
+    fi
+    git_quiet add -A
+    git_quiet commit -m downstream
+    # The step reads origin/<default>, so give the repo an origin pointing at itself.
+    git_quiet remote add origin "$dir"
+    git_quiet fetch origin
+    if [ -n "$head_body" ]; then
+      mkdir -p scripts
+      printf '%s' "$head_body" >scripts/locale-lint.sh
+      chmod +x scripts/locale-lint.sh
+    fi
+  )
+}
+
+# Run the extracted step inside a downstream repo with a given canonical remote.
+run_step() {
+  local downstream="$1" remote="$2" body="$3"
+  (
+    cd "$downstream" || exit 1
+    DEFAULT_BRANCH=main GOVERNANCE_REMOTE="$remote" bash -c "$body" 2>&1
+  )
+}
+
+STEP=$(extract_step "Check for hardcoded locale lists")
+
+echo ""
+echo "=== governed-script source: 'Check for hardcoded locale lists' ==="
+
+if [ -z "$STEP" ]; then
+  fail "step body is extractable" "no run: block found for the step"
+else
+  pass "step body is extractable"
+
+  CANON="${TMPDIR_BASE}/canonical"
+  make_canonical "$CANON" "$GUARDED_SCRIPT"
+
+  # Retired properly: gone from canonical AND dropped from managed_files.
+  CANON_RETIRED="${TMPDIR_BASE}/canonical-retired"
+  make_canonical "$CANON_RETIRED" "" "retired"
+
+  # Gone from canonical but STILL listed in managed_files -- an accidental deletion
+  # or rename, not a retirement.
+  CANON_ACCIDENT="${TMPDIR_BASE}/canonical-accident"
+  make_canonical "$CANON_ACCIDENT" "" "listed"
+
+  # 1. THE DEADLOCK. Canonical carries the guard; the downstream default branch does
+  #    not. The old behaviour ran the stale guardless copy and failed, blocking the
+  #    very PR that would deliver the guard.
+  d1="${TMPDIR_BASE}/d1"
+  make_downstream "$d1" "$GUARDLESS_SCRIPT" "$GUARDLESS_SCRIPT"
+  rc=0
+  out=$(run_step "$d1" "$CANON" "$STEP") || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    pass "stale downstream copy does not block: canonical bytes run"
+  else
+    fail "stale downstream copy does not block: canonical bytes run" \
+      "exit $rc — the deadlock is still present: $(printf '%s' "$out" | tail -2 | tr '\n' ' ')"
+  fi
+
+  # 2. The skip_files opt-out is expressed by file absence and must survive.
+  d2="${TMPDIR_BASE}/d2"
+  make_downstream "$d2" "" ""
+  rc=0
+  out=$(run_step "$d2" "$CANON" "$STEP") || rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "nothing to enforce"; then
+    pass "opt-out preserved: absent on the default branch means nothing to enforce"
+  else
+    fail "opt-out preserved: absent on the default branch means nothing to enforce" \
+      "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+
+  # 3. The head must not be able to weaken the gate. Head's copy exits 0
+  #    unconditionally; canonical still flags, so the step must still fail.
+  d3="${TMPDIR_BASE}/d3"
+  make_downstream "$d3" "$GUARDLESS_SCRIPT" '#!/usr/bin/env bash
+exit 0
+'
+  # Remove the i18n-core marker so canonical's guard does not legitimately exempt it.
+  echo '{ "name": "some-consumer", "version": "1.0.0" }' >"${d3}/package.json"
+  rc=0
+  out=$(run_step "$d3" "$CANON" "$STEP") || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "head cannot weaken the gate: its own copy is never executed"
+  else
+    fail "head cannot weaken the gate: its own copy is never executed" \
+      "exit 0 — the head's exit-0 copy appears to have run"
+  fi
+
+  # 4. Unreachable canonical must fail closed, not pass or skip.
+  d4="${TMPDIR_BASE}/d4"
+  make_downstream "$d4" "$GUARDLESS_SCRIPT" "$GUARDLESS_SCRIPT"
+  rc=0
+  out=$(run_step "$d4" "${TMPDIR_BASE}/does-not-exist" "$STEP") || rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "cannot reach canonical governance"; then
+    pass "unreachable canonical fails closed"
+  else
+    fail "unreachable canonical fails closed" \
+      "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+
+  # 5. A genuine retirement: gone from canonical and dropped from managed_files. The
+  #    orphaned downstream copy stays forever (the sync never deletes), so the
+  #    manifest is the only reliable signal.
+  d5="${TMPDIR_BASE}/d5"
+  make_downstream "$d5" "$GUARDLESS_SCRIPT" "$GUARDLESS_SCRIPT"
+  rc=0
+  out=$(run_step "$d5" "$CANON_RETIRED" "$STEP") || rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "has been retired"; then
+    pass "a real retirement (dropped from managed_files) exits 0"
+  else
+    fail "a real retirement (dropped from managed_files) exits 0" \
+      "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+
+  # 6. Missing from canonical but still listed in managed_files must fail closed:
+  #    passing would silently disable the gate in every still-opted-in repository.
+  d6="${TMPDIR_BASE}/d6"
+  make_downstream "$d6" "$GUARDLESS_SCRIPT" "$GUARDLESS_SCRIPT"
+  rc=0
+  out=$(run_step "$d6" "$CANON_ACCIDENT" "$STEP") || rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "still listed in canonical managed_files"; then
+    pass "accidental removal from canonical fails closed, not open"
+  else
+    fail "accidental removal from canonical fails closed, not open" \
+      "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
+  fi
+fi
+
+# The sibling hygiene step shares the pattern and must get the same treatment, or the
+# deadlock simply moves to the next governed script.
+echo ""
+echo "=== the sibling hygiene step uses the same source ==="
+HYGIENE=$(extract_step "Check repository hygiene")
+if [ -z "$HYGIENE" ]; then
+  fail "hygiene step body is extractable" "no run: block found"
+else
+  pass "hygiene step body is extractable"
+  if printf '%s' "$HYGIENE" | grep -q 'canonical_sha}:\${script}'; then
+    pass "hygiene step also executes canonical bytes"
+  else
+    fail "hygiene step also executes canonical bytes" "still sources the local default branch"
+  fi
+fi
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: ${PASS} passed, ${FAIL} failed ($((PASS + FAIL)) total)"
+echo "════════════════════════════════════════════"
+
+[ "$FAIL" -eq 0 ]

--- a/tests/test-governed-script-source.sh
+++ b/tests/test-governed-script-source.sh
@@ -245,6 +245,29 @@ exit 0
     fail "accidental removal from canonical fails closed, not open" \
       "exit $rc out=$(printf '%s' "$out" | tr '\n' ' ')"
   fi
+
+  # 7. The workspace must be left pristine. A --depth=1 fetch into the checkout writes
+  #    .git/shallow, which breaks Super-Linter's GIT_MERGE_BASE calculation and fails
+  #    the whole job — caught in CI on PR #817, not locally.
+  d7="${TMPDIR_BASE}/d7"
+  make_downstream "$d7" "$GUARDLESS_SCRIPT" "$GUARDLESS_SCRIPT"
+  run_step "$d7" "$CANON" "$STEP" >/dev/null 2>&1 || true
+  if [ ! -f "${d7}/.git/shallow" ]; then
+    pass "workspace is not made shallow by the canonical fetch"
+  else
+    fail "workspace is not made shallow by the canonical fetch" \
+      ".git/shallow was created — this breaks Super-Linter's merge-base calculation"
+  fi
+  # The fixture's own `git fetch origin` legitimately leaves a FETCH_HEAD, so the
+  # meaningful assertion is that the canonical fetch did not overwrite it.
+  fetch_head_after=$(git -C "$d7" rev-parse --quiet --verify FETCH_HEAD 2>/dev/null || echo "")
+  canonical_head=$(git -C "$CANON" rev-parse HEAD)
+  if [ "$fetch_head_after" != "$canonical_head" ]; then
+    pass "workspace FETCH_HEAD is not clobbered by the canonical fetch"
+  else
+    fail "workspace FETCH_HEAD is not clobbered by the canonical fetch" \
+      "FETCH_HEAD now points at the canonical commit — the fetch landed in the workspace"
+  fi
 fi
 
 # The sibling hygiene step shares the pattern and must get the same treatment, or the

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -211,7 +211,7 @@ else
   fail "5f.1 repo-hygiene step is present in the lint job" "step not found"
 fi
 
-if printf '%s' "$HYG_STEP" | grep -qE 'git show "\$\{canonical_sha\}:\$\{script\}"' &&
+if printf '%s' "$HYG_STEP" | grep -qE 'git -C "\$gov_dir" show "\$\{canonical_sha\}:\$\{script\}"' &&
   ! printf '%s' "$HYG_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
   pass "5f.2 repo-hygiene runs the canonical copy, not this repo's"
 else
@@ -241,7 +241,7 @@ else
   fail "5f.5 locale-lint step is present in the lint job" "step not found"
 fi
 
-if printf '%s' "$LOCALE_STEP" | grep -qE 'git show "\$\{canonical_sha\}:\$\{script\}"' &&
+if printf '%s' "$LOCALE_STEP" | grep -qE 'git -C "\$gov_dir" show "\$\{canonical_sha\}:\$\{script\}"' &&
   ! printf '%s' "$LOCALE_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
   pass "5f.6 locale-lint runs the canonical copy, not this repo's"
 else
@@ -276,6 +276,24 @@ for pair in "5f.9:HYG:check-repo-hygiene.sh" "5f.10:LOC:locale-lint.sh"; do
   else
     fail "${num} ${name} keeps the default-branch presence gate (skip_files opt-out)" \
       "without it, repos that opted out would start being enforced"
+  fi
+done
+
+# The canonical fetch must not touch this workspace: a --depth=1 fetch into the
+# checkout writes .git/shallow and breaks Super-Linter's GIT_MERGE_BASE calculation,
+# failing the whole job (observed on PR #817).
+for pair in "5f.13:HYG:check-repo-hygiene.sh" "5f.14:LOC:locale-lint.sh"; do
+  num=${pair%%:*}
+  rest=${pair#*:}
+  which=${rest%%:*}
+  name=${rest##*:}
+  if [ "$which" = "HYG" ]; then step="$HYG_STEP"; else step="$LOCALE_STEP"; fi
+  if printf '%s' "$step" | grep -qE 'git -C "\$gov_dir" fetch' &&
+    ! printf '%s' "$step" | grep -qE '^[[:space:]]*git fetch --no-tags --quiet --depth=1'; then
+    pass "${num} ${name} fetches canonical into a throwaway repo, not the workspace"
+  else
+    fail "${num} ${name} fetches canonical into a throwaway repo, not the workspace" \
+      "a --depth=1 fetch into the checkout writes .git/shallow and breaks merge-base"
   fi
 done
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -211,10 +211,12 @@ else
   fail "5f.1 repo-hygiene step is present in the lint job" "step not found"
 fi
 
-if printf '%s' "$HYG_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
-  pass "5f.2 runs the default-branch copy of the script"
+if printf '%s' "$HYG_STEP" | grep -qE 'git show "\$\{canonical_sha\}:\$\{script\}"' &&
+  ! printf '%s' "$HYG_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
+  pass "5f.2 repo-hygiene runs the canonical copy, not this repo's"
 else
-  fail "5f.2 runs the default-branch copy of the script" "no git show of the default-branch copy"
+  fail "5f.2 repo-hygiene runs the canonical copy, not this repo's" \
+    "a sync target's copy can lag docs-control and deadlock the PR that would fix it (#815)"
 fi
 
 if printf '%s' "$HYG_STEP" | grep -qE '^[[:space:]]*run: bash scripts/check-repo-hygiene\.sh[[:space:]]*$'; then
@@ -229,18 +231,22 @@ else
   pass "5f.4 enforcement cannot be skipped by deleting the file"
 fi
 
-# Every governed script the lint job executes must come from the default branch,
-# never from the pull request head, and must not be skippable by deleting the file.
+# Every governed script the lint job executes must come from CANONICAL governance,
+# never from the pull request head and never from this repo's possibly-stale copy,
+# and must not be skippable by deleting the file. Whether a script applies here is
+# still decided by the default branch carrying it, so skip_files keeps working.
 if [ -n "$LOCALE_STEP" ]; then
   pass "5f.5 locale-lint step is present in the lint job"
 else
   fail "5f.5 locale-lint step is present in the lint job" "step not found"
 fi
 
-if printf '%s' "$LOCALE_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
-  pass "5f.6 locale-lint runs the default-branch copy"
+if printf '%s' "$LOCALE_STEP" | grep -qE 'git show "\$\{canonical_sha\}:\$\{script\}"' &&
+  ! printf '%s' "$LOCALE_STEP" | grep -qE 'git show "origin/\$\{branch\}:\$\{script\}"'; then
+  pass "5f.6 locale-lint runs the canonical copy, not this repo's"
 else
-  fail "5f.6 locale-lint runs the default-branch copy" "no git show of the default-branch copy"
+  fail "5f.6 locale-lint runs the canonical copy, not this repo's" \
+    "a sync target's copy can lag docs-control and deadlock the PR that would fix it (#815)"
 fi
 
 if printf '%s' "$LOCALE_STEP" | grep -qE '^[[:space:]]*run: bash scripts/locale-lint\.sh[[:space:]]*$'; then
@@ -254,6 +260,41 @@ if printf '%s' "$LOCALE_STEP" | grep -q "hashFiles('scripts/locale-lint.sh')"; t
 else
   pass "5f.8 locale-lint enforcement cannot be skipped by deleting the file"
 fi
+
+# The skip_files opt-out is expressed by the repo not carrying the script at all, so
+# the presence check against the default branch must remain. Sourcing canonical
+# unconditionally would start enforcing locale-lint in terraform-provider-xcsh, which
+# deliberately opted out.
+for pair in "5f.9:HYG:check-repo-hygiene.sh" "5f.10:LOC:locale-lint.sh"; do
+  num=${pair%%:*}
+  rest=${pair#*:}
+  which=${rest%%:*}
+  name=${rest##*:}
+  if [ "$which" = "HYG" ]; then step="$HYG_STEP"; else step="$LOCALE_STEP"; fi
+  if printf '%s' "$step" | grep -qE 'git cat-file -e "origin/\$\{branch\}:\$\{script\}"'; then
+    pass "${num} ${name} keeps the default-branch presence gate (skip_files opt-out)"
+  else
+    fail "${num} ${name} keeps the default-branch presence gate (skip_files opt-out)" \
+      "without it, repos that opted out would start being enforced"
+  fi
+done
+
+# A governed gate that silently stops enforcing when it cannot reach canonical is
+# worse than a red check.
+for pair in "5f.11:HYG:check-repo-hygiene.sh" "5f.12:LOC:locale-lint.sh"; do
+  num=${pair%%:*}
+  rest=${pair#*:}
+  which=${rest%%:*}
+  name=${rest##*:}
+  if [ "$which" = "HYG" ]; then step="$HYG_STEP"; else step="$LOCALE_STEP"; fi
+  if printf '%s' "$step" | grep -q "cannot reach canonical governance" &&
+    printf '%s' "$step" | grep -qE '^[[:space:]]*exit 1$'; then
+    pass "${num} ${name} fails closed when canonical is unreachable"
+  else
+    fail "${num} ${name} fails closed when canonical is unreachable" \
+      "an unreachable remote must not pass or skip the gate"
+  fi
+done
 
 # ════════════════════════════════════════════════════════════════════
 # SECTION 6: zizmor.yaml suppressions are complete enough for caller


### PR DESCRIPTION
## What

Both governed-script steps in `super-linter.yml` now execute **canonical** bytes (docs-control `main`) instead of the downstream repository's own default-branch copy.

## Why

When the downstream copy lags docs-control, the pull request that would deliver the fix is blocked by the stale copy it is trying to replace. There is no sanctioned escape: the script is a managed file, so `protect-managed-files.sh` blocks hand-editing, and the sync PR is the only delivery path.

**This is stranding `i18n-core` right now.** Canonical `scripts/locale-lint.sh:44-51` carries a self-exclusion guard for the package that owns the locale definitions. i18n-core's `main` copy does not — the guard is the *only* difference between the two files (1783 bytes / 61 lines vs 2317 / 70). So the stale script flags `src/display-names.ts:3` for `LOCALE_DISPLAY_NAMES`, a line that is a pure `Object.fromEntries` projection over `LOCALE_REGISTRY` and hardcodes nothing.

Six sync PRs have now churned and closed unmerged (#204, #206, #208, #210, #213, #215). The repo has had no managed-file update since before 2026-07-25 and is one of two still missing `repo_classes` from #798.

**It is a class, not an instance.** `scripts/check-repo-hygiene.sh` at `:41-53` uses the identical pattern and has the identical latent exposure in all 39 repos. Both steps are fixed.

## Design

`REVIEWER-SPEC.md:38-40` invariant 3 is preserved and strengthened — bytes still never come from the PR head; the trusted source becomes docs-control `main` rather than a sync target that can silently lag.

Three properties kept deliberately:

| Property | Why |
|---|---|
| Presence check against the downstream default branch **stays** | The `skip_files` opt-out is expressed by *file absence*. Without it, `terraform-provider-xcsh` — which opted out of locale-lint — would start being enforced. |
| Unreachable canonical **fails the check** | A governed gate that quietly stops enforcing is worse than a red one. |
| Each step resolves `FETCH_HEAD` to a SHA and **logs it** | A run names the exact governance commit whose bytes ran, so behaviour is reproducible and attributable. |

**Retirement is decided by canonical's manifest, not by the downstream file.** The sync only ever adds and updates blobs — `commit_tree` never emits the `"sha": null` form that deletes a path (`sync-managed-files.yml:275-278`) — so a retired script lingers downstream forever and cannot serve as the signal. Dropped from `managed_files` ⇒ retired, gate stands down. Missing from canonical while still listed ⇒ accidental deletion, fails closed.

**This unblocks i18n-core without the blocked PR needing to land first**, because downstream callers use `uses: …/super-linter.yml@main`.

## Testing

New `tests/test-governed-script-source.sh` — **9 assertions, 0 failures**. It extracts the step from the workflow so it exercises shipped bytes, and drives it against local git repositories via a `GOVERNANCE_REMOTE` seam: no network, no GitHub.

| Case | Expected |
|---|---|
| Stale downstream copy (the deadlock) | passes — canonical bytes run |
| Absent on the default branch | exit 0, opt-out preserved |
| Head's copy exits 0, canonical flags | fails — head bytes never run |
| Canonical unreachable | exit 1 |
| Retired (dropped from `managed_files`) | exit 0 |
| Missing but still listed | exit 1 |

Verified red-before/green-after by stashing the workflow: **4 of 8 failing** with the old behaviour (`FAIL: hardcoded locale data` — the real i18n-core failure) versus **9 of 9 passing** with the fix.

`test-linter-configs.sh` Section 5f pinned the old mechanism and would have failed. 5f.2 and 5f.6 now assert the property rather than the literal `git show "origin/${branch}:${script}"` string; **5f.9-5f.12** add the opt-out gate and fail-closed guarantees. 5f.3, 5f.4, 5f.7, 5f.8 untouched. Suite: 114/0.

Full local suite green (`test-locale-lint` 10/0 unchanged, `test-protect-managed-files` 124/0, `test-retry-stdout` 22/0, plus inlined-helpers, preflight-fleet, dispatch-matrix, fetch-governed). `pre-commit`, `shellcheck` and **`shfmt`** all clean — `shfmt -l $(git ls-files '*.sh')` is empty.

### Second-opinion review

`codex:verified-code-review`, four rounds. **Two confirmed and fixed, one confirmed and reported, one refuted.**

**Fixed:**
1. *Missing canonical script fails open* (high) — an accidental deletion would have silently disabled the gate fleet-wide. Now fails closed, distinguished from real retirement via the manifest.
2. *The claimed retirement path cannot delete downstream scripts* (high) — **this one corrected my own error message.** I had told operators to remove the `managed_files` entry "so the sync deletes it downstream". It does not: `commit_tree` only ever adds blobs. Combined with fail-closed, that would have permanently red-flagged every still-carrying repo on a genuine retirement. Retirement now keys off the manifest instead.

**Reported, not fixed — for reviewer judgement:**
3. *Canonical policy is not pinned atomically* (medium) — the two steps each fetch `main` independently, so a docs-control merge landing between them could mix commits. The window is the seconds between two adjacent steps of one job, both candidates are on a protected check-gated branch, and each step now logs its SHA so divergence is visible. The available fix is cross-step state via `$GITHUB_ENV`, which couples the locale step to whether the hygiene step ran (it is skipped in repos that opted out) and adds a conditional fallback — more moving parts than the race it removes. If the fleet wants atomic pinning, the clean version is a dedicated resolve step with a job output, as a separate change.

**Refuted:**
4. *Mutable canonical `main` executed with write-scoped credentials* (high, raised twice) — downstream repos consume this job as `uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main` (`workflows/super-linter.yml:23`), so the **entire job body**, including the `permissions` block granting `statuses:write` / `pull-requests:write` and every step in it, already comes from mutable docs-control `main` and already runs in all 39 repos. Sourcing one script from that same ref cannot bypass a boundary the workflow itself does not have.

One correction to my own wording in #815: I described docs-control `main` as "review-required". `gh api …/branches/main/protection` reports `enforce_admins=true` and 2 required checks but `required_approving_review_count=0` — protected and check-gated, not approval-gated.

## Verification after merge

The fix applies to i18n-core immediately (`@main`). I will re-run `lint / Lint Code Base` on its `governance/sync-managed-files` branch and confirm it passes where it currently fails, let the sync PR merge, confirm `repo_classes` reaches 39/39, and confirm `terraform-provider-xcsh` still reports "nothing to enforce".

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)