### PR TITLE
fix: stop requiring the translation-freshness audit

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -33,7 +33,7 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues", "lint / Lint Code Base", "audit / Translation freshness"],
+        "contexts": ["check / Check linked issues", "lint / Lint Code Base"],
         "self_contexts": ["Check linked issues", "Lint Code Base"]
       },
       "required_pull_request_reviews": null,
@@ -60,12 +60,6 @@
     },
     "console": {
       "additional_contexts": ["Validate Catalog Schemas"]
-    },
-    "terraform-provider-xcsh": {
-      "excluded_required_contexts": ["audit / Translation freshness"]
-    },
-    "code-review": {
-      "excluded_required_contexts": ["audit / Translation freshness"]
     }
   },
   "topics": [],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, translation-freshness audit) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended** and is no longer part of this gate — see "CI (suspended)" below.
+- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended**, and the translation-freshness audit still runs but no longer gates a merge — see CONTRIBUTING.md.
 
 ## Two review layers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ The `main` branch is protected. The following rules are enforced:
 
 - No direct pushes to `main` — all changes go through PRs
 - No force pushes
-- Required status checks: `Check linked issues`, `Lint Code Base` and `audit / Translation freshness` must pass, plus any repo-specific contexts. The `review / claude-review` check is **suspended** and no longer required
+- Required status checks: `Check linked issues` and `Lint Code Base` must pass, plus any repo-specific contexts. The `review / claude-review` check is **suspended**. `audit / Translation freshness` still runs but **no longer gates a merge**
 - Admin enforcement enabled — these rules apply to everyone
 
 ## AI Assistant Guidelines


### PR DESCRIPTION
Closes #867 — part 1 of 2 of #863, which stays open for PR B.

Each part closes its own issue: the linked-issue gate requires a `Closes #N`, so "Refs #863" failed it. Splitting the issue is the fix rather than borrowing #863's closing link, which would have closed the parent while half the work was still outstanding.

## What

Removes `audit / Translation freshness` from the fleet required status checks. The audit workflow keeps
running and reporting — it just no longer blocks a merge.

**Generation is untouched here.** PR B gates both the `docs-translate` pre-commit hook (the actual
spend) and the audit workflow itself.

## Why two PRs, in this order

`workflows/code-review.yml:51-54` already records the lesson from the reviewer suspension:

> "The `review / claude-review` context was removed from branch protection first (docs-control#833);
> skipping this job while it was still required would have deadlocked every open PR."

The two failure modes are not equally bad:

| If this lands first | Result |
| ------------------- | ------ |
| Workflow gated off while context still required | check never reports → **PRs deadlock**, needs admin intervention |
| Generation off while context still required | audit legitimately fails → red check, **recoverable** by regenerating |

Branch protection and managed files propagate through **separate** fan-outs, so per-repo arrival order
is not guaranteed. Matching #833 → #838.

## Forced extra scope, and it was verified rather than assumed

`tests/test-linter-configs.sh` §7c asserts every `excluded_required_contexts` entry matches a real
required context, because one that matches nothing silently no-ops. Two repos excluded this exact
context, so removing it from the base list breaks that test.

Confirmed by running it before the cleanup:

```
FAIL: 7c.1 every excluded_required_contexts entry matches a real context
      — unmatched: audit / Translation freshness (in repo_overrides.terraform-provider-xcsh)
Results: 117 passed, 1 failed (118 total)
```

After removing the `terraform-provider-xcsh` and `code-review` exclusions: **118 passed, 0 failed**.

Those two exclusions must be re-added along with the base context at restore time, or those repos
silently gain a check they were deliberately exempt from. PR B documents that.

## Codex review

First pass, **confirmed**: my draft documented the end state as already true — it described generation
as off and gated on `TRANSLATIONS_ENABLED`, when this PR changes neither, and it shipped a restore
procedure for a suspension that had not happened. That prose moved to PR B. Second pass: **approve**.

What remains says only what is true now: the audit runs and does not gate.

## Verification

| Check | Result |
| ----- | ------ |
| Predicted test failure | reproduced before the fix (§7c.1), green after |
| Suites | 21/21 pass; `test-linter-configs.sh` 118/118 |
| `pre-commit run --all-files` | all pass |
| JSON | valid; contexts now `["check / Check linked issues", "lint / Lint Code Base"]` |
| textlint | exit 0; canary produced 2 errors, proving the rule was live |
| markdownlint | 0 issues |
| `CLAUDE.md` size | 7,446 bytes, inside the 8,500 budget from #855 |
| Codex | 1 confirmed finding, fixed; final verdict **approve** |

## Post-merge, before PR B

Confirm branch protection actually updated on a sample of governed repos:

```bash
gh api repos/f5-sales-demo/<repo>/branches/main/protection \
  --jq '.required_status_checks.contexts'
```

PR B does not start until that is confirmed — that ordering is the whole point of splitting these.

## Adjacent defect, surfaced not fixed

`tests/test-linter-configs.sh` §7c resolves the owning repo with `head -1`, so when two repos share an
unmatched exclusion it names the first one twice (visible in the failure output above — both lines say
`terraform-provider-xcsh`, but one was `code-review`). Cosmetic, in a pre-existing test, and it made
this failure harder to read than it needed to be. Happy to fix separately.
