### PR TITLE
docs: record who reads repo_classes

### DIFF
--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -207,6 +207,23 @@ honest: every assignment must name a defined class, and every entry in
 fleet without classifying it therefore fails CI rather than silently
 inheriting the default.
 
+### Who reads it
+
+Two consumers outside this repository, so a misclassification is visible in
+more than one place:
+
+- **xcsh** resolves `xcsh://fleet` from it -- the current repository's class,
+  and the roster of which repositories the assistant authors in versus
+  delegates. It reads the local synced copy first and only falls back to the
+  GitHub API, so the classification works offline from any checkout.
+- **`clone-all-repos.sh`** in `f5-sales-demo/.github` scopes a clone by class
+  (`--content`, `--code`, `--infrastructure`), so a developer can check out only
+  the repositories they actually work in. A misclassification therefore also
+  changes what lands on someone's disk.
+
+Both treat an unlisted repository as `_default`, matching the fail-closed rule
+above.
+
 ## Setting up docs content
 
 Every repository that publishes documentation needs a `docs/` directory with at least an `index.mdx` file containing YAML frontmatter.


### PR DESCRIPTION
Closes #853

The `Repository classes: repo_classes` section in `docs/onboarding.mdx` explained the manifest's shape, what each class means, why `_default` is fail-closed, and which CI assertions keep it honest — but not who reads it.

That gap matters now, because the answer is no longer "docs-control tooling". A new **Who reads it** subsection names both consumers:

- **xcsh** resolves `xcsh://fleet` from it — the current repository's class, and the roster of which repositories the assistant authors in versus delegates. Local synced copy first, GitHub API only as fallback, so it works offline from any checkout.
- **`clone-all-repos.sh`** in `f5-sales-demo/.github` scopes a clone by class (`--content`, `--code`, `--infrastructure`).

Plus the consequence worth writing down: a misclassification no longer just mislabels a repository, it changes what an assistant believes it may author and what lands on a developer's disk. And a note that both consumers treat an unlisted repository as `_default`, so the fail-closed rule stated above the new text holds all the way through.

### Scope

**Documentation only.** `governance.json`, `downstream-repos.json` and every test are untouched — the classification is already correct and is exactly what both consumers read. No existing consumer (`dispatch-downstream.yml`, `preflight-fleet.sh`) is affected.

### Verification

```
$ ./tests/test-protect-managed-files.sh
  Results: 124 passed, 0 failed (124 total)     # incl. repo_classes assertions 3.7–3.11

$ ./tests/test-dispatch-matrix.sh
  [OK] … actionlint clean

$ markdownlint-cli2 --config .markdownlint.json docs/onboarding.mdx
  Summary: 0 issues in 0 files
```

The counts the consumers see, cross-checked against the manifest: 19 `content`, 15 `developer`, 5 `scaffolding`, 39 total.

Paired with f5-sales-demo/xcsh#2587 and f5-sales-demo/.github#9, the two consumers this documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)