### PR TITLE
docs: never sync by overwriting the working tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 ## Workflow
 
 - **Start from current.** `git fetch --prune` and confirm you are not behind `origin/<default-branch>` before you plan, branch, or edit; create branches from `origin/<default-branch>`, never from local `main`. The git status injected at session start is a snapshot with no ahead/behind count — a stale checkout still reports a clean tree.
-- **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work that the reflog does not cover — unlike a bad branch delete, there is nothing to recover from. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — see CONTRIBUTING.md.
+- **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 ## Workflow
 
 - **Start from current.** `git fetch --prune` and confirm you are not behind `origin/<default-branch>` before you plan, branch, or edit; create branches from `origin/<default-branch>`, never from local `main`. The git status injected at session start is a snapshot with no ahead/behind count — a stale checkout still reports a clean tree.
+- **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work that the reflog does not cover — unlike a bad branch delete, there is nothing to recover from. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — see CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,9 +111,11 @@ Ignored files are the exception, and they are not protected anywhere in this flo
 stash them, and if upstream starts tracking a path you hold as ignored — `.env` is the obvious case —
 `git pull` overwrites it **silently and exits 0**. Git refuses to clobber an *untracked* file that
 way; it does not extend that courtesy to ignored ones. `git stash push --all` does capture them, but
-`pop` then fails with `.env already exists, no checkout` once the path is tracked (the stash is
-retained, so `git checkout stash@{0} -- <path>` still gets the content back). The reliable move is to
-copy out any ignored file you care about before you sync. This is the same blind spot as the worktree
+`pop` then fails with `.env already exists, no checkout` once the path is tracked. The stash is
+retained, but recovering from it is not the obvious command: `--all` stores untracked and ignored
+files in the stash commit's **third parent**, so `git checkout stash@{0} -- <path>` fails with
+`did not match any file(s) known to git`. Use `git show 'stash@{0}^3:<path>' > <path>` instead. The
+reliable move is to copy out any ignored file you care about before you sync. This is the same blind spot as the worktree
 warning under Worktrees: git's safety checks do not see ignored files.
 
 **Never sync by overwriting the working tree.** `git checkout <ref> -- .` looks like a refresh and is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,8 @@ If you are editing an existing checkout rather than creating a branch, confirm i
 If it *does* show `[behind N]` and you have work in progress, park the work rather than discarding it:
 
 ```bash
-git stash push -u        # -u also stashes untracked files
+git status --short --ignored   # ignored files are NOT protected — see below
+git stash push -u              # -u covers untracked files, but NOT ignored ones
 git pull --ff-only
 git stash pop
 ```
@@ -106,11 +107,27 @@ git stash pop
 exits non-zero and **keeps the stash entry**, so resolve the conflict and drop the stash afterwards —
 nothing is lost by trying.
 
+Ignored files are the exception, and they are not protected anywhere in this flow. `-u` does not
+stash them, and if upstream starts tracking a path you hold as ignored — `.env` is the obvious case —
+`git pull` overwrites it **silently and exits 0**. Git refuses to clobber an *untracked* file that
+way; it does not extend that courtesy to ignored ones. `git stash push --all` does capture them, but
+`pop` then fails with `.env already exists, no checkout` once the path is tracked (the stash is
+retained, so `git checkout stash@{0} -- <path>` still gets the content back). The reliable move is to
+copy out any ignored file you care about before you sync. This is the same blind spot as the worktree
+warning under Worktrees: git's safety checks do not see ignored files.
+
 **Never sync by overwriting the working tree.** `git checkout <ref> -- .` looks like a refresh and is
 not one: it overwrites tracked files with the other ref's content, stages the result, and leaves
-files that exist only in your branch behind — a mixed state that is neither commit. The work it
-overwrites is **unrecoverable**. Git writes no reflog entry for it and keeps no object, so unlike a
-mistaken `git branch -D` there is nothing to restore from. `git reset --hard` has the same effect on
+files that exist only in your branch behind — a mixed state that is neither commit. Git writes no
+reflog entry for what it overwrote, so unlike a mistaken `git branch -D` there is no ref to restore.
+
+How much is lost depends on whether the work was staged, and the difference is worth knowing before
+you give up on it. Content you had `git add`ed still exists as a blob and stays recoverable until
+garbage collection — `git fsck --lost-found` lists it, and `git cat-file -p <blob>` prints it. Content
+you never staged was never written to the object store at all, and that is genuinely gone. So if you
+do clobber something, check `git fsck --lost-found` before concluding the work is lost.
+
+`git reset --hard` has the same effect on
 uncommitted changes (commits it moves past *are* reflog-recoverable; uncommitted edits are not), and
 `git clean -fd` deletes untracked files and directories — add `-x` and it takes ignored files too,
 including the `.env` and local config described under Worktrees.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,8 +114,20 @@ way; it does not extend that courtesy to ignored ones. `git stash push --all` do
 `pop` then fails with `.env already exists, no checkout` once the path is tracked. The stash is
 retained, but recovering from it is not the obvious command: `--all` stores untracked and ignored
 files in the stash commit's **third parent**, so `git checkout stash@{0} -- <path>` fails with
-`did not match any file(s) known to git`. Use `git show 'stash@{0}^3:<path>' > <path>` instead. The
-reliable move is to copy out any ignored file you care about before you sync. This is the same blind spot as the worktree
+`did not match any file(s) known to git`. Read it out of the third parent instead, to a scratch file
+**outside** the repository:
+
+```bash
+git show 'stash@{0}^3:.env' > /tmp/recovered.env   # never redirect onto the path itself
+```
+
+Two reasons for the scratch file. Redirecting onto the original path would write your ignored local
+copy over the version upstream now tracks, turning a secret into a tracked modification somebody can
+commit by accident. And the shell truncates the target *before* `git show` runs, so a wrong ref or
+path empties the file even when the command fails — `git show` exits 128 and the destination is left
+at 0 bytes. Recover to the side, then merge by hand.
+
+The reliable move is to copy out any ignored file you care about before you sync. This is the same blind spot as the worktree
 warning under Worktrees: git's safety checks do not see ignored files.
 
 **Never sync by overwriting the working tree.** `git checkout <ref> -- .` looks like a refresh and is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,27 @@ Branching from the fetched ref also works when `main` is checked out in another 
 If you are editing an existing checkout rather than creating a branch, confirm it is current first —
 `git status -sb` should show `## main...origin/main` with no `[behind N]`.
 
+If it *does* show `[behind N]` and you have work in progress, park the work rather than discarding it:
+
+```bash
+git stash push -u        # -u also stashes untracked files
+git pull --ff-only
+git stash pop
+```
+
+`git stash pop` can hit a conflict when the pull touched the same file you edited. That is safe: pop
+exits non-zero and **keeps the stash entry**, so resolve the conflict and drop the stash afterwards —
+nothing is lost by trying.
+
+**Never sync by overwriting the working tree.** `git checkout <ref> -- .` looks like a refresh and is
+not one: it overwrites tracked files with the other ref's content, stages the result, and leaves
+files that exist only in your branch behind — a mixed state that is neither commit. The work it
+overwrites is **unrecoverable**. Git writes no reflog entry for it and keeps no object, so unlike a
+mistaken `git branch -D` there is nothing to restore from. `git reset --hard` has the same effect on
+uncommitted changes (commits it moves past *are* reflog-recoverable; uncommitted edits are not), and
+`git clean -fd` deletes untracked files and directories — add `-x` and it takes ignored files too,
+including the `.env` and local config described under Worktrees.
+
 A long-running session goes stale the same way, since nothing re-checks after start. Fetch again
 before branching a second time, and before creating a git worktree — a worktree inherits whatever
 the cached remote ref says, so it can be born behind (see CLAUDE.md).


### PR DESCRIPTION
## Summary

From a transcript:

> *"I just clobbered my worktree with `git checkout origin/main -- .` — restoring it (the work is
> committed and pushed, so nothing is lost)"*

That was an attempt to **get current** — the pressure the "Start from current" rule (#812) creates —
and the reassurance held only because the work happened to be committed.

Three gaps, the first self-inflicted:

1. **No safe remediation for "behind, with work in progress."** `CONTRIBUTING.md` said *"confirm it is
   current first — `git status -sb` should show no `[behind N]`"* and stopped. It never said what to do
   when it *does* show `[behind 3]`. #812 created the obligation without documenting how to meet it, so
   an agent improvises — and improvisation here destroys work.
2. **No destructive-command guidance existed at all.** We guarded branch deletion and worktree removal
   — the least damaging operations — while the one that destroys unrecoverable work went unmentioned.
3. **Placement.** All sync guidance lived in `CONTRIBUTING.md`, read on demand; this is an agent
   action and agents always read `CLAUDE.md`. Same finding as round 3 of #822.

## Related Issue

Closes #832

## Changes

- **`CLAUDE.md`** — one `## Workflow` bullet (4 → 5): never sync by overwriting the working tree, plus
  the safe alternative, in the file agents actually read.
- **`CONTRIBUTING.md`** — the remediation inserted at the `[behind N]` line, where the unanswered
  question sat.

## Verification evidence

Every command was executed. The three destructive commands do **different** things and are documented
separately rather than lumped together:

```
git checkout <ref> -- .   tracked mods      -> DESTROYED
                          untracked/ignored -> survive
                          files not in ref  -> left in place (mixed state)
                          result            -> STAGED
                          reflog 4 -> 4, 0 objects, 0 dangling blobs
git reset --hard          commits moved past -> reflog-recoverable
                          uncommitted edits  -> not
git clean -fd             untracked files/dirs removed; tracked mods untouched;
                          ignored kept unless -x
```

Recoverability, which turned out to depend on staging:

```
never staged -> no object ever written        -> genuinely gone
git add'ed   -> blob survives: git cat-file -p <blob> returns it,
                git fsck --lost-found lists 1 dangling  -> RECOVERABLE until gc
```

Ignored files are unprotected throughout:

```
git stash push -u   -> .env NOT stashed (still present)
git pull --ff-only  -> exit 0, .env silently overwritten
                       MY-LOCAL-SECRET -> UPSTREAM-NOW-TRACKS-THIS
```

Git refuses to clobber an *untracked* file on merge; it does not extend that to ignored ones. Relevant
because `.worktreeinclude` exists to put `.env` and secrets into worktrees.

Remediation round-trip:

```
git stash push -u -> git pull --ff-only -> git stash pop
  different file : restores tracked mods AND untracked files
  same file      : pop exits 1 on conflict but RETAINS the stash — trying cannot lose work
```

**Lint** — `pre-commit` 0 failures; `textlint` exit 0, canary-checked; **19/19** suites.
**Invariants (#678)** — Engineering Standards exactly 11; `## Workflow` 5; `## Worktrees` 5; longest
`CLAUDE.md` line 386 chars.

## Three review rounds, four confirmed defects — all in the recovery guidance

| Round | Sev | Defect |
| --- | --- | --- |
| 1 | med | `stash -u` excludes ignored files, and `pull` silently overwrites an ignored path upstream begins tracking |
| 1 | med | "keeps no object" was **false for staged content** — would have told someone to abandon recoverable data |
| 2 | **high** | `git checkout stash@{0} -- <path>` **fails** — `--all` stores those files in the stash's *third parent* |
| 3 | **high** | The round-2 fix wrote a secret over a now-tracked path, and shell redirection truncates the target *before* `git show` runs (exit 128, file left at 0 bytes) |

**The prohibition survived every round untouched. All four defects were in the detailed recovery
guidance** — the part meant to help is where the danger accumulated. Rounds 2 and 3 were each fixing
the previous round's fix.

Two of these were wrong in the direction that causes loss rather than merely being imprecise: telling
someone there is "nothing to restore from" when `git fsck --lost-found` would hand it back, and a
recovery command that truncates the file it is recovering.

## Checklist

- [x] Linked to a GitHub issue
- [x] Feature-complete and verified
- [x] Every documented command executed, output pasted
- [x] Verified locally
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions

## Explicit non-goal

Not claimed to change agent behaviour. CLAUDE.md prose measured null twice in controlled A/B tests
(#799, #811). This documents a safe path where none existed and corrects an unrecoverability claim that
was wrong in the harmful direction. No behavioural A/B was run — a rare, catastrophic action is not
something a single trial can demonstrate the absence of.

Note: docs-control does not run `review / claude-review` on its own PRs, so this PR's green CI is not
reviewer evidence.
