### PR TITLE
fix(governance): drop claude-review from required contexts

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -49,121 +49,20 @@
   ],
   "repo_overrides": {
     "xcsh": {
-      "additional_contexts": ["check", "test", "review / claude-review"],
+      "additional_contexts": ["check", "test"],
       "excluded_required_contexts": ["lint / Lint Code Base"]
     },
     "vscode-xcsh": {
-      "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX", "review / claude-review"]
+      "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]
     },
     "console": {
-      "additional_contexts": ["Validate Catalog Schemas", "review / claude-review"]
+      "additional_contexts": ["Validate Catalog Schemas"]
     },
     "terraform-provider-xcsh": {
-      "excluded_required_contexts": ["audit / Translation freshness"],
-      "additional_contexts": ["review / claude-review"]
-    },
-    "code-review": {
-      "additional_contexts": ["review / claude-review"],
       "excluded_required_contexts": ["audit / Translation freshness"]
     },
-    "dns": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "demo-resource-template": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "docs-builder": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "docs-theme": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "docs": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "administration": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "nginx": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "observability": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "was": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "mcn": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "cdn": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "bot-standard": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "bot-advanced": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "ddos": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "waf": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "api-protection": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "webapp-api-protection": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "api-specs": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "api-specs-enriched": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "csd": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "docs-icons": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "devcontainer": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "marketplace": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "cdn-simulator": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "origin-server": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "traffic-generator": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "demo-resources": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "starlight-llms-txt": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "starlight-mega-menu": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "apt-repo": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "i18n-core": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "xcsh-chrome-extension": {
-      "additional_contexts": ["review / claude-review"]
-    },
-    "marketplace-claude-code": {
-      "additional_contexts": ["review / claude-review"]
+    "code-review": {
+      "excluded_required_contexts": ["audit / Translation freshness"]
     }
   },
   "topics": [],


### PR DESCRIPTION
## Problem

The self-hosted `review / claude-review` gate cannot reliably reach model inference or the
VPN. When it cannot run, the check never turns green — and it is a **required** context in
**38 repos**, so the PR simply cannot merge. Reviews also serialise on a single laptop
hosting one runner per repo, so recovery is slow. The result is a merge backlog caused by
reviewer infrastructure, not by code quality.

## Change

Removes `"review / claude-review"` from every `repo_overrides.<repo>.additional_contexts`.

| | |
|---|---|
| Entries the context was removed from | **38** |
| Override entries that held nothing else and are now gone | 33 |
| Override entries remaining | 5 |

Preserved deliberately:

- **Sibling contexts** — `xcsh` keeps `check`, `test`; `vscode-xcsh` keeps
  `Validate Generation`, `Test (ubuntu-latest)`, `Build VSIX`; `console` keeps
  `Validate Catalog Schemas`.
- **Every `excluded_required_contexts`** — untouched, so `test-linter-configs.sh` 7c still
  passes (all three exclusions reference base contexts).
- **The fleet baseline** — `check / Check linked issues`, `lint / Lint Code Base`,
  `audit / Translation freshness` all remain required. Only the reviewer depends on
  inference/VPN; the other two run on GitHub-hosted runners, so weakening them would trade
  away merge safety for nothing.

## Why this actually removes the requirement

Worth stating, because a config-only change that never reaches GitHub would be a silent
no-op: `enforce-repo-settings.yml` builds the **full** desired payload
(base + additional − excluded) and applies it with **PUT**, which replaces the entire
protection object. It is declarative, not additive-only, so dropping an entry here really
does drop it upstream.

Propagation is automatic — `dispatch-downstream.yml` fires on a push to
`repo-settings.json` and fans `enforce-repo-settings` out to every downstream repo in
batches.

## Ordering — why this PR is deliberately narrow

Gating the reviewer workflow off is **not** in this PR. Once the review job is skipped, the
`review / claude-review` context is never produced; if it were still required at that
moment, **every open PR in the fleet would deadlock permanently**. So the requirement is
removed and verified first, and the workflow is disabled only afterwards.

## Verification

| Check | Result |
|---|---|
| Valid JSON | pass |
| `biome check` on the changed file | exit **0** |
| Every script in `tests/` (incl. 117-case managed-files suite) | **all pass** |
| Semantic diff vs `HEAD` | non-override sections **byte-identical**; `repo_overrides` matches the expected removal exactly; the string appears **nowhere** in the file |

Formatting is preserved on purpose — an earlier attempt that round-tripped the JSON through
a serializer produced 266 insertions of pure reformatting churn. This diff only touches the
entries being changed.

**This PR going green does not prove the requirement is gone.** The acceptance criterion in
#833 is reading the live protection object for all 38 repos after propagation, since the
enforcer's PUT is drift-triggered and a green run is not evidence. I captured a pre-change
baseline (38/38 requiring it) to diff against.

Closes #833
