### PR TITLE
Require marketplace's plugin test suites (it has let two red merges through)

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -48,6 +48,9 @@
     }
   ],
   "repo_overrides": {
+    "marketplace": {
+      "additional_contexts": ["Run plugin test suites"]
+    },
     "xcsh": {
       "additional_contexts": ["check", "test"],
       "excluded_required_contexts": ["lint / Lint Code Base"]


### PR DESCRIPTION
## What

One entry in `repo_overrides`, making `Run plugin test suites` a required check on
`marketplace` only:

```json
"marketplace": {
  "additional_contexts": ["Run plugin test suites"]
}
```

Same mechanism `xcsh`, `console` and `vscode-xcsh` already use.

## Why

The job runs on every marketplace PR and cannot block one. **#874 and #877 both auto-merged
with it failing**, each time for a genuine defect — tests spawning real cloud CLIs, then a
`PATH` bug that deleted `/usr/bin` on the runner. Advisory, it gets ignored by auto-merge at
exactly the moments it matters.

## Ordering — why this will not deadlock

The known trap here is requiring a context the workflow does not reliably produce. Checked,
not assumed:

- Workflow is on `marketplace`'s default branch, triggered by `pull_request` **and** `push`
  to `main`.
- **Green on `main` now** — `e1ea703`, `Validate Plugins` conclusion `success`.
- Context string taken verbatim from the check-runs API on that commit
  (`Run plugin test suites`), not inferred.
- Scoped via `repo_overrides`, so no other repo inherits it.

## Verification

- `jq` parses the file; the override reads back as expected.
- `tests/test-linter-configs.sh` — 118 passed, 0 failed.
- Diff is 3 lines. (My first attempt rewrote the file via `json.dump` and produced a
  271-line reformat; reverted and edited surgically.)

## One caveat

The job has a `paths:` filter, so it does not run on a PR touching no plugin or script
files, and GitHub shows a required context that never reports as pending. A docs-only
marketplace PR could therefore sit unmergeable. I have not made that change here because it
is a judgement call: the fix would be a `paths`-less companion job that reports success
trivially. Say the word and I will add it, either now or when it first bites.

Closes #845
