### PR TITLE
fix: stop xcsh skipping CONTRIBUTING.md

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -1,15 +1,7 @@
 {
   "source_repo": "f5-sales-demo/docs-control",
   "skip_files": {
-    "xcsh": [
-      "biome.json",
-      "LICENSE",
-      "CONTRIBUTING.md",
-      ".ruff.toml",
-      ".python-lint",
-      ".mypy.ini",
-      ".github/workflows/super-linter.yml"
-    ],
+    "xcsh": ["biome.json", "LICENSE", ".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/super-linter.yml"],
     "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -79,7 +79,6 @@
       "xcsh": [
         "biome.json",
         "LICENSE",
-        "CONTRIBUTING.md",
         ".ruff.toml",
         ".python-lint",
         ".mypy.ini",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,14 @@ improving how customers are defended.
   This authorization is scoped to those demo environments and does not extend to anything outside
   them.
 
+## Repository-specific guidance
+
+This document is a managed file, identical across the fleet, so it describes the process rather than
+any one repository's toolchain. Some repositories add a `DEVELOPING.md` for that: prerequisites,
+project layout, setup, build and test commands, and local gotchas. **When this repository has a
+`DEVELOPING.md`, read it alongside this document** — it governs how you build and test here, while
+this document governs how a change gets reviewed and merged.
+
 ## Workflow Overview
 
 Every change follows this path:

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -227,28 +227,30 @@ echo "=== Section 4b: no governed repo receives CLAUDE.md but skips CONTRIBUTING
 # guidance into CLAUDE.md — which fights the size budget in Section 5. xcsh was
 # exactly this case until its repo-specific content moved to DEVELOPING.md
 # (f5-sales-demo/xcsh#2605) and this opt-out was removed.
-# Checking skip_files alone is not enough. sync-managed-files.yml decides
-# delivery from three inputs: presence in the manifest, an optional per-file
-# only_repos allowlist (workflow lines ~399-404), and the per-repo skip_files
-# opt-out. Dropping CONTRIBUTING.md from the manifest, or restricting it with
-# only_repos, would deploy CLAUDE.md without its dependency while a skip_files
-# check stayed green. Model the same three rules the sync applies.
+# Checking skip_files alone is not enough. sync-managed-files.yml iterates
+# repo-settings.json's managed_files.files[] and drops a file for a repo when
+# either skip_files lists it or the entry carries an only_repos allowlist that
+# excludes the repo (workflow lines ~387-405). Model those exact two rules
+# against that exact source.
+#
+# Deliberately NOT read from managed-files-manifest.json: that artifact keeps
+# only src/dest/sha/size and discards only_repos, so a real allowlist added in
+# repo-settings.json would be invisible there and this check would pass while
+# the sync skipped the file.
 GOVERNANCE="$REPO_ROOT/.claude/governance.json"
 REPO_SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
-MANIFEST_FILE="$REPO_ROOT/.github/config/managed-files-manifest.json"
 DOWNSTREAM="$REPO_ROOT/.github/config/downstream-repos.json"
 
 OFFENDERS=$(
   jq -n -r \
-    --slurpfile manifest "$MANIFEST_FILE" \
     --slurpfile settings "$REPO_SETTINGS" \
     --slurpfile repos "$DOWNSTREAM" '
-    ($manifest[0].files // {})                  as $files    |
-    ($settings[0].managed_files.skip_files // {}) as $skips   |
-    ($repos[0])                                 as $all      |
-    # receives(repo, file): in manifest, allowed by only_repos, not skipped
+    ($settings[0].managed_files.files // [])      as $files |
+    ($settings[0].managed_files.skip_files // {}) as $skips |
+    ($repos[0])                                   as $all   |
+    # receives(repo, dest): routed to this repo by the same rules the sync applies
     def receives($repo; $name):
-      ($files[$name] // null) as $entry |
+      ([$files[] | select(.dest == $name)] | first) as $entry |
       if $entry == null then false
       elif ($entry.only_repos // null) != null and (($entry.only_repos | index($repo)) == null) then false
       elif (($skips[$repo] // []) | index($name)) != null then false

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -227,27 +227,55 @@ echo "=== Section 4b: no governed repo receives CLAUDE.md but skips CONTRIBUTING
 # guidance into CLAUDE.md — which fights the size budget in Section 5. xcsh was
 # exactly this case until its repo-specific content moved to DEVELOPING.md
 # (f5-sales-demo/xcsh#2605) and this opt-out was removed.
+# Checking skip_files alone is not enough. sync-managed-files.yml decides
+# delivery from three inputs: presence in the manifest, an optional per-file
+# only_repos allowlist (workflow lines ~399-404), and the per-repo skip_files
+# opt-out. Dropping CONTRIBUTING.md from the manifest, or restricting it with
+# only_repos, would deploy CLAUDE.md without its dependency while a skip_files
+# check stayed green. Model the same three rules the sync applies.
 GOVERNANCE="$REPO_ROOT/.claude/governance.json"
 REPO_SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
+MANIFEST_FILE="$REPO_ROOT/.github/config/managed-files-manifest.json"
+DOWNSTREAM="$REPO_ROOT/.github/config/downstream-repos.json"
 
-for cfg_desc in "governance.json:$GOVERNANCE:.skip_files" \
-  "repo-settings.json:$REPO_SETTINGS:.managed_files.skip_files"; do
-  cfg_name="${cfg_desc%%:*}"
-  rest="${cfg_desc#*:}"
-  cfg_path="${rest%%:*}"
-  cfg_query="${rest#*:}"
+OFFENDERS=$(
+  jq -n -r \
+    --slurpfile manifest "$MANIFEST_FILE" \
+    --slurpfile settings "$REPO_SETTINGS" \
+    --slurpfile repos "$DOWNSTREAM" '
+    ($manifest[0].files // {})                  as $files    |
+    ($settings[0].managed_files.skip_files // {}) as $skips   |
+    ($repos[0])                                 as $all      |
+    # receives(repo, file): in manifest, allowed by only_repos, not skipped
+    def receives($repo; $name):
+      ($files[$name] // null) as $entry |
+      if $entry == null then false
+      elif ($entry.only_repos // null) != null and (($entry.only_repos | index($repo)) == null) then false
+      elif (($skips[$repo] // []) | index($name)) != null then false
+      else true end;
+    $all
+    | map(select(receives(.; "CLAUDE.md") and (receives(.; "CONTRIBUTING.md") | not)))
+    | .[]
+  ' 2>/dev/null | tr '\n' ' '
+)
 
-  offenders=$(jq -r --arg q "$cfg_query" \
-    "${cfg_query} // {} | to_entries | map(select(.value | index(\"CONTRIBUTING.md\"))) | .[].key" \
-    "$cfg_path" 2>/dev/null | tr '\n' ' ')
+if [ -z "${OFFENDERS// /}" ]; then
+  pass "4b.1 every repo receiving CLAUDE.md also receives CONTRIBUTING.md"
+else
+  fail "4b.1 every repo receiving CLAUDE.md also receives CONTRIBUTING.md" \
+    "CLAUDE.md points into CONTRIBUTING.md; these repos get one without the other: ${OFFENDERS}"
+fi
 
-  if [ -z "${offenders// /}" ]; then
-    pass "4b.1 $cfg_name has no CONTRIBUTING.md opt-out"
-  else
-    fail "4b.1 $cfg_name has no CONTRIBUTING.md opt-out" \
-      "these repos get CLAUDE.md but not the file it points into: ${offenders}"
-  fi
-done
+# governance.json is the copy the sync and preflight read, so the two skip lists
+# must not drift apart.
+if diff -q \
+  <(jq -S '.skip_files' "$GOVERNANCE") \
+  <(jq -S '.managed_files.skip_files' "$REPO_SETTINGS") >/dev/null 2>&1; then
+  pass "4b.2 governance.json and repo-settings.json skip lists agree"
+else
+  fail "4b.2 governance.json and repo-settings.json skip lists agree" \
+    "the two copies of skip_files have drifted; sync and preflight would disagree"
+fi
 
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5: CLAUDE.md stays small enough to be read (issue #855)

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -216,6 +216,40 @@ $(jq -r '.permissions.deny // [] | .[]' "$SETTINGS" |
 EOF
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 4b: CLAUDE.md's cross-references must resolve everywhere (issue #859)
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 4b: no governed repo receives CLAUDE.md but skips CONTRIBUTING.md ==="
+
+# CLAUDE.md is synced to every governed repo and points into CONTRIBUTING.md for
+# detail it deliberately does not carry. A repo that receives one but skips the
+# other gets dangling pointers, and the only safe response is to inline the
+# guidance into CLAUDE.md — which fights the size budget in Section 5. xcsh was
+# exactly this case until its repo-specific content moved to DEVELOPING.md
+# (f5-sales-demo/xcsh#2605) and this opt-out was removed.
+GOVERNANCE="$REPO_ROOT/.claude/governance.json"
+REPO_SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
+
+for cfg_desc in "governance.json:$GOVERNANCE:.skip_files" \
+  "repo-settings.json:$REPO_SETTINGS:.managed_files.skip_files"; do
+  cfg_name="${cfg_desc%%:*}"
+  rest="${cfg_desc#*:}"
+  cfg_path="${rest%%:*}"
+  cfg_query="${rest#*:}"
+
+  offenders=$(jq -r --arg q "$cfg_query" \
+    "${cfg_query} // {} | to_entries | map(select(.value | index(\"CONTRIBUTING.md\"))) | .[].key" \
+    "$cfg_path" 2>/dev/null | tr '\n' ' ')
+
+  if [ -z "${offenders// /}" ]; then
+    pass "4b.1 $cfg_name has no CONTRIBUTING.md opt-out"
+  else
+    fail "4b.1 $cfg_name has no CONTRIBUTING.md opt-out" \
+      "these repos get CLAUDE.md but not the file it points into: ${offenders}"
+  fi
+done
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 5: CLAUDE.md stays small enough to be read (issue #855)
 # ════════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
Closes #859

## What

Removes `CONTRIBUTING.md` from `skip_files.xcsh` in both config files, so xcsh receives the managed
`CONTRIBUTING.md` like every other governed repo.

## Why

xcsh was the only repo receiving the managed `CLAUDE.md` while opting out of the managed
`CONTRIBUTING.md`. `CLAUDE.md` points into `CONTRIBUTING.md` for detail it deliberately does not
carry, so those pointers resolved to nothing there. Verified before the change:

| Probe | Occurrences in xcsh's own `CONTRIBUTING.md` |
| ----- | ------------------------------------------- |
| `Automated code review` | 0 |
| `verified-code-review` | 0 |
| `Verify before claiming done` | 0 |

That gap had a measurable cost: three of the four Codex findings on #857 had to be fixed by
**inlining** guidance into `CLAUDE.md` rather than delegating it, working directly against the size
budget that PR introduced.

## Safe now, and the order mattered

f5-sales-demo/xcsh#2608 first relocated xcsh's 662 lines of repo-specific engineering documentation
to `DEVELOPING.md`. Verified on xcsh `main`: `DEVELOPING.md` is 23,819 bytes with 25 matches for the
bun/Biome/OOM guidance, and `CONTRIBUTING.md` is a 1,188-byte pointer.

Doing this PR first would have destroyed that content — the sync writes canonical content over any
differing downstream copy and does not merge.

## Codex review: 3 rounds, 3 confirmed findings, all fixed

| Round | Finding | Outcome |
| ----- | ------- | ------- |
| 1 | Sync would orphan xcsh's engineering guide | **Confirmed.** Replacing the pointer removes the `DEVELOPING.md` reference — and xcsh does **not** skip `README.md`, so the sync regenerates it from `README.md.tpl`, whose Contributing section names only `CONTRIBUTING.md` and supports no conditionals. **Both** pointers would have gone |
| 1 | Test only checked `skip_files` | **Confirmed.** The sync also honours a per-file `only_repos` allowlist |
| 2 | Test read `only_repos` from the manifest, which discards it | **Confirmed** — and it invalidated my own proof. The manifest keeps only `src/dest/sha/size`; routing happens on `repo-settings.json`. My counterexample had injected `only_repos` into the wrong file, so it "passed" for the wrong reason |
| 3 | — | **approve**, no findings |

### Fix for the orphaning

Handled generically in the managed `CONTRIBUTING.md` rather than by special-casing xcsh: a short
`## Repository-specific guidance` section saying to read `DEVELOPING.md` alongside it **when the
repository has one**. Valid fleet-wide, no broken link where the file is absent, and it makes any
repo's `DEVELOPING.md` discoverable through the standard contribution path.

## The invariant, now enforced

`tests/test-review-layer-routing.sh` §4b models the sync's actual rules from
`repo-settings.json.managed_files.files[]` — the source the workflow iterates
(`sync-managed-files.yml` ~387-405) — and asserts **no governed repo receives `CLAUDE.md` without
`CONTRIBUTING.md`**, plus a drift check between the two copies of `skip_files`.

Proven against realistic counterexamples:

| Mutation | Result |
| -------- | ------ |
| `only_repos` on `CONTRIBUTING.md` in `repo-settings.json` | **FAIL**, ~36 repos named |
| `CONTRIBUTING.md` removed from `managed_files.files` | **FAIL** |
| `skip_files` copies drift apart | **FAIL** |
| Correct configuration | **PASS** |

## Verification

| Check | Result |
| ----- | ------ |
| Target test | red before the change, naming xcsh in both configs; green after |
| Suites | 21/21 pass |
| `pre-commit run --all-files` | all pass (Biome reformatted the shortened array onto one line, matching its siblings) |
| JSON validity | both configs parse; skip lists still identical |
| textlint | exit 0 on `CONTRIBUTING.md`; canary produced 2 errors, proving the rule was live |
| markdownlint | 0 issues |
| Diff shape | one line removed per config — no incidental reformatting |
| Codex | 3 rounds, final verdict **approve** |

## Post-merge check

The real acceptance test is downstream, not in this diff: after the sync lands, xcsh's
`CONTRIBUTING.md` must contain `Automated code review`. I will confirm that on this PR.
