### PR TITLE
Require each repo's own test suite, and guard against requiring a check that can skip

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -60,6 +60,24 @@
     },
     "console": {
       "additional_contexts": ["Validate Catalog Schemas"]
+    },
+    "terraform-provider-xcsh": {
+      "additional_contexts": [
+        "Build and Test / Build and Test",
+        "Build and Test / Lint",
+        "Mock Tests (Parallel)",
+        "Test Summary",
+        "Validate Docs Generation",
+        "Validate Mock Fixtures",
+        "Validate Shell Scripts",
+        "Validate Terraform Examples"
+      ]
+    },
+    "mcn": {
+      "additional_contexts": ["lint / Shell Unit Tests"]
+    },
+    "api-specs-enriched": {
+      "additional_contexts": ["Run pytest suite"]
     }
   },
   "topics": [],

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -173,6 +173,53 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 7d: additional_contexts must name checks that ALWAYS run
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 7d: additional_contexts name unconditional checks ==="
+
+# A required context that never reports does not fail — it blocks forever, with
+# "Expected — Waiting for status to be reported". So a job carrying a condition
+# that can skip must NOT be required until the condition is moved inside the job
+# and it always reports.
+#
+# These two were audited for #862 and deliberately left out. Each is a real check
+# that has already caught a real defect, and each needs its workflow changed first:
+#
+#   Constitution Check (terraform-provider-xcsh)
+#     if: github.event_name == 'pull_request' &&
+#         !startsWith(github.head_ref, 'auto-generate/') &&
+#         !startsWith(github.head_ref, 'auto-regenerate/') &&
+#         github.head_ref != 'docs/auto-update' && github.head_ref != 'openapi-update'
+#     Skips on the bot branches that legitimately commit generated files —
+#     precisely the branches it must not block.
+#
+#   Contract-diff gate (api-specs-enriched)
+#     if: ${{ !startsWith(github.head_ref, 'release/') }}
+#     Skips on release branches.
+#
+# Requiring either today would deadlock those PRs. Remove the name from this list
+# only together with the workflow change that makes the job always report.
+SKIPPABLE="Constitution Check
+Contract-diff gate"
+WRONGLY_REQUIRED=""
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  if jq -e --arg n "$name" \
+      '[.repo_overrides[] | .additional_contexts // [] | .[]] | index($n) != null' \
+      "$REPO_SETTINGS" >/dev/null; then
+    WRONGLY_REQUIRED="${WRONGLY_REQUIRED}  - ${name}\n"
+  fi
+done < <(printf '%s\n' "$SKIPPABLE")
+
+if [ -z "$WRONGLY_REQUIRED" ]; then
+  pass "7d.1 no additional_contexts entry names a job that can skip"
+else
+  fail "7d.1 no additional_contexts entry names a job that can skip" \
+    "these jobs carry a branch condition and would block forever:\n$WRONGLY_REQUIRED"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 5e: super-linter disables validators not applicable to the
 #             ecosystem's language mix (TS/Rust/Python/Markdown/Astro)
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -206,8 +206,8 @@ WRONGLY_REQUIRED=""
 while IFS= read -r name; do
   [ -z "$name" ] && continue
   if jq -e --arg n "$name" \
-      '[.repo_overrides[] | .additional_contexts // [] | .[]] | index($n) != null' \
-      "$REPO_SETTINGS" >/dev/null; then
+    '[.repo_overrides[] | .additional_contexts // [] | .[]] | index($n) != null' \
+    "$REPO_SETTINGS" >/dev/null; then
     WRONGLY_REQUIRED="${WRONGLY_REQUIRED}  - ${name}\n"
   fi
 done < <(printf '%s\n' "$SKIPPABLE")


### PR DESCRIPTION
Refs #862.

## Why

Four PRs merged **red** across four repositories in a week. In every case the check ran,
found a real defect, reported it, and could not block:

| repo | check that failed and merged anyway |
| --- | --- |
| `mcn` | `lint / Shell Unit Tests` (#719) — the test that catches stale generated includes, so disproved version claims were published |
| `terraform-provider-xcsh` | `Constitution Check` (#1400) — 274 generated files committed against that repo's own rule |
| `api-specs-enriched` | `Contract-diff gate` (#1153) — four upstream contract fields deleted |
| `mcn` | recorded in #722 |

A repository's own tests are required only if listed in
`repo_overrides.<repo>.additional_contexts`. Four repos had done that; the three where
this keeps happening had not. `mcn` and `api-specs-enriched` had no entry at all;
`terraform-provider-xcsh` had one carrying only an exclusion, so **none** of its ten
test jobs were required.

## What changed

Every name was audited against the workflow that produces it — not guessed from a
workflow file, and not copied from the issue, which listed two that turn out to be
unsafe.

```
mcn                      lint / Shell Unit Tests            no job condition
api-specs-enriched       Run pytest suite                   no job condition
terraform-provider-xcsh  Build and Test / Build and Test    no condition
                         Build and Test / Lint              if: inputs.run-lint, hardcoded true
                         Mock Tests (Parallel)              condition true on PRs
                         Test Summary                       if: always()
                         Validate Docs Generation           if: event == pull_request
                         Validate Mock Fixtures             same
                         Validate Shell Scripts             same
                         Validate Terraform Examples        same
```

## Two deliberately left out, and a guard so they stay out

A required context that never reports **does not fail — it blocks forever**, with
"Expected — Waiting for status to be reported". So a job carrying a condition that can
skip must have that condition moved inside it before it can be required.

- **`Constitution Check`** skips on `auto-generate/`, `auto-regenerate/`,
  `docs/auto-update`, `openapi-update` — the bot branches that legitimately commit
  generated files, and exactly the ones it must not block.
- **`Contract-diff gate`** skips on `release/` branches.

Both have already caught real defects and should end up required. They need their
workflows changed first, which belongs with those repositories.

New section 7d fails if either name appears in `additional_contexts`. **Verified to
bite:** adding `Contract-diff gate` makes `7d.1` fail and name it.

```
Results: 119 passed, 0 failed (119 total)
```

## Scope

This does not retroactively fix the four merged PRs — each is being addressed
separately. It stops the next one.

The larger question in #862 — whether the default should be inverted, so a repo opts
*out* of having its tests gate rather than in — is not settled here. The current default
is why this recurred four times, and it is worth deciding, but changing it affects every
repo at once.

## Acceptance criteria not yet met

- [ ] Demonstrated per repo: a PR with a deliberately failing test cannot merge. That
      needs this merged and the settings applied first, and I will verify it per repo
      rather than assume the config took effect.

Closes #862.

The remaining question in #862 — whether the default should invert so a repo opts *out* of
having its tests gate — is filed separately as #877, together with the path-gated-check
problem this work surfaced. #862 asked for the three repos to be fixed and section 7d to
guard the exclusions; both are done here.
