### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-28T01:40:04Z",
-  "source_commit": "d93e9a34ee9baf4d6bcb58309f32cf54db8a3636",
+  "generated_at": "2026-07-28T02:45:11Z",
+  "source_commit": "af7477eeac435dbe963f78ccec5d15e4066f8198",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -71,8 +71,8 @@
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "b07448e2690cf3982790ac54ee0bd2d154679d96",
-      "size": 9920
+      "sha": "147dd5a9e66cad7b357aff1351d2e71affe7fcd5",
+      "size": 10121
     },
     ".editorconfig": {
       "src": ".editorconfig",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.