### PR TITLE
fix: tune CLAUDE.md for Opus 5 — prune, then ask for brevity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 
 Reviewing a **spec or plan** is not reviewing a **pull-request diff**. Pick by what you are reviewing, not by the word "review". Full detail: CONTRIBUTING.md, "Automated code review".
 
-- **Local, pre-PR — advisory, never a gate.** Use `codex:verified-code-review`: `review-doc --kind spec|plan` for a document, `adversarial-review` for a branch. Verify each finding against this codebase before acting, and report the ones you dismissed and why.
+- **Local, pre-PR — advisory, never a gate.** When installed, use `codex:verified-code-review`: `review-doc --kind spec|plan` for a document, `adversarial-review` for a branch. When it is absent, skip it and continue — never substitute a PR-diff reviewer. Confirm each finding against this codebase before acting, and report the ones you dismissed and why.
 - **Never** use a PR-diff reviewer for a spec, plan, or local branch. `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`; `code-review-f5:code-review` is marked `disable-model-invocation`. The built-ins `/review` and `/security-review` cannot be denied — not selecting them is on you.
 - **CI** — the `review / claude-review` diff reviewer is **suspended**: not running, not required. Do not wait for it, and do not re-enable it outside REVIEWER-SPEC.md.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 Reviewing a **spec or plan** is not reviewing a **pull-request diff**. Pick by what you are reviewing, not by the word "review". Full detail: CONTRIBUTING.md, "Automated code review".
 
 - **Local, pre-PR — advisory, never a gate.** Use `codex:verified-code-review`: `review-doc --kind spec|plan` for a document, `adversarial-review` for a branch. Verify each finding against this codebase before acting, and report the ones you dismissed and why.
-- **Never** use a PR-diff reviewer for a spec, plan, or local branch — not `code-review:code-review`, `code-review-f5:code-review`, `pr-review-toolkit:review-pr`, `/review`, or `/security-review`. The first two are denied in `.claude/settings.json` and the third is `disable-model-invocation`; the built-ins are on you.
+- **Never** use a PR-diff reviewer for a spec, plan, or local branch. `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`; `code-review-f5:code-review` is marked `disable-model-invocation`. The built-ins `/review` and `/security-review` cannot be denied — not selecting them is on you.
 - **CI** — the `review / claude-review` diff reviewer is **suspended**: not running, not required. Do not wait for it, and do not re-enable it outside REVIEWER-SPEC.md.
 
 ## Worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 
 Reviewing a **spec or plan** is not reviewing a **pull-request diff**. Pick by what you are reviewing, not by the word "review". Full detail: CONTRIBUTING.md, "Automated code review".
 
-- **Local, pre-PR — advisory, never a gate.** When installed, use `codex:verified-code-review`: `review-doc --kind spec|plan` for a document, `adversarial-review` for a branch. When it is absent, skip it and continue — never substitute a PR-diff reviewer. Confirm each finding against this codebase before acting, and report the ones you dismissed and why.
+- **Local, pre-PR — advisory, never a gate.** When installed, use `codex:verified-code-review` before a human reviews a spec or plan (`review-doc --kind spec|plan`, its primary use), before a push that opens or updates a PR (`adversarial-review`), and after each round of fixes. When absent, skip it — never substitute a PR-diff reviewer. Confirm findings here before acting; report those you dismissed.
 - **Never** use a PR-diff reviewer for a spec, plan, or local branch. `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`; `code-review-f5:code-review` is marked `disable-model-invocation`. The built-ins `/review` and `/security-review` cannot be denied — not selecting them is on you.
 - **CI** — the `review / claude-review` diff reviewer is **suspended**: not running, not required. Do not wait for it, and do not re-enable it outside REVIEWER-SPEC.md.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,47 +21,13 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - Work on a feature branch and open a pull request.
 - Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, translation-freshness audit) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended** and is no longer part of this gate — see "CI (suspended)" below.
 
-## Two review layers — never substitute one for the other
+## Two review layers
 
-Reviewing a **spec or plan** and reviewing a **pull-request diff** are different jobs, done by different tools, with different authority. Pick by what you are reviewing, not by the word "review".
+Reviewing a **spec or plan** is not reviewing a **pull-request diff**. Pick by what you are reviewing, not by the word "review". Full detail: CONTRIBUTING.md, "Automated code review".
 
-| Layer | What it reviews | When | Tool | Authority |
-| ----- | --------------- | ---- | ---- | --------- |
-| **Local, pre-PR** | A spec, an implementation plan, or your own unpushed branch | Before a human reviews the document; before a push that opens or updates a PR; after each round of fixes | `codex:verified-code-review` | Advisory. Never a merge gate. |
-| **CI** | The pull-request diff | — | Self-hosted `review / claude-review` workflow | **Currently suspended.** Not running, not required. |
-
-### Local, pre-PR (Codex second opinion)
-
-When the `codex` plugin provides the `verified-code-review` skill, use it as a second-opinion reviewer at three points. When the skill is not installed, skip it and continue — this is an additive local layer, never a merge gate.
-
-- Before asking a human to review a written spec or an implementation plan. **This is the layer's primary use.** Review the document itself — `review-doc --kind spec` or `review-doc --kind plan` — not a diff.
-- Before pushing a branch that will open or update a pull request (`adversarial-review`, against the base ref or uncommitted work).
-- After each round of fixes, until no confirmed critical or high finding remains.
-
-**Never review a spec, a plan, or a local branch with a PR-diff reviewer.** Do not invoke `code-review:code-review`, `code-review-f5:code-review`, `pr-review-toolkit:review-pr`, `/review`, or `/security-review` as your local review step.
-
-- They review a pull-request diff, which is the CI layer's job — and a spec has no diff to review.
-- Enforced, not just documented: `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`, and `code-review-f5:code-review` is marked `disable-model-invocation` in the vendored plugin. A wrong choice fails loudly instead of quietly producing the wrong kind of review.
-- `/review` and `/security-review` are built-in commands that no rule can deny. Not selecting them for local spec, plan, or branch review is on you.
-
-Treat every second-opinion finding as external review feedback under `superpowers:receiving-code-review`: verify each claim against this codebase before acting on it, and push back with technical reasoning when it is wrong. Fix only confirmed findings, each with a test that fails before the fix and passes after.
-
-Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none.
-
-### CI (suspended)
-
-**The Claude Code review is currently suspended and is no longer a required check.** The self-hosted reviewer could not reliably reach model inference or the VPN, so the check often never went green and blocked PRs for infrastructure reasons rather than code-quality ones.
-
-The `review / claude-review` context was removed from branch protection (docs-control#833), and the workflow is gated off behind the `REVIEWER_ENABLED` variable (docs-control#838).
-
-What this means for you now:
-
-- **Do not wait for it, and do not treat its absence as a problem.** No CI job reviews PR diffs at present.
-- Required checks are the linked-issue check, `Lint Code Base`, and `audit / Translation freshness` (plus any repo-specific contexts).
-- The local pre-PR layer above is now the only review step in practice. It remains **advisory** — it is not a gate and does not become one because the CI layer is absent.
-- **Do not re-enable it, re-add the required context, or work around the suspension** without going through REVIEWER-SPEC.md. Order matters: set the variable first and confirm a real review completes, then re-add the context. Reversing that deadlocks every open PR.
-
-When it is restored it becomes a required, merge-gating check again: on a block, read its findings, fix at the source, and push to re-trigger it — never merge around it or rename the branch to a bypass prefix. See CONTRIBUTING.md.
+- **Local, pre-PR — advisory, never a gate.** Use `codex:verified-code-review`: `review-doc --kind spec|plan` for a document, `adversarial-review` for a branch. Verify each finding against this codebase before acting, and report the ones you dismissed and why.
+- **Never** use a PR-diff reviewer for a spec, plan, or local branch — not `code-review:code-review`, `code-review-f5:code-review`, `pr-review-toolkit:review-pr`, `/review`, or `/security-review`. The first two are denied in `.claude/settings.json` and the third is `disable-model-invocation`; the built-ins are on you.
+- **CI** — the `review / claude-review` diff reviewer is **suspended**: not running, not required. Do not wait for it, and do not re-enable it outside REVIEWER-SPEC.md.
 
 ## Worktrees
 
@@ -80,7 +46,7 @@ Apply where applicable to this repo:
 - **TDD** — write the failing test first, then the code.
 - **Automate UAT** — automate acceptance testing wherever possible.
 - **Programmatic & idempotent** — fix with deterministic, re-runnable automation, not one-off manual steps; the same run yields the same result in CI.
-- **Verify before done (IMPORTANT)** — never guess; verify locally before you push, and mark a task complete only when its result is verified with evidence (commands, output, run link). Watch the GitHub Actions runs to completion; when a change publishes a version, install and exercise it. No unverified claims.
+- **Report outcomes** — lead with what happened. Show the command and its output as evidence, and say plainly what is done and what is not.
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease, pre-production code under active development; make clean-break changes, never add compatibility shims or keep deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
@@ -88,3 +54,9 @@ Apply where applicable to this repo:
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.
+
+## Communication
+
+Keep responses focused, brief, and concise; spend most of the response on the main answer. Before your first tool call, say in one sentence what you are about to do. While working, give a brief update only when you find something important or change direction. When you finish, lead with the outcome — your first sentence answers "what happened" — with supporting detail after it.
+
+Match written documents (issues, PR bodies, specs) to what the task needs. Do not pad with filler sections, redundant summaries, or boilerplate.

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -146,6 +146,32 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 5: CLAUDE.md stays small enough to be read (issue #855)
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 5: CLAUDE.md stays within its size budget ==="
+
+# CLAUDE.md loads at the start of every session and again in every subagent's
+# own context. Anthropic's Claude Code best practices: "Bloated CLAUDE.md files
+# cause Claude to ignore your actual instructions" and "If Claude keeps doing
+# something you don't want despite having a rule against it, the file is
+# probably too long and the rule is getting lost."
+#
+# This file grew 7x in three weeks (1,449 bytes on 2026-07-05 to 10,121 on
+# 2026-07-27) one well-intentioned rule at a time, and no single PR looked
+# unreasonable. The budget makes the next increment a conscious decision: to add
+# something, prune something. Raising this number is not the fix.
+CLAUDE_MD_MAX_BYTES=8500
+CLAUDE_MD_BYTES=$(wc -c <"$CLAUDE_MD" | tr -d ' ')
+
+if [ "$CLAUDE_MD_BYTES" -le "$CLAUDE_MD_MAX_BYTES" ]; then
+  pass "5.1 CLAUDE.md is ${CLAUDE_MD_BYTES}B, within the ${CLAUDE_MD_MAX_BYTES}B budget"
+else
+  fail "5.1 CLAUDE.md is within its ${CLAUDE_MD_MAX_BYTES}B budget" \
+    "it is ${CLAUDE_MD_BYTES}B — prune before adding; bloat makes Claude ignore the rules that matter"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 echo ""
 echo "════════════════════════════════════════════════════════════════"
 echo "Tests run: $TESTS_RUN | Passed: $PASS | Failed: $FAIL"

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -167,17 +167,40 @@ else
   pass "3b.1 CLAUDE.md states mechanisms without ordinal references"
 fi
 
-# The mechanism claims must still be present and correctly paired, checked
-# against the real configuration rather than against the prose's own ordering.
-for denied in "code-review:code-review" "pr-review-toolkit:review-pr"; do
-  if jq -e --arg s "Skill($denied)" '.permissions.deny // [] | index($s)' "$SETTINGS" >/dev/null 2>&1 &&
-    grep -qF "$denied" "$CLAUDE_MD"; then
-    pass "3b.2 $denied is denied in settings and named in CLAUDE.md"
+# Banning ordinals alone is not enough: the mechanisms could be inverted in
+# plain prose and still pass. Check the pairing itself. The sentence states two
+# mechanisms in separate semicolon-delimited clauses, so read each clause and
+# require that it names the tools that mechanism actually covers — and none of
+# the tools it does not.
+MECH_LINE=$(grep 'disable-model-invocation' "$CLAUDE_MD" | head -1)
+DENY_CLAUSE=$(printf '%s' "$MECH_LINE" | tr ';' '\n' | grep -i 'denies' | head -1)
+DMI_CLAUSE=$(printf '%s' "$MECH_LINE" | tr ';' '\n' | grep -F 'disable-model-invocation' | head -1)
+
+# The flagged tool belongs to the disable-model-invocation clause, never the deny one.
+DMI_TOOL="code-review-f5:code-review"
+if printf '%s' "$DMI_CLAUSE" | grep -qF "$DMI_TOOL" &&
+  ! printf '%s' "$DENY_CLAUSE" | grep -qF "$DMI_TOOL"; then
+  pass "3b.2 $DMI_TOOL is paired with disable-model-invocation, not with the deny rules"
+else
+  fail "3b.2 $DMI_TOOL is paired with disable-model-invocation, not with the deny rules" \
+    "the mechanisms are inverted: it is flagged in the vendored plugin, not denied in settings"
+fi
+
+# Every reviewer genuinely in the deny list belongs to the deny clause, and must
+# not be described as using the flag instead.
+while IFS= read -r denied; do
+  case "$denied" in *:*) : ;; *) continue ;; esac
+  if printf '%s' "$DENY_CLAUSE" | grep -qF "$denied" &&
+    ! printf '%s' "$DMI_CLAUSE" | grep -qF "$denied"; then
+    pass "3b.3 $denied is paired with the settings.json deny rules"
   else
-    fail "3b.2 $denied is denied in settings and named in CLAUDE.md" \
-      "the deny rule and the documentation disagree"
+    fail "3b.3 $denied is paired with the settings.json deny rules" \
+      "settings.json denies it, but CLAUDE.md attributes it to another mechanism"
   fi
-done
+done <<EOF
+$(jq -r '.permissions.deny // [] | .[]' "$SETTINGS" |
+  sed -n 's/^Skill(\(.*review.*\))$/\1/p')
+EOF
 
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5: CLAUDE.md stays small enough to be read (issue #855)

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -146,6 +146,40 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 3b: each safeguard is attributed to the tool it actually protects
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 3b: CLAUDE.md attributes each enforcement mechanism correctly ==="
+
+# Compressing this section once produced prose saying the deny rules covered
+# code-review-f5 and that pr-review-toolkit used disable-model-invocation. Both
+# were backwards. The cause was ordinal referencing — "the first two are denied
+# ... the third is disable-model-invocation" — which points by position into a
+# list, so it silently mis-maps the moment the list is written in any other
+# order. A line-based content check cannot catch it, because every name sits on
+# the same line. Ban the construct instead: name each tool where its mechanism
+# is stated.
+ORDINALS='the first two|the first one|the second one|the third|the former|the latter|the first three'
+if grep -nEi "$ORDINALS" "$CLAUDE_MD" >/dev/null 2>&1; then
+  fail "3b.1 CLAUDE.md states mechanisms without ordinal references" \
+    "found: $(grep -oEi "$ORDINALS" "$CLAUDE_MD" | sort -u | tr '\n' ' ')— name the tool instead of its position"
+else
+  pass "3b.1 CLAUDE.md states mechanisms without ordinal references"
+fi
+
+# The mechanism claims must still be present and correctly paired, checked
+# against the real configuration rather than against the prose's own ordering.
+for denied in "code-review:code-review" "pr-review-toolkit:review-pr"; do
+  if jq -e --arg s "Skill($denied)" '.permissions.deny // [] | index($s)' "$SETTINGS" >/dev/null 2>&1 &&
+    grep -qF "$denied" "$CLAUDE_MD"; then
+    pass "3b.2 $denied is denied in settings and named in CLAUDE.md"
+  else
+    fail "3b.2 $denied is denied in settings and named in CLAUDE.md" \
+      "the deny rule and the documentation disagree"
+  fi
+done
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 5: CLAUDE.md stays small enough to be read (issue #855)
 # ════════════════════════════════════════════════════════════════════
 echo ""

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -159,6 +159,19 @@ echo "=== Section 3b: CLAUDE.md attributes each enforcement mechanism correctly 
 # order. A line-based content check cannot catch it, because every name sits on
 # the same line. Ban the construct instead: name each tool where its mechanism
 # is stated.
+# The local layer is optional tooling. CLAUDE.md must say so itself rather than
+# delegating it to CONTRIBUTING.md: `.claude/governance.json` skip_files excludes
+# CONTRIBUTING.md from xcsh, whose own copy contains none of this content, so a
+# pointer there resolves to nothing in that repo. An unconditional "use the
+# skill" can stall work, or push an agent toward a prohibited PR-diff reviewer.
+LOCAL_LINE=$(grep -F 'codex:verified-code-review' "$CLAUDE_MD" | head -1)
+if printf '%s' "$LOCAL_LINE" | grep -qiE 'when (it is )?(installed|available|present)|skip|absent|not installed'; then
+  pass "3b.0 CLAUDE.md itself says the local layer is skipped when the tooling is absent"
+else
+  fail "3b.0 CLAUDE.md itself says the local layer is skipped when the tooling is absent" \
+    "reads as unconditional; CONTRIBUTING.md is not synced to xcsh so the caveat must live here"
+fi
+
 ORDINALS='the first two|the first one|the second one|the third|the former|the latter|the first three'
 if grep -nEi "$ORDINALS" "$CLAUDE_MD" >/dev/null 2>&1; then
   fail "3b.1 CLAUDE.md states mechanisms without ordinal references" \


### PR DESCRIPTION
Closes #855

## What

`CLAUDE.md` was tuned for Opus 4.8 and now fights Opus 5. Three changes, plus two guard tests.

**10,121 → 7,441 bytes (26% smaller).** Engineering Standards stays 11 bullets, `## Worktrees` stays 5.

## Why, per Anthropic

[Prompting Claude Opus 5](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5):

> "Claude Opus 5 verifies its own work without being told to. If your prompt contains explicit
> verification instructions ... remove them: instructions like these cause over-verification ...
> The same applies to legacy harness scaffolding that adds separate verification steps."

> "The effort parameter controls how much the model thinks rather than how much it says ...
> To control response length, prompt for it explicitly."

[Claude Code best practices](https://code.claude.com/docs/en/best-practices): *"Bloated CLAUDE.md files cause Claude to ignore your actual instructions."*

## The changes

1. **`Verify before done (IMPORTANT)` → `Report outcomes`.** The old clause *"mark a task complete
   only when its result is verified with evidence"* caused a real incident in the authoring session:
   the agent refused to mark finished work complete and the operator had to ask "did you finish?".
   The replacement keeps the evidence and drops the over-verification.
2. **`## Two review layers` collapsed 41 lines → 9.** It was 46% of the file, largely duplicating
   `CONTRIBUTING.md` "Automated code review".
3. **New `## Communication` section** using Anthropic's published conciseness and narration-cadence
   guidance, including *"lead with the outcome"* — the Opus 4.8 behaviour the operator missed.

## Guard tests

- **Size budget, 8,500 bytes.** The file grew **7× in three weeks** (1,449 → 10,121), one
  reasonable-looking rule at a time. Written TDD-first and observed failing at 10,121B.
- **Safeguard pairing.** Bans ordinal references and checks each mechanism against
  `.claude/settings.json`.

## Codex review: 4 rounds, 4 findings, 3 confirmed and fixed, 1 refuted

Gate: `done: true`, `findingsClear: true`, no escalation. The CI reviewer is suspended, so this was the only review layer — and it earned its place.

| Round | Finding | Outcome |
| ----- | ------- | ------- |
| 1 | My compression said the deny rules covered `code-review-f5` and that `pr-review-toolkit` used `disable-model-invocation` | **Confirmed** — ground truth is the reverse. Caused by ordinal referencing ("the first two… the third"). Fixed by naming each tool where its mechanism is stated |
| 2 | My *fix's own test* false-passed the inversion it claimed to catch | **Confirmed** — it asserted co-location on a line that already contained every token. Replaced with a clause-level check, **proven** against an ordinal-free inverted variant: 3 assertions fail, correct prose passes |
| 3 | Collapsed bullet read as an unconditional "use the skill", losing skip-when-absent | **Confirmed** — and it cannot be delegated: `.claude/governance.json` `skip_files` excludes `CONTRIBUTING.md` from **xcsh**, whose own 23KB copy has **zero** occurrences of "Automated code review", "verified-code-review", or "Verify before claiming done" |
| 4 | Lost the reviewer's three invocation points | **Confirmed** — restored inline for the same xcsh reason |
| 3–4 | "Replacing mandatory verification with reporting lets work be reported complete while CI is broken" | **Refuted** — see below |

**The refutation.** This is the PR's purpose, chosen by the operator with the guidance in hand, and
the failure mode described is prevented by mechanism rather than by that sentence. `xcsh` required
checks are `["check", "check / Check linked issues", "test", "audit / Translation freshness"]`
(`gh api repos/f5-sales-demo/xcsh/branches/main/protection`) — auto-merge cannot merge a red
branch. Add pre-commit hooks and 21 local suites. Meanwhile the removed wording has one measured
effect on record: it made the agent refuse to mark finished work complete.

## Verification

| Check | Result |
| ----- | ------ |
| Size | 10,121 → 7,441 bytes, inside the 8,500 budget |
| Budget test TDD | red at 10,121B, green at 7,441B |
| Pairing test | proven to fail on an ordinal-free inversion (3 assertions), pass on correct prose |
| Routing tokens | all 7 present; `test-review-layer-routing.sh` 21/21 |
| Suites | 21/21 pass |
| `pre-commit run --all-files` | all pass |
| textlint | exit 0; canary with `github`/`nodejs` produced 2 errors, proving the rule was live |
| markdownlint | 0 issues (authoritative for MD013 — `awk` counts bytes and over-counts em-dashes) |
| Structure | Engineering Standards 11, Worktrees 5 |

## What this PR does not claim

**Whether it changes behaviour cannot be tested in the session that authored it.** `CLAUDE.md` is
snapshotted at session start; two such tests were invalidated earlier the same day for exactly this
reason. The honest check is the operator's experience in a **fresh session**: shorter responses,
outcome-first reporting, and completion stated rather than deferred.

## Surfaced, not fixed

`xcsh` skipping `CONTRIBUTING.md` while receiving `CLAUDE.md` is a live governance gap — any
`CLAUDE.md` pointer into `CONTRIBUTING.md` silently dangles there. Worth its own issue.
