### PR TITLE
fix: deny clean_gone, which the docs forbid but nothing stopped

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,11 @@
     "baseRef": "fresh"
   },
   "permissions": {
-    "deny": ["Skill(code-review:code-review)", "Skill(pr-review-toolkit:review-pr)"]
+    "deny": [
+      "Skill(code-review:code-review)",
+      "Skill(pr-review-toolkit:review-pr)",
+      "Skill(commit-commands:clean_gone)"
+    ]
   },
   "hooks": {
     "PreToolUse": [

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -117,6 +117,35 @@ for reviewer in "code-review:code-review" "code-review-f5:code-review" \
 done
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 4: unsafe destructive tools denied (issue #825)
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 4: destructive tools the docs forbid are denied, not merely discouraged ==="
+
+# clean_gone runs `git worktree remove --force` and `git branch -D` over every
+# [gone] branch with no merge check. [gone] is also true for a PR closed WITHOUT
+# merging, where the local branch holds the only copy of unmerged commits — so
+# the force-delete can destroy work. CONTRIBUTING.md tells contributors not to
+# use it; this rule makes that enforceable rather than advisory.
+# Verified empirically: without the rule the tool returns "Launching skill:
+# commit-commands:clean_gone"; with it, "Skill execution blocked by permission rules".
+if jq -e '.permissions.deny // [] | index("Skill(commit-commands:clean_gone)")' \
+  "$SETTINGS" >/dev/null 2>&1; then
+  pass "4.1 permissions.deny contains Skill(commit-commands:clean_gone)"
+else
+  fail "4.1 permissions.deny contains Skill(commit-commands:clean_gone)" \
+    "the docs forbid this tool but nothing stops it being invoked"
+fi
+
+# The docs must keep explaining WHY, so the rule is not mistaken for arbitrary.
+if grep -q 'clean_gone' "$REPO_ROOT/CONTRIBUTING.md"; then
+  pass "4.2 CONTRIBUTING.md still documents why clean_gone is unsafe"
+else
+  fail "4.2 CONTRIBUTING.md still documents why clean_gone is unsafe" \
+    "a deny rule with no stated rationale invites someone to remove it"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 echo ""
 echo "════════════════════════════════════════════════════════════════"
 echo "Tests run: $TESTS_RUN | Passed: $PASS | Failed: $FAIL"


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md:312-314` tells contributors not to treat `/clean_gone` as safe. The documentation is
accurate — from the installed command:

```bash
git worktree remove --force "$worktree"
git branch -D "$branch"
```

No merge check, no confirmation: every `[gone]` branch is force-deleted. `[gone]` means only "the
remote branch is gone", which is **also** true for a PR closed *without* merging or a manually deleted
remote. In those cases the local branch holds the only copy of unmerged commits and `git branch -D`
discards it — the exact hazard the docs warn about.

Yet the command carries no `disable-model-invocation`, so it stayed selectable while the docs said not
to use it. Advisory prose against a destructive one-shot tool is the wrong instrument.

## Related Issue

Closes #825

## Changes

- `.claude/settings.json` — add `Skill(commit-commands:clean_gone)` to `permissions.deny`.
- `tests/test-review-layer-routing.sh` — new Section 4.

## Verification evidence

**The rule works** (A/B, run before committing it):

```
no deny rule -> RESULT: Launching skill: commit-commands:clean_gone
with rule    -> RESULT: Skill execution blocked by permission rules
```

**Nothing in CI invokes it** — `grep -rl clean_gone .github/ workflows/ scripts/` → 0 files. Unlike
`code-review-f5:code-review` (see #802) there is no gate to protect, so a plain deny is safe here.

**Test is red before, green after:**

```
rule removed -> FAIL: 4.1 permissions.deny contains Skill(commit-commands:clean_gone)
                (15 run, 14 passed, 1 failed)
restored     -> Tests run: 15 | Passed: 15 | Failed: 0
```

`pre-commit run --all-files`: 0 failures. `textlint`: exit 0.

## Two deliberate choices

**Section 4, not an extension of Section 1.** Section 1 is specifically about model-invocable *PR-diff
reviewers*. `clean_gone` is denied for an unrelated reason — destructive, no merge check — and folding
it in would blur why each rule exists.

**Assertion 4.2 requires `CONTRIBUTING.md` to keep explaining why.** A deny rule with no stated
rationale is one someone deletes later as arbitrary; the test fails if the explanation disappears.

## Accepted consequence

A deny rule blocks a *typed* `/clean_gone` too, not only model selection — verified in #802 that deny
applies to prompt-level slash commands as well. That is intended: the safe alternative is the
confirm-then-delete flow at `CONTRIBUTING.md:325-357`, which verifies each branch actually merged
first. If you want the convenience back, the right fix is a merge-checking replacement, not removing
this rule.

## Checklist

- [x] Linked to a GitHub issue
- [x] Feature-complete and verified
- [x] Test written and confirmed red before the fix, green after
- [x] Verified locally by exercising the change — A/B evidence above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions

Note: docs-control does not run `review / claude-review` on its own PRs, so this PR's green CI is not
reviewer evidence.
