### PR TITLE
fix: exempt changeset-release/** from the required linked-issue gate

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -19,7 +19,14 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const EXCLUDE_BRANCHES = "dependabot/**,release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*";
+            // Bot-authored branches whose content is derived from changes that
+            // already passed this gate. `changeset-release/**` is the Changesets
+            // release PR: a version bump plus a changelog assembled from
+            // changeset files that arrived through ordinary issue-linked PRs, so
+            // there is no new authored change for an issue to describe. Without
+            // the exemption it fails a required check and can only be merged by
+            // an administrator overriding branch protection.
+            const EXCLUDE_BRANCHES = "dependabot/**,release/**,changeset-release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*";
             const MARKER = "<!-- require-linked-issue -->";
             const MESSAGE = `${MARKER}\nThis PR must be linked to a GitHub issue. Use 'Closes #123' in the PR description, or link an issue from the sidebar.`;
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -410,6 +410,10 @@ jobs:
         if: hashFiles('tests/test-check-repo-hygiene.sh') != ''
         run: bash tests/test-check-repo-hygiene.sh
 
+      - name: Run require-linked-issue exemptions test
+        if: hashFiles('tests/test-require-linked-issue-exemptions.sh') != ''
+        run: bash tests/test-require-linked-issue-exemptions.sh
+
       # Consumer repos: auto-run their OWN tests/test-*.sh so a caller repo (e.g.
       # code-review) gets shell-unit-test coverage through this reusable workflow
       # without editing the enumerated list above. Skipped in docs-control itself,

--- a/tests/test-require-linked-issue-exemptions.sh
+++ b/tests/test-require-linked-issue-exemptions.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Hermetic test for the branch-exemption set of the required linked-issue gate in
+# .github/workflows/require-linked-issue.yml.
+#
+# The gate is a required status check, so a branch that is wrongly gated cannot
+# merge at all — which is what happened to Changesets release PRs, whose bot-
+# authored body is a generated changelog with no issue to reference.
+#
+# The constant and the glob matcher are extracted from the workflow itself and
+# evaluated as-is, so this exercises the shipped logic rather than a copy of it
+# that could agree with the test while disagreeing with production.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WORKFLOW="${REPO_ROOT}/.github/workflows/require-linked-issue.yml"
+
+FAIL=0
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Lift `const EXCLUDE_BRANCHES = "..."` and the `globToRegex` arrow function out
+# of the inline github-script body, then rebuild the decision the workflow makes.
+exclude_line=$(grep -m1 'const EXCLUDE_BRANCHES' "$WORKFLOW" | sed 's/^[[:space:]]*//')
+if [ -z "$exclude_line" ]; then
+  echo "[FAIL] could not find EXCLUDE_BRANCHES in $(basename "$WORKFLOW")"
+  exit 1
+fi
+glob_fn=$(awk '
+  /const globToRegex = \(glob\) => \{/ { inside = 1 }
+  inside { sub(/^[[:space:]]*/, ""); print }
+  inside && /^[[:space:]]*\};[[:space:]]*$/ { exit }
+' "$WORKFLOW")
+if [ -z "$glob_fn" ]; then
+  echo "[FAIL] could not find globToRegex in $(basename "$WORKFLOW")"
+  exit 1
+fi
+
+cat >"$WORK/is-exempt.mjs" <<EOF
+${exclude_line}
+${glob_fn}
+const patterns = EXCLUDE_BRANCHES.split(",").map((p) => globToRegex(p.trim()));
+const headRef = process.argv[2];
+process.exit(patterns.some((re) => re.test(headRef)) ? 0 : 1);
+EOF
+
+is_exempt() { node "$WORK/is-exempt.mjs" "$1"; }
+
+assert_exempt() { # assert_exempt <branch> <why>
+  if is_exempt "$1"; then
+    echo "[OK] '$1' is exempt — $2"
+  else
+    echo "[FAIL] '$1' should be exempt — $2"
+    FAIL=1
+  fi
+}
+
+assert_gated() { # assert_gated <branch> <why>
+  if is_exempt "$1"; then
+    echo "[FAIL] '$1' should still require a linked issue — $2"
+    FAIL=1
+  else
+    echo "[OK] '$1' still requires a linked issue — $2"
+  fi
+}
+
+# The regression this test exists for: a Changesets release PR carries only a
+# version bump and a changelog generated from already-gated PRs.
+assert_exempt "changeset-release/main" "Changesets release PR against main"
+assert_exempt "changeset-release/next" "Changesets release PR against another base"
+
+# Exemptions that were already relied upon, locked so a future edit cannot drop
+# one while adding another.
+assert_exempt "dependabot/npm_and_yarn/astro-6.1.5" "dependency bump"
+assert_exempt "release/3.9.14" "release branch"
+assert_exempt "openapi-sync/2026-07-28" "spec sync"
+assert_exempt "plugin-sync/marketplace" "plugin sync"
+assert_exempt "deps/bump-node" "dependency branch"
+assert_exempt "sync/managed-files" "managed-file sync"
+assert_exempt "docs/update-terminology" "docs update branch"
+
+# Authored work must stay gated, and the patterns must stay anchored so a
+# prefix cannot be smuggled in mid-path.
+assert_gated "feat/locale-complete-llms-surface" "ordinary feature branch"
+assert_gated "fix/exempt-changeset-release-branches" "ordinary fix branch"
+assert_gated "feature/changeset-release/main" "exemption must be anchored at the start"
+assert_gated "changeset-release" "directory prefix without a base is not a release branch"
+assert_gated "docs/update" "docs/update-* needs the suffix"
+assert_gated "main" "the default branch is not exempt"
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "PASS: linked-issue gate exemptions behave as specified"
+else
+  echo "FAIL: linked-issue gate exemptions are wrong"
+fi
+exit "$FAIL"


### PR DESCRIPTION
Closes #851

## Problem

Changesets opens its release PR on `changeset-release/<base>`. Its body is a
generated changelog with no issue reference, and `EXCLUDE_BRANCHES` in
`require-linked-issue.yml` covered `dependabot/**` and `release/**` but not this
one — so the required `check / Check linked issues` context failed and the PR was
permanently `BLOCKED`. Releases could only ship by an administrator merging past
branch protection, which is precisely what the "root-cause only, never merge
around a required check" standard rules out.

Observed on `starlight-llms-txt#339` (the 1.4.0 release PR) at 23:10Z today:
every other required context passed, this one failed in 3s.

## Why this exemption is not a loophole

A release PR carries a version bump plus a changelog assembled from changeset
files that each arrived through an ordinary, issue-linked, CI-gated PR. There is
no newly authored change for an issue to describe — the same reasoning already
applied to `dependabot/**`.

## Test

`tests/test-require-linked-issue-exemptions.sh` lifts the shipped
`EXCLUDE_BRANCHES` constant and the `globToRegex` helper **out of the workflow**
and evaluates them as-is. Reimplementing the matcher in the test would let a copy
agree with the test while disagreeing with production.

Fails before the change on exactly the two intended cases and nothing else:

```
[FAIL] 'changeset-release/main' should be exempt
[FAIL] 'changeset-release/next' should be exempt
[OK]   ...13 other cases pass
```

Passes after, 15/15. Coverage:

- the two release branches
- all seven pre-existing exemptions, so a future edit cannot drop one while adding another
- six branches that must stay gated, including `feature/changeset-release/main`
  and a bare `changeset-release` to prove the patterns stay anchored, and
  `docs/update` to prove `docs/update-*` still needs its suffix

`docs-control` deliberately skips the consumer `tests/test-*.sh` glob for itself,
so the test is added to the enumerated list its own CI runs — otherwise it would
never execute here.

`shellcheck`, `shfmt -d` and `actionlint` are clean. The change to the workflow is
a literal glob added to a JS string constant; `pr.head.ref` continues to be
regex-tested in JS and is never interpolated into a shell command.