### PR TITLE
fix: stop the sync closing its own open PR

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -386,6 +386,10 @@ jobs:
         if: hashFiles('tests/test-readme-generation.sh') != ''
         run: bash tests/test-readme-generation.sh
 
+      - name: Run sync-managed-files test
+        if: hashFiles('tests/test-sync-managed-files.sh') != ''
+        run: bash tests/test-sync-managed-files.sh
+
       - name: Run review-layer-routing test
         if: hashFiles('tests/test-review-layer-routing.sh') != ''
         run: bash tests/test-review-layer-routing.sh

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -226,6 +226,12 @@ jobs:
           commit_tree() {
             local branch="$1"
             local commit_msg="$2"
+            # Optional base commit. When given, the new commit is parented on it and the
+            # branch ref is force-moved -- which rebases the branch and adds the drift in a
+            # SINGLE ref update. Doing those as two calls empties the PR in between: the
+            # branch briefly equals main, so it has zero commits ahead of base and GitHub
+            # closes it and disables auto-merge (#836).
+            local base_override="${3:-}"
             local repo_slug="${OWNER}/${REPO}"
 
             # Never interpolate a non-SHA into a URL: that is what turned a transient
@@ -238,8 +244,13 @@ jobs:
               fi
             }
 
-            local ref_sha
-            ref_sha=$(retry 3 gh api "repos/${repo_slug}/git/ref/heads/${branch}" --jq '.object.sha')
+            local ref_sha force_update="false"
+            if [ -n "$base_override" ]; then
+              ref_sha="$base_override"
+              force_update="true"
+            else
+              ref_sha=$(retry 3 gh api "repos/${repo_slug}/git/ref/heads/${branch}" --jq '.object.sha')
+            fi
             require_sha "ref_sha for ${branch}" "$ref_sha" || return 1
 
             local base_tree
@@ -299,7 +310,8 @@ jobs:
             new_commit_sha=$(echo "$commit_json" | retry 3 gh api "repos/${repo_slug}/git/commits" --method POST --input - --jq '.sha')
 
             local ref_update
-            ref_update=$(jq -n --arg sha "$new_commit_sha" '{"sha": $sha}')
+            ref_update=$(jq -n --arg sha "$new_commit_sha" --argjson force "$force_update" \
+              '{"sha": $sha, "force": $force}')
             retry_json 3 "$ref_update" "repos/${repo_slug}/git/refs/heads/${branch}" --method PATCH >/dev/null
 
             echo "[OK] Atomic commit ${new_commit_sha:0:8} (${item_count} files)"
@@ -637,15 +649,18 @@ jobs:
                 if [ -n "$EXISTING_PR" ]; then
                   echo "[INFO] Open sync PR #${EXISTING_PR} already exists -- updating drifted files"
 
-                  # Force-update the PR branch to main's HEAD so it stays rebased
+                  # Rebase onto main AND add the drift in one ref update, by handing
+                  # commit_tree main's SHA as the base. Two calls -- reset the branch to
+                  # main, then commit -- leave the branch equal to main in between, so the
+                  # PR has zero commits ahead of base and GitHub closes it and disables
+                  # auto-merge. The content returns on the next call but the PR does not
+                  # reopen, stranding the change on an unmerged branch (#836).
                   MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
-                  BRANCH_UPDATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}')
-                  retry_json 3 "$BRANCH_UPDATE_JSON" \
-                    "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" --method PATCH >/dev/null
-                  echo "[OK] Rebased PR branch onto main HEAD"
 
                   commit_tree "governance/sync-managed-files" \
-                    "chore: sync managed files from governance template"
+                    "chore: sync managed files from governance template" \
+                    "$MAIN_SHA"
+                  echo "[OK] Rebased onto main and committed drift in one update"
 
                   echo "[INFO] PR branch updated -- attempting merge"
                   auto_merge "${EXISTING_PR}" "${OWNER}/${REPO}" || true

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Assertions on how sync-managed-files updates an existing sync PR.
+#
+# When drift is found and a sync PR is already open, the branch has to be
+# rebased onto main so the PR diff shows only managed files rather than
+# reverting whatever landed in between. Doing that as a standalone force-reset
+# to main's SHA empties the PR: for the interval between the reset and the
+# follow-up commit the branch IS main, so the PR has zero commits ahead of
+# base, and GitHub closes it and disables auto-merge. The content comes back on
+# the next call, but a closed PR does not reopen (#836).
+#
+# The rebase and the commit therefore have to be a single ref update.
+#
+# Run from repo root: bash tests/test-sync-managed-files.sh
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TESTS_RUN=0
+
+pass() {
+  PASS=$((PASS + 1))
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "  PASS: $1"
+}
+fail() {
+  FAIL=$((FAIL + 1))
+  TESTS_RUN=$((TESTS_RUN + 1))
+  echo "  FAIL: $1 — $2"
+}
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SYNC="$REPO_ROOT/.github/workflows/sync-managed-files.yml"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# The branch of the drift handler that runs when a sync PR is already open.
+awk '/if \[ -n "\$EXISTING_PR" \]; then/{f=1} f{print} f&&/^                else$/{exit}' \
+  "$SYNC" >"$WORK/existing_pr_block.txt"
+
+echo ""
+echo "=== Section 1: the existing-PR path is present ==="
+
+if [ -s "$WORK/existing_pr_block.txt" ]; then
+  pass "1.1 located the existing-PR branch of the drift handler"
+else
+  fail "1.1 located the existing-PR branch of the drift handler" \
+    "extraction produced nothing; the assertions below would be vacuous"
+fi
+
+if grep -q 'commit_tree' "$WORK/existing_pr_block.txt"; then
+  pass "1.2 the existing-PR path commits the drifted files"
+else
+  fail "1.2 the existing-PR path commits the drifted files" "no commit_tree call found"
+fi
+
+echo ""
+echo "=== Section 2: the branch is never reset to main on its own ==="
+
+# The defect: a PATCH of the sync branch ref carrying main's SHA, separate from
+# the commit. Detected structurally rather than by message, so rewording the
+# echo cannot hide it.
+if grep -q 'refs/heads/governance/sync-managed-files.*--method PATCH' \
+  "$WORK/existing_pr_block.txt"; then
+  fail "2.1 no standalone reset of the sync branch to main's SHA" \
+    "the existing-PR path force-updates the branch ref directly; that empties the PR and GitHub closes it (#836)"
+else
+  pass "2.1 no standalone reset of the sync branch to main's SHA"
+fi
+
+if grep -qE 'Rebased PR branch onto main HEAD' "$WORK/existing_pr_block.txt"; then
+  fail "2.2 the emptying rebase step is gone" \
+    "the standalone rebase echo is still present"
+else
+  pass "2.2 the emptying rebase step is gone"
+fi
+
+echo ""
+echo "=== Section 3: rebasing still happens, atomically ==="
+
+# Dropping the rebase is not an acceptable fix: a branch based on an old main
+# produces a diff that reverts unrelated commits. It has to move to main's SHA
+# as part of the same ref update that adds the drift commit.
+# The call is written across backslash-continued lines, so join continuations
+# before matching -- grep is line-based and would miss it.
+perl -0pe 's/\\\n\s*/ /g' "$WORK/existing_pr_block.txt" >"$WORK/existing_pr_joined.txt"
+
+if grep -qE 'commit_tree[^|;]*"\$MAIN_SHA"' "$WORK/existing_pr_joined.txt"; then
+  pass "3.1 the existing-PR path rebases via commit_tree's base argument"
+else
+  fail "3.1 the existing-PR path rebases via commit_tree's base argument" \
+    "commit_tree is not given a base commit, so the branch would stay on its old base"
+fi
+
+if grep -qE 'local base_override|base_override="\$3"' "$SYNC"; then
+  pass "3.2 commit_tree accepts a base-commit override"
+else
+  fail "3.2 commit_tree accepts a base-commit override" \
+    "commit_tree still derives its parent solely from the branch head"
+fi
+
+# A force update is required once the parent is main rather than the branch tip.
+if grep -qE '"force": *(true|\$force)' "$SYNC"; then
+  pass "3.3 commit_tree can force the ref update when rebasing"
+else
+  fail "3.3 commit_tree can force the ref update when rebasing" \
+    "a non-force PATCH cannot move the branch onto a new base"
+fi
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed ($TESTS_RUN total)"
+echo "════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #836

## Problem

When `sync-managed-files` finds drift and a sync PR is **already open**, it kills that PR. Deterministically — not a race.

The existing-PR path rebased the branch as a standalone step:

```bash
PATCH refs/heads/governance/sync-managed-files {"sha": MAIN_SHA, "force": true}
commit_tree "governance/sync-managed-files" "..."
```

Between those two calls the branch **is** main, so the PR has zero commits ahead of base. GitHub closes it and disables auto-merge. `commit_tree` then restores the content, but a closed PR does not reopen when its branch gets new commits — and the following `auto_merge "${EXISTING_PR}"` operates on a closed PR, failing into its `|| true`.

## Observed

f5-sales-demo/api-specs#735. The two runs did **not** overlap — run 1 ended 00:09:57, run 2 started 00:10:01 — so workflow concurrency was working correctly. This is the rebase step:

| Time | Event |
| ---- | ----- |
| 00:09:54 | run 1 creates PR #735, `auto_squash_enabled` |
| 00:12:54 | run 2 rebases: `head_ref_force_pushed`, `auto_merge_disabled`, `closed` |

Both drifted files were still on the branch afterwards. The PR was closed with "no commit found on the pull request" and had to be reopened and merged by hand.

## Impact

A sync PR that does not merge within one 6-hour interval — for any reason, including a transient red check — is killed by the next run and never recovers. Silently: the run logs `[OK] Rebased PR branch onto main HEAD` and exits 0, leaving a closed PR, an open tracking issue pointing at it, and the change stranded on an unmerged branch.

## Fix

Make the rebase and the commit **one** ref update.

`commit_tree` now takes an optional base commit. When given, it parents the new commit on that base and forces the ref update, so the branch moves from its old base straight to a commit that already contains the drift — never passing through main.

**Deleting the rebase would have been the wrong fix.** A branch based on an old main produces a diff that reverts whatever landed in between. The rebase is kept; it is just no longer done as a separate, PR-emptying step.

The no-base path is untouched and still uses a non-force update, so `commit_tree` cannot rewrite history unless a caller explicitly asks it to.

## TDD

`tests/test-sync-managed-files.sh` extracts the existing-PR branch of the drift handler and asserts it contains no standalone ref PATCH, and that it hands `commit_tree` a base. Red before the fix: **3 passed, 4 failed**.

Verified by mutation rather than asserted — reinstating the two-step reset:

```
FAIL: 2.1 no standalone reset of the sync branch to main's SHA
FAIL: 2.2 the emptying rebase step is gone
FAIL: 3.1 the existing-PR path rebases via commit_tree's base argument
Results: 4 passed, 3 failed
```

Reverting returns it to **7 passed, 0 failed**. Section 1 is a vacuity guard: if the block extraction ever stops matching, the later assertions would pass on empty input, so they are checked for non-emptiness first.

One test bug was caught and fixed along the way — the `commit_tree` call spans backslash-continued lines, and the initial line-based `grep` could not see it. The test now joins continuations before matching.

## Verification

- All **20** test files in `tests/` pass.
- `shfmt -d` and `shellcheck -S warning` clean on the new test.
- `sync-managed-files.yml` parses as YAML.
- `pre-commit` on the changed files: every hook passes, including zizmor.
- Wired into `super-linter.yml` beside the existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)