### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-28T02:45:11Z",
-  "source_commit": "af7477eeac435dbe963f78ccec5d15e4066f8198",
+  "generated_at": "2026-07-30T04:10:25Z",
+  "source_commit": "1303bedff3119f21ca33474775495004a25bd2ba",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -71,8 +71,8 @@
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "147dd5a9e66cad7b357aff1351d2e71affe7fcd5",
-      "size": 10121
+      "sha": "e5702709e0c5e574d0fa84f8fdbeedaa577eb777",
+      "size": 7441
     },
     ".editorconfig": {
       "src": ".editorconfig",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.