### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-28T01:16:26Z",
-  "source_commit": "41398622605470b1b2703f6063d3aebeff64d8ef",
+  "generated_at": "2026-07-28T01:40:04Z",
+  "source_commit": "d93e9a34ee9baf4d6bcb58309f32cf54db8a3636",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,14 +65,14 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "12e6a426824d538b20bdd1b93eef9c11f9ca8e73",
-      "size": 27042
+      "sha": "d469ed5aecd69a4aaf905fcc8365b53da08c8ec7",
+      "size": 28011
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "2da860caeaad64e418b15901661fca3a7aa2adf4",
-      "size": 8731
+      "sha": "b07448e2690cf3982790ac54ee0bd2d154679d96",
+      "size": 9920
     },
     ".editorconfig": {
       "src": ".editorconfig",
@@ -263,8 +263,8 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "319d8e5778ca47ee645f31ee4003d0b3a50df055",
-      "size": 5164
+      "sha": "8b712ff4169ef4460ab6e0783f4f83f442b67d3c",
+      "size": 6523
     },
     ".github/workflows/workflow-security-audit.yml": {
       "src": "workflows/workflow-security-audit.yml",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.