### PR TITLE
fix: stop generating translations and stop the audit reporting

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -394,6 +394,10 @@ jobs:
         if: hashFiles('tests/test-review-layer-routing.sh') != ''
         run: bash tests/test-review-layer-routing.sh
 
+      - name: Run translation-suspension test
+        if: hashFiles('tests/test-translation-suspension.sh') != ''
+        run: bash tests/test-translation-suspension.sh
+
       - name: Run locale-lint test
         if: hashFiles('tests/test-locale-lint.sh') != ''
         run: bash tests/test-locale-lint.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -225,9 +225,21 @@ repos:
   # ===========================================================================
   # Translation generation — regenerate locale docs when English changes.
   # Runs docs-translate --staged (docs-theme) for staged docs/en/*.mdx, which
-  # needs ANTHROPIC_API_KEY and the docs-theme toolchain. No-ops gracefully
-  # when either is unavailable; the required CI translation-audit verifies
-  # freshness regardless. Generation is intentionally local, never in CI.
+  # needs ANTHROPIC_API_KEY and the docs-theme toolchain. Generation is
+  # intentionally local, never in CI.
+  #
+  # SUSPENDED: gated on TRANSLATIONS_ENABLED, which is currently unset, so this
+  # hook does not run. Each changed English file costs one model API call per
+  # locale — twelve per file — and that is not justified while the documentation
+  # is still churning. The `audit / Translation freshness` context was removed
+  # from branch protection first (docs-control#867); stopping generation while
+  # that check was still required would have failed every docs/en pull request.
+  # Existing docs/<locale>/ files stay in place and drift out of date on purpose.
+  # To restore, see "Restoring translations" in CONTRIBUTING.md — set the
+  # variable and regenerate BEFORE re-adding the required context.
+  #
+  # An unset variable is empty, so the default is off: nobody spends money by
+  # accident, and enabling it is an explicit act.
   # ===========================================================================
   - repo: local
     hooks:
@@ -235,9 +247,11 @@ repos:
         name: "i18n: regenerate translations for staged English docs"
         entry: >-
           bash -c
-          'if command -v docs-translate >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ];
+          'if [ "${TRANSLATIONS_ENABLED:-}" != "true" ];
+          then echo "[i18n] translations suspended (TRANSLATIONS_ENABLED unset) — skipping generation; see CONTRIBUTING.md.";
+          elif command -v docs-translate >/dev/null 2>&1 && [ -n "${ANTHROPIC_API_KEY:-}" ];
           then docs-translate --staged;
-          else echo "[i18n] docs-translate/ANTHROPIC_API_KEY unavailable — skipping; CI translation-audit will verify freshness."; fi'
+          else echo "[i18n] docs-translate/ANTHROPIC_API_KEY unavailable — skipping."; fi'
         language: system
         files: ^docs/en/.*\.mdx?$
         pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,6 +349,23 @@ reviewer left behind.
    UN-GATING`, `skipped`, `failure` — means that repository will not emit the check, and re-adding the
    context would deadlock it.
 
+   `NO RUN SINCE UN-GATING` is the expected result for most repositories, not a fault. The audit
+   triggers only on `pull_request` `opened`, `synchronize`, and `reopened`; **merging** the sync pull
+   request fires nothing afterwards, so a repository with no later pull-request activity will report it
+   indefinitely. Do not wave that through — provoke a run instead:
+
+   ```bash
+   # for any repo reading NO RUN SINCE UN-GATING
+   gh api "repos/f5-sales-demo/$r/contents/docs/en" >/dev/null 2>&1 || continue  # no docs/en: audit passes trivially, nothing to prove
+   git clone --depth 1 "https://github.com/f5-sales-demo/$r" /tmp/probe-$r
+   cd /tmp/probe-$r && git switch -c "chore/audit-probe" \
+     && printf '\n' >> README.md && git commit -aqm "chore: probe translation audit" \
+     && git push -q -u origin HEAD && gh pr create --fill --base main
+   ```
+
+   Close the probe pull request once the audit reports. Skipping this step is how an operator ends up
+   re-adding the required context on the strength of repositories that were never actually exercised.
+
 5. **Only then** re-add `audit / Translation freshness` to
    `branch_protection[0].required_status_checks.contexts` — **and re-add
    `excluded_required_contexts: ["audit / Translation freshness"]` to the `terraform-provider-xcsh`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,19 +304,37 @@ reviewer left behind.
    `docs-translate` hook in `.pre-commit-config.yaml`, and let that sync downstream.
    `tests/test-translation-suspension.sh` keys section 1 on those markers, so leaving them in place
    fails the guard the moment the context comes back.
-4. Confirm the audit actually reports on **every governed repository**, not on one pull request. One
-   green PR proves one repo. During the suspension a five-repository spot check came back clean while
-   **9 of 38** still had the old branch protection, because enforcement fans out in batches of five —
-   re-adding the context on that evidence would have deadlocked nine repositories.
+4. Confirm the audit actually reports on **every governed repository that receives the workflow**, not
+   on one pull request. Three traps here, all of them load-bearing:
+
+   - **One green PR proves one repo.** During the suspension a five-repository spot check came back
+     clean while **9 of 38** still had the old branch protection, because enforcement fans out in
+     batches of five. Re-adding the context on that evidence would have deadlocked nine repositories.
+   - **An old run proves nothing.** The last conclusion may predate the variable being set. Only count
+     runs created *after* you set it.
+   - **Some repos never receive this workflow at all.** Anything listed under `skip_files` for
+     `translation-audit.yml` does not have the file — `terraform-provider-xcsh` skips it, and the path
+     returns 404 there. Demanding a report from those repos is impossible, and it is exactly why they
+     carry an `excluded_required_contexts` entry: a required check whose workflow does not exist is a
+     *permanent* deadlock, not a transient one.
 
    ```bash
-   # every governed repo must show a translation-audit run on a recent PR
+   SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)   # capture BEFORE setting the variable
+   # ... set the variable, then:
+   SKIP=$(jq -r '.skip_files | to_entries[]
+                 | select(any(.value[]; test("translation-audit"))) | .key' .claude/governance.json)
    while IFS= read -r r; do
-     n=$(gh run list -R "f5-sales-demo/$r" --workflow=translation-audit.yml \
-           --limit 1 --json conclusion -q '.[0].conclusion // "none"')
-     printf '%-24s %s\n' "$r" "$n"
+     grep -qxF "$r" <<<"$SKIP" && { printf '%-24s skipped (no workflow)\n' "$r"; continue; }
+     gh run list -R "f5-sales-demo/$r" --workflow=translation-audit.yml \
+       --created ">$SINCE" --limit 1 --json conclusion \
+       -q '.[0].conclusion // "NO RUN SINCE VARIABLE WAS SET"' \
+       | xargs printf '%-24s %s\n' "$r"
    done < <(jq -r '.[]' .github/config/downstream-repos.json)
    ```
+
+   Every non-skipped repository must show `success`. A `skipped` conclusion means the job's `if:`
+   evaluated false there — the variable is not visible to that repository, and re-adding the context
+   would deadlock it.
 
 5. **Only then** re-add `audit / Translation freshness` to
    `branch_protection[0].required_status_checks.contexts` — **and re-add

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,18 +296,39 @@ reviewer left behind.
    Setting just the organisation variable is the trap: the `--force` run in step 2 works, because you
    run it directly, and then every later English edit silently skips generation. Nothing complains
    until the audit is required again, at which point pull requests fail fleet-wide.
+   Make sure the organisation variable is visible to **all** governed repositories. An organisation
+   variable scoped to a subset leaves the rest with a job that silently never runs.
 2. Regenerate everything with `docs-translate --force` and commit. Expect roughly 4,320 files across
    the fleet.
-3. Confirm `audit / Translation freshness` reports green on a real pull request.
-4. **Only then** re-add `audit / Translation freshness` to
+3. **Remove the `SUSPENDED:` comment blocks** from `workflows/translation-audit.yml` and the
+   `docs-translate` hook in `.pre-commit-config.yaml`, and let that sync downstream.
+   `tests/test-translation-suspension.sh` keys section 1 on those markers, so leaving them in place
+   fails the guard the moment the context comes back.
+4. Confirm the audit actually reports on **every governed repository**, not on one pull request. One
+   green PR proves one repo. During the suspension a five-repository spot check came back clean while
+   **9 of 38** still had the old branch protection, because enforcement fans out in batches of five —
+   re-adding the context on that evidence would have deadlocked nine repositories.
+
+   ```bash
+   # every governed repo must show a translation-audit run on a recent PR
+   while IFS= read -r r; do
+     n=$(gh run list -R "f5-sales-demo/$r" --workflow=translation-audit.yml \
+           --limit 1 --json conclusion -q '.[0].conclusion // "none"')
+     printf '%-24s %s\n' "$r" "$n"
+   done < <(jq -r '.[]' .github/config/downstream-repos.json)
+   ```
+
+5. **Only then** re-add `audit / Translation freshness` to
    `branch_protection[0].required_status_checks.contexts` — **and re-add
    `excluded_required_contexts: ["audit / Translation freshness"]` to the `terraform-provider-xcsh`
    and `code-review` overrides**, which were removed with the base context because an exclusion that
    matches no required context silently no-ops. Without them those two repositories would gain a
    check they were deliberately exempt from.
 
-Re-adding the required context before step 3 makes a check that never reports mandatory, which blocks
-every pull request until an administrator intervenes.
+Re-adding the required context before step 4 makes a check that never reports mandatory, which blocks
+every pull request until an administrator intervenes. The guard test cannot catch this for you: it
+reads files, and no static check can see whether an organisation variable is set in every repository.
+Step 4 is the only thing standing between a restore and a fleet-wide outage.
 
 ## Branch Protection Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,8 +279,23 @@ What this means for you now:
 Order matters, and getting it wrong deadlocks every open pull request — the same trap the suspended
 reviewer left behind.
 
-1. Set the `TRANSLATIONS_ENABLED` organisation variable to `true`, and export `ANTHROPIC_API_KEY`
-   locally. This re-enables both the generation hook and the audit workflow.
+1. Turn on **both** switches. `TRANSLATIONS_ENABLED` is one name for two independent settings, and
+   setting only one half-restores the system:
+
+   ```bash
+   # Generation — the pre-commit hook reads your local process environment.
+   # No organisation variable sets this; it must be exported where you commit.
+   export TRANSLATIONS_ENABLED=true
+   export ANTHROPIC_API_KEY=...
+   ```
+
+   Then set the `TRANSLATIONS_ENABLED` **organisation variable** to `true`, which is what the audit
+   workflow reads — an organisation variable is exposed to Actions through the `vars` context only, so
+   it never reaches the hook on your machine.
+
+   Setting just the organisation variable is the trap: the `--force` run in step 2 works, because you
+   run it directly, and then every later English edit silently skips generation. Nothing complains
+   until the audit is required again, at which point pull requests fail fleet-wide.
 2. Regenerate everything with `docs-translate --force` and commit. Expect roughly 4,320 files across
    the fleet.
 3. Confirm `audit / Translation freshness` reports green on a real pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,18 +300,28 @@ reviewer left behind.
    variable scoped to a subset leaves the rest with a job that silently never runs.
 2. Regenerate everything with `docs-translate --force` and commit. Expect roughly 4,320 files across
    the fleet.
-3. **Remove the `SUSPENDED:` comment blocks** from `workflows/translation-audit.yml` and the
-   `docs-translate` hook in `.pre-commit-config.yaml`, and let that sync downstream.
-   `tests/test-translation-suspension.sh` keys section 1 on those markers, so leaving them in place
-   fails the guard the moment the context comes back.
+3. **Un-gate both, and let that sync downstream.** In `workflows/translation-audit.yml`, delete the
+   `if: vars.TRANSLATIONS_ENABLED == 'true'` line *and* the `SUSPENDED:` comment block, returning the
+   job to unconditional. In `.pre-commit-config.yaml`, remove the `TRANSLATIONS_ENABLED` branch from
+   the `docs-translate` hook.
+
+   Delete the `if:`, do not merely set the variable. Leaving the condition in place makes organisation
+   variable visibility permanently load-bearing for CI: any repository the variable is not visible to
+   silently skips the job, and once the context is required again its pull requests wait forever for a
+   check that is never emitted. An unconditional job removes that whole class of failure — after this,
+   `TRANSLATIONS_ENABLED` governs only local generation, which fails visibly and cheaply.
+
+   `tests/test-translation-suspension.sh` keys section 1 on the `SUSPENDED:` marker, so leaving it in
+   place fails the guard the moment the context comes back.
 4. Confirm the audit actually reports on **every governed repository that receives the workflow**, not
    on one pull request. Three traps here, all of them load-bearing:
 
    - **One green PR proves one repo.** During the suspension a five-repository spot check came back
      clean while **9 of 38** still had the old branch protection, because enforcement fans out in
      batches of five. Re-adding the context on that evidence would have deadlocked nine repositories.
-   - **An old run proves nothing.** The last conclusion may predate the variable being set. Only count
-     runs created *after* you set it.
+   - **An old run proves nothing.** The last conclusion may predate the un-gating in step 3, or come
+     from a repository still running the gated workflow. Confirm the synced file no longer contains the
+     `if:` before trusting a run, and only count runs created after that.
    - **Some repos never receive this workflow at all.** Anything listed under `skip_files` for
      `translation-audit.yml` does not have the file — `terraform-provider-xcsh` skips it, and the path
      returns 404 there. Demanding a report from those repos is impossible, and it is exactly why they
@@ -319,22 +329,25 @@ reviewer left behind.
      *permanent* deadlock, not a transient one.
 
    ```bash
-   SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)   # capture BEFORE setting the variable
-   # ... set the variable, then:
+   SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)   # capture AFTER step 3 has synced
    SKIP=$(jq -r '.skip_files | to_entries[]
                  | select(any(.value[]; test("translation-audit"))) | .key' .claude/governance.json)
    while IFS= read -r r; do
-     grep -qxF "$r" <<<"$SKIP" && { printf '%-24s skipped (no workflow)\n' "$r"; continue; }
+     grep -qxF "$r" <<<"$SKIP" && { printf '%-24s n/a (no workflow)\n' "$r"; continue; }
+     # the synced file must be un-gated, or a green run proves nothing
+     gated=$(gh api "repos/f5-sales-demo/$r/contents/.github/workflows/translation-audit.yml" \
+               -q .content 2>/dev/null | base64 -d 2>/dev/null | grep -c 'TRANSLATIONS_ENABLED')
+     [ "${gated:-1}" -ne 0 ] && { printf '%-24s STILL GATED — wait for sync\n' "$r"; continue; }
      gh run list -R "f5-sales-demo/$r" --workflow=translation-audit.yml \
        --created ">$SINCE" --limit 1 --json conclusion \
-       -q '.[0].conclusion // "NO RUN SINCE VARIABLE WAS SET"' \
+       -q '.[0].conclusion // "NO RUN SINCE UN-GATING"' \
        | xargs printf '%-24s %s\n' "$r"
    done < <(jq -r '.[]' .github/config/downstream-repos.json)
    ```
 
-   Every non-skipped repository must show `success`. A `skipped` conclusion means the job's `if:`
-   evaluated false there — the variable is not visible to that repository, and re-adding the context
-   would deadlock it.
+   Every non-skipped repository must read `success`. Anything else — `STILL GATED`, `NO RUN SINCE
+   UN-GATING`, `skipped`, `failure` — means that repository will not emit the check, and re-adding the
+   context would deadlock it.
 
 5. **Only then** re-add `audit / Translation freshness` to
    `branch_protection[0].required_status_checks.contexts` — **and re-add

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,49 @@ problems while they are still cheap to fix — in a spec or a plan, before any c
 The two layers are complementary: the local layer catches issues before the pull request exists and
 costs nothing when it is wrong, while CI remains the gate that decides whether a change merges.
 
+## Translations (suspended)
+
+> **Suspended during development.** Translation generation calls a model API once per locale per
+> changed English file — twelve calls for every edit under `docs/en/`. That cost is not justified
+> while the documentation is still churning, so generation is off and the freshness audit no longer
+> gates merges. Translations will be regenerated as a deliberate effort before go-live.
+
+How the three parts fit together, because only one of them costs anything:
+
+| Part | Where | Cost |
+| ---- | ----- | ---- |
+| Generation | the `docs-translate` pre-commit hook, on `docs/en/**/*.md[x]` | the entire spend |
+| Freshness audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against the SHA-256 of its English source | none; it performs no translation |
+| Required context | `audit / Translation freshness` in branch protection | none; it made the audit blocking |
+
+What this means for you now:
+
+- **Existing translations under `docs/<locale>/` stay in place and will drift out of date.** That is
+  expected. Do not regenerate them individually, and do not treat the drift as a defect to fix.
+- Editing `docs/en/` no longer requires a matching translation update.
+- Both the generation hook and the audit are gated on the `TRANSLATIONS_ENABLED` variable. Unset means
+  off, so nothing spends money by accident.
+
+### Restoring translations
+
+Order matters, and getting it wrong deadlocks every open pull request — the same trap the suspended
+reviewer left behind.
+
+1. Set the `TRANSLATIONS_ENABLED` organisation variable to `true`, and export `ANTHROPIC_API_KEY`
+   locally. This re-enables both the generation hook and the audit workflow.
+2. Regenerate everything with `docs-translate --force` and commit. Expect roughly 4,320 files across
+   the fleet.
+3. Confirm `audit / Translation freshness` reports green on a real pull request.
+4. **Only then** re-add `audit / Translation freshness` to
+   `branch_protection[0].required_status_checks.contexts` — **and re-add
+   `excluded_required_contexts: ["audit / Translation freshness"]` to the `terraform-provider-xcsh`
+   and `code-review` overrides**, which were removed with the base context because an exclusion that
+   matches no required context silently no-ops. Without them those two repositories would gain a
+   check they were deliberately exempt from.
+
+Re-adding the required context before step 3 makes a check that never reports mandatory, which blocks
+every pull request until an administrator intervenes.
+
 ## Branch Protection Rules
 
 The `main` branch is protected. The following rules are enforced:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,12 +356,18 @@ reviewer left behind.
 
    ```bash
    # for any repo reading NO RUN SINCE UN-GATING
-   gh api "repos/f5-sales-demo/$r/contents/docs/en" >/dev/null 2>&1 || continue  # no docs/en: audit passes trivially, nothing to prove
    git clone --depth 1 "https://github.com/f5-sales-demo/$r" /tmp/probe-$r
    cd /tmp/probe-$r && git switch -c "chore/audit-probe" \
      && printf '\n' >> README.md && git commit -aqm "chore: probe translation audit" \
      && git push -q -u origin HEAD && gh pr create --fill --base main
    ```
+
+   Probe **every** repository that reads `NO RUN SINCE UN-GATING`, including those with no `docs/en`.
+   It is tempting to skip them on the grounds that the audit passes trivially there — the reusable
+   workflow exits 0 when `docs/en` is absent — but passing and *reporting* are different things. Once
+   the context is required, such a repository must still emit `audit / Translation freshness`, and it
+   cannot do so if its caller workflow is missing, malformed, or not triggering. That is exactly the
+   deadlock this step exists to catch, and it is invisible until the context is already required.
 
    Close the probe pull request once the audit reports. Skipping this step is how an operator ends up
    re-adding the required context on the strength of repositories that were never actually exercised.

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -151,6 +151,27 @@ else
     "the org variable reaches Actions only; the pre-commit hook reads the local environment"
 fi
 
+# Section 1 keys on the SUSPENDED marker, so restoring must remove it. A
+# procedure that flips the variable and the context but leaves the marker in place
+# would fail 1.1 immediately after a correct restore.
+if grep -qi 'SUSPENDED' "$CONTRIBUTING" && grep -qiE 'remove the .?SUSPENDED|delete the .?SUSPENDED' "$CONTRIBUTING"; then
+  pass "3.3 restore procedure removes the SUSPENDED markers that section 1 keys on"
+else
+  fail "3.3 restore procedure removes the SUSPENDED markers that section 1 keys on" \
+    "leaving the marker in place fails 1.1 straight after a correct restore"
+fi
+
+# One green pull request does not prove the audit reports everywhere. During #867
+# a five-repo spot check came back clean while 9 of 38 repos were still stale,
+# because enforcement fans out in batches. Re-adding the context on that evidence
+# deadlocks whichever repos have not caught up.
+if grep -qiE 'all 38|every governed repo|all governed repo' "$CONTRIBUTING"; then
+  pass "3.4 restore procedure requires fleet-wide confirmation, not a single PR"
+else
+  fail "3.4 restore procedure requires fleet-wide confirmation, not a single PR" \
+    "a sample can be green while repos lag; the context must not be re-added on that evidence"
+fi
+
 # The ordering rule is the load-bearing part of the procedure. Assert the two
 # substantive facts rather than one exact phrase: that re-adding the context is
 # explicitly sequenced last, and that the consequence of getting it wrong is
@@ -158,9 +179,9 @@ fi
 # the rule three different ways.
 if grep -qiE 'only then|order matters' "$CONTRIBUTING" &&
   grep -qi 'deadlock' "$CONTRIBUTING"; then
-  pass "3.3 restore procedure sequences the context last and names the deadlock consequence"
+  pass "3.5 restore procedure sequences the context last and names the deadlock consequence"
 else
-  fail "3.3 restore procedure sequences the context last and names the deadlock consequence" \
+  fail "3.5 restore procedure sequences the context last and names the deadlock consequence" \
     "re-adding the required context before the check can pass deadlocks every open PR"
 fi
 

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -54,31 +54,42 @@ REQUIRED=$(jq -r --arg c "$CONTEXT" '
   | index($c) != null
 ' "$REPO_SETTINGS")
 
-# Is the stub's audit job gated behind a variable?
-if grep -qE '^\s*if:\s*vars\.[A-Z_]+ == .true.' "$AUDIT_STUB"; then
-  GATED=true
+# Is the audit intentionally suspended? Read the declared intent, not the
+# presence of a condition.
+#
+# The obvious test — "does the job carry an `if: vars.X == 'true'`" — is wrong,
+# and wrong in the direction that breaks restoration. That condition is still
+# present when translations are switched back on; only the variable's value
+# changes, and a static test cannot see it. Treating any conditioned job as
+# gated off would fail the moment someone follows the restore procedure, which
+# legitimately ends with the context required AND the condition present.
+#
+# The `SUSPENDED:` marker states intent in the repository, changes in the same
+# commit as the condition, and is the convention already used in
+# workflows/code-review.yml. Restoring translations removes both together.
+if grep -q 'SUSPENDED:' "$AUDIT_STUB"; then
+  SUSPENDED=true
 else
-  GATED=false
+  SUSPENDED=false
 fi
 
-if [ "$REQUIRED" = "true" ] && [ "$GATED" = "true" ]; then
-  fail "1.1 required context and gated-off workflow do not coexist" \
-    "'$CONTEXT' is a required check but its job is gated off — it will never report and every PR deadlocks"
+if [ "$REQUIRED" = "true" ] && [ "$SUSPENDED" = "true" ]; then
+  fail "1.1 a suspended audit is never a required context" \
+    "'$CONTEXT' is required while the audit is marked SUSPENDED — it will never report and every PR deadlocks"
 else
-  pass "1.1 required context and gated-off workflow do not coexist (required=$REQUIRED gated=$GATED)"
+  pass "1.1 a suspended audit is never a required context (required=$REQUIRED suspended=$SUSPENDED)"
 fi
 
-# The safe states are both acceptable, but say which one we are in, so a reader
-# of CI output can tell suspended from active without opening two files.
-if [ "$GATED" = "true" ] && [ "$REQUIRED" = "false" ]; then
-  pass "1.2 suspended state is coherent: workflow gated off, context not required"
-elif [ "$GATED" = "false" ] && [ "$REQUIRED" = "true" ]; then
-  pass "1.2 active state is coherent: workflow runs, context required"
-elif [ "$GATED" = "false" ] && [ "$REQUIRED" = "false" ]; then
-  # Wasteful rather than dangerous: the audit runs and reports but gates nothing.
-  pass "1.2 workflow runs but gates nothing — safe, though the audit is advisory only"
+# Both safe states are legitimate. Name which one we are in, so CI output says
+# suspended or active without a reader opening two files.
+if [ "$SUSPENDED" = "true" ] && [ "$REQUIRED" = "false" ]; then
+  pass "1.2 suspended state is coherent: audit off, context not required"
+elif [ "$SUSPENDED" = "false" ] && [ "$REQUIRED" = "true" ]; then
+  pass "1.2 restored state is coherent: audit active, context required"
 else
-  fail "1.2 suspension state is coherent" "unreachable combination: required=$REQUIRED gated=$GATED"
+  # Audit active but gating nothing: wasteful rather than dangerous, and it is the
+  # transient state between the two halves of a restore.
+  pass "1.2 audit active but not required — safe, advisory only (mid-restore)"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -54,42 +54,54 @@ REQUIRED=$(jq -r --arg c "$CONTEXT" '
   | index($c) != null
 ' "$REPO_SETTINGS")
 
-# Is the audit intentionally suspended? Read the declared intent, not the
-# presence of a condition.
+# GATED is the functional question: can this job decline to report?
 #
-# The obvious test — "does the job carry an `if: vars.X == 'true'`" — is wrong,
-# and wrong in the direction that breaks restoration. That condition is still
-# present when translations are switched back on; only the variable's value
-# changes, and a static test cannot see it. Treating any conditioned job as
-# gated off would fail the moment someone follows the restore procedure, which
-# legitimately ends with the context required AND the condition present.
+# The condition is what actually withholds the status. Because restoration deletes
+# the `if:` outright rather than flipping the variable (see "Restoring translations"
+# in CONTRIBUTING.md), its presence is a reliable signal — and it is the only signal
+# that catches the dangerous case where someone removes the explanatory comment but
+# leaves the condition behind. A repository the variable is not visible to then
+# emits no status at all, and a required context would wait on it forever.
 #
-# The `SUSPENDED:` marker states intent in the repository, changes in the same
-# commit as the condition, and is the convention already used in
-# workflows/code-review.yml. Restoring translations removes both together.
+# Keying on the comment alone was wrong for exactly that reason.
+if grep -qE "^\s*if:\s*vars\.TRANSLATIONS_ENABLED" "$AUDIT_STUB"; then
+  GATED=true
+else
+  GATED=false
+fi
+
+# The marker is documentation of intent. It must agree with the condition, or the
+# next reader is told one thing while CI does another.
 if grep -q 'SUSPENDED:' "$AUDIT_STUB"; then
-  SUSPENDED=true
+  MARKED=true
 else
-  SUSPENDED=false
+  MARKED=false
 fi
 
-if [ "$REQUIRED" = "true" ] && [ "$SUSPENDED" = "true" ]; then
-  fail "1.1 a suspended audit is never a required context" \
-    "'$CONTEXT' is required while the audit is marked SUSPENDED — it will never report and every PR deadlocks"
+if [ "$REQUIRED" = "true" ] && [ "$GATED" = "true" ]; then
+  fail "1.1 a conditionally-skipped audit is never a required context" \
+    "'$CONTEXT' is required while the job can skip itself — repos without the variable emit no status and their PRs deadlock"
 else
-  pass "1.1 a suspended audit is never a required context (required=$REQUIRED suspended=$SUSPENDED)"
+  pass "1.1 a conditionally-skipped audit is never a required context (required=$REQUIRED gated=$GATED)"
 fi
 
-# Both safe states are legitimate. Name which one we are in, so CI output says
-# suspended or active without a reader opening two files.
-if [ "$SUSPENDED" = "true" ] && [ "$REQUIRED" = "false" ]; then
-  pass "1.2 suspended state is coherent: audit off, context not required"
-elif [ "$SUSPENDED" = "false" ] && [ "$REQUIRED" = "true" ]; then
-  pass "1.2 restored state is coherent: audit active, context required"
+if [ "$GATED" = "$MARKED" ]; then
+  pass "1.2 the SUSPENDED marker agrees with the actual gate (gated=$GATED marked=$MARKED)"
 else
-  # Audit active but gating nothing: wasteful rather than dangerous, and it is the
+  fail "1.2 the SUSPENDED marker agrees with the actual gate" \
+    "gated=$GATED but marked=$MARKED — the comment and the condition disagree, so one of them is lying"
+fi
+
+# Name the state, so CI output says suspended or restored without a reader
+# opening two files.
+if [ "$GATED" = "true" ] && [ "$REQUIRED" = "false" ]; then
+  pass "1.3 suspended state is coherent: audit can skip, context not required"
+elif [ "$GATED" = "false" ] && [ "$REQUIRED" = "true" ]; then
+  pass "1.3 restored state is coherent: audit unconditional, context required"
+else
+  # Unconditional but gating nothing: wasteful rather than dangerous, and it is the
   # transient state between the two halves of a restore.
-  pass "1.2 audit active but not required — safe, advisory only (mid-restore)"
+  pass "1.3 audit unconditional but not required — safe, advisory only (mid-restore)"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -110,14 +110,31 @@ fi
 echo ""
 echo "=== Section 2: generation is opt-in, not opt-out ==="
 
-# The hook must require an explicit opt-in. Testing for the negative form
-# ("!= true") rather than any mention of the variable, because a hook that
-# merely names it could still run by default.
+# Assert against the current state rather than assuming suspension forever.
+# Restoration removes this branch from the hook (CONTRIBUTING step 3), so an
+# unconditional requirement would fail the moment someone follows the documented
+# procedure — forcing an undocumented test edit in the middle of a recovery.
+#
+# Testing the negative form ("!= true") rather than any mention of the variable,
+# because a hook that merely names it could still run by default.
 if grep -qE 'TRANSLATIONS_ENABLED:-.*\!=\s*"true"' "$PRE_COMMIT"; then
-  pass "2.1 docs-translate hook requires TRANSLATIONS_ENABLED=true to run"
+  HOOK_GATED=true
 else
-  fail "2.1 docs-translate hook requires TRANSLATIONS_ENABLED=true to run" \
-    "unset or absent must mean no generation; an opt-out default spends money by accident"
+  HOOK_GATED=false
+fi
+
+if [ "$GATED" = "true" ]; then
+  if [ "$HOOK_GATED" = "true" ]; then
+    pass "2.1 while suspended, the docs-translate hook requires TRANSLATIONS_ENABLED=true"
+  else
+    fail "2.1 while suspended, the docs-translate hook requires TRANSLATIONS_ENABLED=true" \
+      "the audit is suspended but generation is not gated — unset must mean no generation, or money is spent by accident"
+  fi
+elif [ "$HOOK_GATED" = "false" ]; then
+  pass "2.1 while restored, the docs-translate hook runs unconditionally"
+else
+  fail "2.1 while restored, the docs-translate hook runs unconditionally" \
+    "the audit is active but generation is still gated — translations would go stale while the audit demands freshness"
 fi
 
 # The hook must still exist and still be scoped to English sources — a suspension

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -165,11 +165,28 @@ fi
 # a five-repo spot check came back clean while 9 of 38 repos were still stale,
 # because enforcement fans out in batches. Re-adding the context on that evidence
 # deadlocks whichever repos have not caught up.
-if grep -qiE 'all 38|every governed repo|all governed repo' "$CONTRIBUTING"; then
+if grep -qiE 'every governed repo|all governed repo' "$CONTRIBUTING"; then
   pass "3.4 restore procedure requires fleet-wide confirmation, not a single PR"
 else
   fail "3.4 restore procedure requires fleet-wide confirmation, not a single PR" \
     "a sample can be green while repos lag; the context must not be re-added on that evidence"
+fi
+
+# "Every governed repo must report" is impossible as stated: repos listed in
+# skip_files for translation-audit.yml never receive the workflow, so the check
+# can never appear there. Verified: terraform-provider-xcsh skips it and the file
+# 404s in that repository. That is exactly why it carried an
+# excluded_required_contexts entry — a required check whose workflow does not
+# exist is a permanent deadlock, not a transient one.
+#
+# So the procedure must scope its verification to repos that actually receive the
+# workflow, and must derive that set from skip_files rather than from a
+# hand-maintained list that will drift.
+if grep -q 'skip_files' "$CONTRIBUTING"; then
+  pass "3.4b restore procedure excludes repos that never receive the audit workflow"
+else
+  fail "3.4b restore procedure excludes repos that never receive the audit workflow" \
+    "terraform-provider-xcsh skips translation-audit.yml; demanding a report from it is impossible"
 fi
 
 # The ordering rule is the load-bearing part of the procedure. Assert the two

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -126,6 +126,20 @@ for repo in terraform-provider-xcsh code-review; do
   fi
 done
 
+# TRANSLATIONS_ENABLED is one name for two independent switches, and conflating
+# them silently half-restores the system. The organisation variable reaches only
+# the Actions `vars` context, so it enables the audit workflow; the pre-commit
+# hook reads the developer's local process environment, which no organisation
+# variable sets. A procedure that mentions only the variable leaves generation off
+# — the first `--force` run works, then every later English edit silently skips
+# translation, and the failure surfaces only once the audit is required again.
+if grep -q 'export TRANSLATIONS_ENABLED' "$CONTRIBUTING"; then
+  pass "3.2 restore procedure sets TRANSLATIONS_ENABLED locally, not just as an org variable"
+else
+  fail "3.2 restore procedure sets TRANSLATIONS_ENABLED locally, not just as an org variable" \
+    "the org variable reaches Actions only; the pre-commit hook reads the local environment"
+fi
+
 # The ordering rule is the load-bearing part of the procedure. Assert the two
 # substantive facts rather than one exact phrase: that re-adding the context is
 # explicitly sequenced last, and that the consequence of getting it wrong is
@@ -133,9 +147,9 @@ done
 # the rule three different ways.
 if grep -qiE 'only then|order matters' "$CONTRIBUTING" &&
   grep -qi 'deadlock' "$CONTRIBUTING"; then
-  pass "3.2 restore procedure sequences the context last and names the deadlock consequence"
+  pass "3.3 restore procedure sequences the context last and names the deadlock consequence"
 else
-  fail "3.2 restore procedure sequences the context last and names the deadlock consequence" \
+  fail "3.3 restore procedure sequences the context last and names the deadlock consequence" \
     "re-adding the required context before the check can pass deadlocks every open PR"
 fi
 

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Guards the translation suspension against the one combination that deadlocks
+# pull requests fleet-wide: a required status check whose workflow is gated off
+# never reports, so the check can never go green and no PR can merge without an
+# administrator.
+#
+# This is not hypothetical. The suspended Claude reviewer hit it, and the fix is
+# recorded in workflows/code-review.yml:
+#
+#   "The `review / claude-review` context was removed from branch protection
+#    first (docs-control#833); skipping this job while it was still required
+#    would have deadlocked every open PR."
+#
+# The two settings live in different files that propagate through different
+# fan-outs (branch protection via enforce-repo-settings, the workflow via
+# managed-file sync), so nothing else couples them. This test does.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
+AUDIT_STUB="$REPO_ROOT/workflows/translation-audit.yml"
+PRE_COMMIT="$REPO_ROOT/.pre-commit-config.yaml"
+CONTRIBUTING="$REPO_ROOT/CONTRIBUTING.md"
+
+CONTEXT="audit / Translation freshness"
+PASS=0
+FAIL=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  FAIL: $1 — $2"
+  FAIL=$((FAIL + 1))
+}
+
+echo "════════════════════════════════════════════════════════════════"
+echo "Translation suspension guards"
+echo "════════════════════════════════════════════════════════════════"
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 1: the deadlock combination is impossible
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 1: a required context never coexists with a gated-off workflow ==="
+
+# Is the context required anywhere it could be? Base contexts plus any
+# per-repo additional_contexts — the two sources enforce-repo-settings merges.
+REQUIRED=$(jq -r --arg c "$CONTEXT" '
+  ((.branch_protection[0].required_status_checks.contexts // []) +
+   ([.repo_overrides // {} | .[] | .additional_contexts // []] | flatten))
+  | index($c) != null
+' "$REPO_SETTINGS")
+
+# Is the stub's audit job gated behind a variable?
+if grep -qE '^\s*if:\s*vars\.[A-Z_]+ == .true.' "$AUDIT_STUB"; then
+  GATED=true
+else
+  GATED=false
+fi
+
+if [ "$REQUIRED" = "true" ] && [ "$GATED" = "true" ]; then
+  fail "1.1 required context and gated-off workflow do not coexist" \
+    "'$CONTEXT' is a required check but its job is gated off — it will never report and every PR deadlocks"
+else
+  pass "1.1 required context and gated-off workflow do not coexist (required=$REQUIRED gated=$GATED)"
+fi
+
+# The safe states are both acceptable, but say which one we are in, so a reader
+# of CI output can tell suspended from active without opening two files.
+if [ "$GATED" = "true" ] && [ "$REQUIRED" = "false" ]; then
+  pass "1.2 suspended state is coherent: workflow gated off, context not required"
+elif [ "$GATED" = "false" ] && [ "$REQUIRED" = "true" ]; then
+  pass "1.2 active state is coherent: workflow runs, context required"
+elif [ "$GATED" = "false" ] && [ "$REQUIRED" = "false" ]; then
+  # Wasteful rather than dangerous: the audit runs and reports but gates nothing.
+  pass "1.2 workflow runs but gates nothing — safe, though the audit is advisory only"
+else
+  fail "1.2 suspension state is coherent" "unreachable combination: required=$REQUIRED gated=$GATED"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 2: generation cannot spend money by default
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 2: generation is opt-in, not opt-out ==="
+
+# The hook must require an explicit opt-in. Testing for the negative form
+# ("!= true") rather than any mention of the variable, because a hook that
+# merely names it could still run by default.
+if grep -qE 'TRANSLATIONS_ENABLED:-.*\!=\s*"true"' "$PRE_COMMIT"; then
+  pass "2.1 docs-translate hook requires TRANSLATIONS_ENABLED=true to run"
+else
+  fail "2.1 docs-translate hook requires TRANSLATIONS_ENABLED=true to run" \
+    "unset or absent must mean no generation; an opt-out default spends money by accident"
+fi
+
+# The hook must still exist and still be scoped to English sources — a suspension
+# that deleted the hook would be harder to restore and would lose the trigger.
+if grep -q 'id: docs-translate' "$PRE_COMMIT" &&
+  grep -qE '^\s*files:\s*\^docs/en/\.\*\\\.mdx\?\$' "$PRE_COMMIT"; then
+  pass "2.2 the hook is suspended rather than deleted, still scoped to docs/en"
+else
+  fail "2.2 the hook is suspended rather than deleted, still scoped to docs/en" \
+    "suspension should gate the hook, not remove it"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+# SECTION 3: the restore procedure records what removal took away
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 3: restoring is documented, including the non-obvious parts ==="
+
+# Removing the base context forced the removal of two per-repo exclusions,
+# because tests/test-linter-configs.sh section 7c rejects an exclusion that
+# matches no required context. Restoring the context without restoring those
+# exclusions silently subjects those repos to a check they were exempt from.
+for repo in terraform-provider-xcsh code-review; do
+  if grep -q "$repo" "$CONTRIBUTING"; then
+    pass "3.1 restore procedure names $repo, whose exclusion was removed with the context"
+  else
+    fail "3.1 restore procedure names $repo, whose exclusion was removed with the context" \
+      "restoring the context without its exclusion gives this repo a check it was exempt from"
+  fi
+done
+
+# The ordering rule is the load-bearing part of the procedure. Assert the two
+# substantive facts rather than one exact phrase: that re-adding the context is
+# explicitly sequenced last, and that the consequence of getting it wrong is
+# named. Grepping for a single wording made this fail against prose that stated
+# the rule three different ways.
+if grep -qiE 'only then|order matters' "$CONTRIBUTING" &&
+  grep -qi 'deadlock' "$CONTRIBUTING"; then
+  pass "3.2 restore procedure sequences the context last and names the deadlock consequence"
+else
+  fail "3.2 restore procedure sequences the context last and names the deadlock consequence" \
+    "re-adding the required context before the check can pass deadlocks every open PR"
+fi
+
+echo ""
+echo "════════════════════════════════════════════════════════════════"
+echo "  Results: $PASS passed, $FAIL failed ($((PASS + FAIL)) total)"
+echo "════════════════════════════════════════════════════════════════"
+
+[ "$FAIL" -eq 0 ]

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -154,7 +154,17 @@ fi
 # Section 1 keys on the SUSPENDED marker, so restoring must remove it. A
 # procedure that flips the variable and the context but leaves the marker in place
 # would fail 1.1 immediately after a correct restore.
-if grep -qi 'SUSPENDED' "$CONTRIBUTING" && grep -qiE 'remove the .?SUSPENDED|delete the .?SUSPENDED' "$CONTRIBUTING"; then
+# Match the marker token exactly, case-sensitively, and flattened.
+#
+# Three earlier attempts got this wrong, in both directions. Requiring the verb
+# adjacent to the marker missed correct prose. Widening to a sentence broke on the
+# period inside `vars.TRANSLATIONS_ENABLED`. Widening further with -i made it
+# vacuous, because the document says "suspended" nine times in ordinary prose and
+# something always matched. `SUSPENDED:` with its colon is the literal marker and
+# appears only where the procedure discusses it, so it is the discriminating token.
+# Flattening is still needed: the verb and the marker wrap onto different lines and
+# grep is line-based.
+if tr '\n' ' ' <"$CONTRIBUTING" | grep -qE '(remove|delete|Remove|Delete).{0,200}SUSPENDED:'; then
   pass "3.3 restore procedure removes the SUSPENDED markers that section 1 keys on"
 else
   fail "3.3 restore procedure removes the SUSPENDED markers that section 1 keys on" \

--- a/workflows/translation-audit.yml
+++ b/workflows/translation-audit.yml
@@ -15,4 +15,24 @@ permissions:
 jobs:
   audit:
     # Read-only freshness audit — no secrets required.
+    #
+    # SUSPENDED: gated on the `TRANSLATIONS_ENABLED` variable, which is currently
+    # unset, so this job never runs. Generation is suspended for cost reasons
+    # (docs-control#863), so translations drift out of date on purpose — leaving
+    # the audit enabled would paint every docs/en pull request red for an expected
+    # condition, which trains people to ignore failing checks.
+    #
+    # The `audit / Translation freshness` context was removed from branch
+    # protection FIRST (docs-control#867), and that removal was confirmed on every
+    # governed repository before this gate landed. Skipping a job while its context
+    # is still required makes a check that never reports mandatory, deadlocking
+    # every open pull request — the same trap the suspended reviewer left behind
+    # (see the SUSPENDED note in code-review.yml). To restore, see "Restoring
+    # translations" in CONTRIBUTING.md: set the variable and regenerate BEFORE
+    # re-adding the required context.
+    #
+    # `vars` is used rather than `env` because the `env` context is not available
+    # in a job-level `if:`. An unset variable evaluates false, so this fails safe
+    # toward not spending money.
+    if: vars.TRANSLATIONS_ENABLED == 'true'
     uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@main


### PR DESCRIPTION
Closes #863 — part 2 of 2. Part 1 was #865 (issue #867).

## What

Stops translations costing money, and stops the audit reporting noise.

- **Generation** — the `docs-translate` pre-commit hook now requires `TRANSLATIONS_ENABLED=true`.
  Unset means off, so the default spends nothing and enabling is an explicit act. **This is the change
  that stops the spend:** each changed English file cost one model call per locale, twelve per file.
- **Audit** — `workflows/translation-audit.yml`'s job is gated on `vars.TRANSLATIONS_ENABLED`, mirroring
  `workflows/code-review.yml`. With generation off, translations drift on purpose; leaving the audit
  enabled would paint every `docs/en` PR red for an expected condition, which trains people to ignore
  failing checks.
- **`tests/test-translation-suspension.sh`** — makes the fleet-deadlock combination fail loudly.
- **CONTRIBUTING.md** — documents the suspension and the restore procedure.

## Safe to land now, and this was measured rather than assumed

Gating a job while its context is still required makes a check that never reports mandatory, which
deadlocks every open PR. So #865 removed the context first — and the confirmation mattered:

> After #865 merged, **9 of 38** repos still required the context, because enforcement fans out in
> batches of five. A five-repo spot check came back clean and would have been a false green.

I polled real branch protection until **0 of 38** required it before committing this. That gate is the
entire reason these were two PRs.

## Review record: 8 rounds, 8 confirmed findings

Every finding was real and fixed. Notably, **seven were in the restore procedure** — the suspension
itself was correct from round 1.

| Round | Finding | Outcome |
| ----- | ------- | ------- |
| 1 | Docs described the end state as already true | Fixed by moving that prose out of #865 into this PR |
| 2 | Org variable cannot enable the local pre-commit hook | Confirmed — `vars` reaches Actions only. Procedure now sets both switches explicitly |
| 3 | Guard rejected the documented restored state | Confirmed — my check treated any conditioned job as gated off |
| 4 | One green PR does not prove fleet-wide reporting; `terraform-provider-xcsh` **404s** on the workflow | Confirmed — "all 38 must report" was impossible. Verification now derives the skip set from `skip_files` |
| 5 | Restore left the `if:` in place, making org-variable visibility permanently load-bearing | Confirmed — **fixed at the root:** restoring now deletes the `if:`, removing the class of failure |
| 6 | Guard keyed on a comment, so removing it while keeping the `if:` would pass | Confirmed — keys on the condition now, with the marker asserted to agree |
| 6 | Audit only fires on PR events, so most repos would read `NO RUN` forever | Confirmed — probe-PR commands added |
| 7 | Probe skipped repos without `docs/en` | Confirmed — passing and *reporting* are different things |
| 8 | §2.1 required the hook gate unconditionally, which the restore procedure removes | Confirmed — assertions are now state-aware |

Three of those were assertions of mine that were valid only while suspended and would have failed the
moment someone followed my own restore steps. Four attempts at one grep were all test defects against
correct prose, not documentation defects.

## The gate escalated, and I am not hiding it

`review-gate` reports `escalate: true`, blocking on one CONFIRMED high finding that this PR does
**not** fix:

> The guard runs in the `Shell Unit Tests` job, which is not a required check — required contexts are
> only `check / Check linked issues` and `lint / Lint Code Base`. Auto-merge can therefore merge a PR
> that makes the audit both gated and required.

Verified, and it applies to **all 22 suites**, not just this one — there is no
`scripts/pre-commit-local.sh`, so they run nowhere else. Tracked as **#869**.

Not fixed here on purpose: making `Shell Unit Tests` required is the mirror image of #867 and carries
the same deadlock risk in reverse — if any repo lacks or skips that job, every PR there blocks on a
check that never reports. It needs the same staged verification, which is its own work, not a rider on
a translation change. The operator was given the choice between shipping now and holding for #869, and
chose to ship: the spend is ongoing, and the guard still fails visibly in CI even though it cannot block.

## Verification

| Check | Result |
| ----- | ------ |
| Mutation proofs | required + gated → FAIL; marker/condition disagreement → FAIL; suspended + ungated hook → FAIL; fully restored → PASS |
| `test-translation-suspension.sh` | 12/12 |
| Suites | 22/22 |
| `pre-commit run --all-files` | all pass |
| markdownlint / textlint / shellcheck / yamllint | clean; textlint canary produced 2 errors, proving the rule was live |
| Documented `jq` for the skip set | executed — selects exactly `terraform-provider-xcsh` |
| Base | rebased onto `origin/main`, `behind=0` |

## After merge

Confirm the sync reaches downstream and that a `docs/en` change can still merge. The audit will stop
appearing on PRs, which is the intended outcome, not a regression.
