### PR TITLE
fix: scope the worktree instruction to the main session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ When it is restored it becomes a required, merge-gating check again: on a block,
 
 ## Worktrees
 
-- For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.
+- For non-trivial coding tasks, **the main session** works in a git worktree (Claude Code: `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions. A subagent never creates one: spawned with `isolation: "worktree"` it already has one, and `EnterWorktree` refuses from a pinned cwd. Grant isolation at spawn, never from inside.
 - **Know where you are.** Before starting, run `git worktree list` and confirm the current directory belongs to the task at hand. Never begin new work in a worktree left over from a finished one — retire it and start fresh. A finished worktree looks unmerged (squash-merge) and its base is stale. Retiring has a required order and an ignored-file check first — see CONTRIBUTING.md.
 - New worktrees branch from `origin/<default-branch>` (`worktree.baseRef` is set to `fresh` in `.claude/settings.json`). The `.claude/worktrees/` directory is already gitignored.
 - `fresh` means "from the cached remote ref", not "freshly fetched" — it only re-fetches when `FETCH_HEAD` is over 24 hours old. A worktree created after an earlier same-day fetch is born behind whatever merged since, so fetch before you create one.


### PR DESCRIPTION
Closes #842

## What

`CLAUDE.md`'s Worktrees section opened with an unconditional directive to work in a git worktree
via `EnterWorktree`. A subagent loads its own copy of project `CLAUDE.md`, complied, and hit a hard
error. This scopes the directive to the main session and names the supported subagent path.

## Reproduced first (failing test)

Spawned a subagent with `isolation: "worktree"`, gave it a non-trivial coding task, and told it to
follow this repo's CLAUDE.md conventions for environment setup. It reported:

```
4. EnterWorktree — {"name": "worktree-test-guidance"}
Yes, I attempted it. It failed. Exact error text:

EnterWorktree cannot create a worktree from a subagent with a cwd override
(isolation: "worktree" or explicit cwd) — it would mutate the parent session's
process-wide working directory. ...
```

The important part is its own state at the time:

```
/…/.claude/worktrees/agent-ab686895211ac989e  8b28cff [worktree-agent-ab686895211ac989e] locked
git rev-list --left-right --count origin/main...HEAD  ->  0  0
```

It was **already in a clean, locked, current worktree** and asked for another one anyway. The
instruction was not only illegal in that context, it was redundant — and the subagent only worked
that out after being refused.

## The change

```diff
-- For non-trivial coding tasks, work in a git worktree (Claude Code: `EnterWorktree` or
-  `claude --worktree`) to isolate changes from the main checkout and enable parallel sessions.
+- For non-trivial coding tasks, **the main session** works in a git worktree (Claude Code:
+  `EnterWorktree` or `claude --worktree`) to isolate changes from the main checkout and enable
+  parallel sessions. A subagent never creates one: spawned with `isolation: "worktree"` it already
+  has one, and `EnterWorktree` refuses from a pinned cwd. Grant isolation at spawn, never from
+  inside.
```

Consistent with [upstream guidance](https://code.claude.com/docs/en/sub-agents): *"To give the
subagent an isolated copy of the repository instead, set `isolation: worktree`."* That mode also
branches from the default branch rather than the parent's `HEAD`, which already satisfies our
"branch from `origin/<default-branch>`" rule.

Amended the existing bullet rather than adding one, so `## Worktrees` stays at 5 bullets and
Engineering Standards at 11 (#678).

## Verification

| Check | Result |
| ----- | ------ |
| Reproduction before fix | error captured verbatim (above) |
| `pre-commit run --all-files` | all pass |
| textlint (`terminology`) on `CLAUDE.md` | exit 0 — canary with `github`/`javascript`/`nodejs` produced 3 errors, proving the rule was live |
| `tests/test-*.sh` | 20/20 suites pass |
| markdownlint MD013 | 0 issues; bullet is 381 chars |
| Invariants | Worktrees 5 bullets, Engineering Standards 11 |
| `codex:verified-code-review` | `adversarial-review` verdict **approve**, 0 findings; gate `done: true`, `findingsClear: true`, no escalation |

**Behavioural confirmation is deferred to post-merge and will be reported on this PR.** A subagent
with `isolation: "worktree"` branches from the *default branch*, so it cannot see this wording until
it lands on `main`. Testing it before merge would measure the old text.

## Related, not fixed here

- The operator's private `~/.claude/CLAUDE.md` carries the same unconditional wording and loads in
  every project. Not managed by docs-control; flagged to the operator.
- The reproduction branch was named `worktree-agent-ab686895211ac989e` — the `worktree-<name>`
  default-naming gap from #821 is still live.
