### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-30T05:15:35Z",
-  "source_commit": "a1b4f443a4e02d50b4d72dd17df1ea9dea3e4460",
+  "generated_at": "2026-07-30T17:55:19Z",
+  "source_commit": "f0d2d9184d12f48f3f755d940b9b55b222ca5b29",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,14 +65,14 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "50426dfc497d147bae5e5761766e3d6277ee709b",
-      "size": 28501
+      "sha": "ac10e66f062c535f2564662a3f4f5522e0609523",
+      "size": 28521
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "e5702709e0c5e574d0fa84f8fdbeedaa577eb777",
-      "size": 7441
+      "sha": "7b014b79366f1082ffc16dbb0f80ee6d3d46b314",
+      "size": 7446
     },
     ".editorconfig": {
       "src": ".editorconfig",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.