### PR TITLE
docs: add governed documentation style guide for example values, PII, and secrets

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -29,6 +29,7 @@
     ".github/dependabot.yml",
     "CONTRIBUTING.md",
     "CLAUDE.md",
+    "STYLE_GUIDE.md",
     "README.md",
     ".editorconfig",
     ".gitignore",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -136,6 +136,10 @@
         "dest": "CLAUDE.md"
       },
       {
+        "src": "STYLE_GUIDE.md",
+        "dest": "STYLE_GUIDE.md"
+      },
+      {
         "src": ".editorconfig",
         "dest": ".editorconfig"
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease, pre-production code under active development; make clean-break changes, never add compatibility shims or keep deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
+- **Documentation style** — published content (guides, product documentation, READMEs) follows `STYLE_GUIDE.md`: documentation-reserved example values only (RFC 5737 addresses, `example.com`, RFC 5398 ASNs), never ACME, no credential material even if revoked, no real customer data, and sanitized screenshots. Run its pre-publish checklist before opening a documentation PR.
 - **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, retire your worktree, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches, leftover worktrees) unprompted — see CONTRIBUTING.md for the safe procedure.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -501,6 +501,17 @@ apply what fits.
 
 - Reuse existing code, patterns, and content before adding new. Do not duplicate.
 
+### Documentation content
+
+- Published content — blog articles, how-to guides, demo guides, product documentation, and
+  README files — follows `STYLE_GUIDE.md`, a managed file synced across the fleet.
+- Examples use only identifiers reserved for documentation (RFC 5737 addresses, `example.com`,
+  RFC 5398 ASNs), so content a reader copies cannot reach infrastructure we do not own. Never
+  publish credential material — including revoked or expired material — real customer data, or
+  an unsanitized screenshot.
+- Work that guide's pre-publish checklist before opening a documentation PR, and treat its
+  detection commands as a first pass rather than proof.
+
 ### Clean branches
 
 - A branch is for trial-and-error: guess, probe, refactor, and learn freely while you

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,302 @@
+# Documentation Style Guide
+
+Conventions for every piece of published content this fleet produces: blog articles, how-to
+guides, demo guides, lab walkthroughs, product documentation, README files, code comments, and
+conference material.
+
+This is a **managed file** owned by docs-control and synced to every downstream repository. Do
+not edit it in a downstream repo — a hook blocks it. To change a rule, open an issue in
+docs-control and the change propagates fleet-wide. See `CONTRIBUTING.md`.
+
+Two goals, in priority order:
+
+1. **Nothing in an example can cause harm if a reader copies and pastes it.** No traffic sent to
+   infrastructure we do not own, no live credentials, no real customer data.
+2. **Examples are consistent, so a reader learns the pattern once.** Someone who sees
+   `203.0.113.10` in three different demo guides knows it is a placeholder without being told.
+
+Goal 1 is not negotiable. Goal 2 is a strong default.
+
+## Reserved network identifiers
+
+Use only identifiers that the IETF, IANA, or ICANN has reserved for documentation. These are
+guaranteed not to route, not to resolve, and not to belong to anyone.
+
+| Identifier | Use this | Reservation |
+| --- | --- | --- |
+| IPv4, public-facing | `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` | RFC 5737 (TEST-NET-1/2/3) |
+| IPv6 | `2001:db8::/32` | RFC 3849 |
+| IPv6, large topologies | `3fff::/20` | RFC 9637 |
+| Registrable domains | `example.com`, `example.net`, `example.org` | RFC 2606 |
+| Top-level domains | `.example`, `.test`, `.invalid`, `.localhost` | RFC 2606, RFC 6761 |
+| Internal and private hostnames | `.internal` | ICANN, July 2024 — never delegated |
+| Autonomous system numbers | `64496`-`64511` (16-bit), `65536`-`65551` (32-bit) | RFC 5398 |
+| MAC and EUI-48 addresses | `00-00-5E-00-53-00` through `00-00-5E-00-53-FF` | RFC 7042 |
+| Phone numbers, United States | `800-555-0100` through `800-555-0199` | NANP fictional-use range |
+
+### Which IPv4 range to reach for
+
+- **TEST-NET-1/2/3 for anything representing a public address**: origin server addresses, load
+  balancer addresses, DNS `A` records, advertised prefixes, service policy allowlists and
+  blocklists, and `curl` targets. This is where a real-looking address does actual damage — a
+  reader pastes an allowlist entry into production and now a stranger's host is trusted.
+- **RFC 1918 space (`10/8`, `172.16/12`, `192.168/16`) for private and lab addressing.** Do not
+  substitute TEST-NET here. If the reader will genuinely configure `10.1.0.0/16` on a cloud
+  virtual network, write `10.1.0.0/16` — a fabricated public address in that position is less
+  accurate and no safer.
+- **`100.64.0.0/10` (RFC 6598)** when the example is specifically about carrier-grade address
+  translation.
+- **RFC 6996 private ASNs (`64512`-`65534`)** in lab routing configuration a reader will paste;
+  the RFC 5398 documentation ASNs in prose and diagrams.
+
+### Assign ranges by role, and stay consistent
+
+Pick one convention and reuse it everywhere, so the ranges themselves carry meaning:
+
+| Role | Range |
+| --- | --- |
+| Client, attacker, or traffic source | `192.0.2.0/24` |
+| Origin servers and origin pool members | `198.51.100.0/24` |
+| Published service addresses and load balancer addresses | `203.0.113.0/24` |
+
+### Use IPv6 that reflects reality
+
+`2001:db8::/32` is too small to demonstrate credible IPv6 address planning — a per-site `/48`
+allocation does not fit inside a `/32`. When the example is about address architecture, use
+`3fff::/20`, reserved by RFC 9637 in 2024 for exactly this reason. For a single illustrative
+address, `2001:db8::/32` remains the better-recognized choice.
+
+### Domains and hostnames
+
+- Default to `example.com`. When you need several names, prefer subdomains
+  (`api.example.com`, `shop.example.com`, `origin.example.com`) over inventing new registrable
+  domains. A subdomain of a reserved domain is itself safe.
+- When a scenario genuinely involves two separate organizations, use `example.com` and
+  `example.net`.
+- Lab and internal hostnames: `ce01.lab.internal`, `origin.example.test`.
+- Never use a domain you have not verified as reserved or F5-owned. "It looks fake" is not a
+  reservation. `acme.com`, `mycompany.com`, `test.com`, `foo.com`, and `example.io` all resolve
+  to real parties.
+
+## Fictitious organizations and people
+
+### Do not use ACME
+
+Two independent reasons:
+
+1. **It is not a cleared placeholder.** "Acme" is a live trademark in several classes and
+   multiple operating companies use it. Placeholders that are genuinely safe — Microsoft's
+   Contoso, Google's Altostrat — were trademark-cleared and their domains are company-owned and
+   redirected. ACME has neither property.
+2. **In networking and TLS content the name is already taken.** ACME means RFC 8555, the
+   certificate issuance protocol behind Let's Encrypt and behind automated certificate
+   management in F5 Distributed Cloud and most modern platforms. "ACME certificate renewal" in
+   one of our documents is a genuine ambiguity, not a stylistic preference.
+
+Do not introduce new ACME references. Rename existing ones as you touch the surrounding
+content; no separate cleanup sweep is required.
+
+### Organization names
+
+Use the `Example` pattern. It needs no trademark clearance and no domain registration, it maps
+onto the reserved `example.com`, and it is self-documenting:
+
+| Role | Name | Domain |
+| --- | --- | --- |
+| Primary customer or tenant | Example Corp | `example.com` |
+| Second party, partner, or acquisition | Example Partners | `example.net` |
+| Vertical-specific scenarios | Example Retail, Example Bank, Example Health | subdomain or `example.org` |
+
+If a scenario needs a name that reads less generic, clear it through F5 legal first and add it to
+this table. Do not coin one ad hoc.
+
+### Person names
+
+Use short, culture-neutral given names with a surname initial: `Dana R.`, `Kiran M.`,
+`Quinn N.`, `Alex T.`, `Yuri S.`, `Amal B.`, `Noam K.`, `Rosario L.`
+
+- Use **they/them** for placeholder people unless the scenario has a specific reason to do
+  otherwise. Do not assign gender to roles.
+- Do not distribute names by stereotype. The security engineer, the finance approver, and the
+  attacker in a scenario should not be drawn from predictable demographics.
+- Never cast a real colleague, customer contact, or executive as an example persona — not even
+  favorably, and not in internal drafts.
+
+### Email addresses
+
+A placeholder name at a reserved domain: `dana@example.com`, `kiran.m@example.net`. Role
+addresses are fine: `security@example.com`, `noreply@example.com`.
+
+### Never use real customer data
+
+This applies to internal drafts, demo tenants, and screenshots, not only to published work. When
+you need realistic-looking data, generate it. A sanitized real dataset is still a real dataset;
+treat removal of identifying details as unreliable and synthesis as the default.
+
+## Secrets, credentials, and identifiers
+
+### Placeholder convention
+
+Angle brackets, capitals and underscores, one obvious meaning:
+
+```text
+<XC_TENANT>
+<XC_API_TOKEN>
+<XC_NAMESPACE>
+<ORIGIN_POOL_NAME>
+```
+
+This form is searchable, obviously non-functional, and survives a paste into a shell as a visible
+syntax error rather than a silent misconfiguration. Do not use `YOUR_TOKEN_HERE`, `xxxxx`,
+`changeme`, or anything that looks like a real value.
+
+### Never publish a real-shaped credential
+
+Not even a revoked, expired, or rotated one. A reader cannot tell that it is dead, secret
+scanners flag it and burn reviewer attention, and "revoked" is discovered to be wrong more often
+than anyone expects. This covers API tokens, JSON web tokens, session cookies, certificate
+private keys, cluster configuration files, cloud access keys, and webhook signing secrets.
+
+When output genuinely must be shown:
+
+- Truncate and label it: `eyJhbGciOiJSUzI1NiIsInR5… (truncated)`.
+- Or replace the value with the placeholder form above.
+- For certificate and key material, generate a throwaway self-signed pair specifically for the
+  document and say so in a note. Never excerpt from a real chain.
+
+### Tenant, namespace, and account identifiers
+
+Treat these as sensitive even though they are not secrets. They identify a real customer and
+often gate support and billing conversations.
+
+| Thing | Use |
+| --- | --- |
+| Tenant name | `example-corp` |
+| Namespace | `demo-app`; genuine reserved namespace names such as `shared` and `system` are fine |
+| Account or project identifier | `123456789012` — twelve digits, obviously synthetic |
+| Cloud region | Real values are fine; regions are public and identify nobody |
+
+Product names, API paths, configuration field names, error codes, and HTTP status codes are
+**not** anonymized. Genericizing those makes a document useless. The line is: anything that
+identifies a party gets replaced, anything that describes the system stays exact.
+
+### Screenshots
+
+The highest-risk surface, because the sensitive content is usually outside the region you were
+thinking about. Before publishing any screenshot, check:
+
+- [ ] Address bar — session tokens, tenant names, query parameters
+- [ ] Adjacent browser tabs — titles leak account names and message subjects
+- [ ] Desktop notifications, chat badges, calendar popups
+- [ ] Dock, taskbar, menu bar, system tray
+- [ ] File paths in terminals and editors — these contain your user name
+- [ ] Terminal scrollback above the region of interest
+- [ ] The signed-in user chip, avatar, and email in the product's own header
+- [ ] Screen-sharing and recording indicators
+
+Redaction must remove pixels. A black rectangle drawn in a layered editor and exported to a
+format that preserves layers is not redaction. Flatten, then verify by reopening the exported
+file.
+
+## Prose and structure
+
+### Voice
+
+- **Second person, present tense, active voice.** "You create an origin pool," not "an origin
+  pool is created" and not "we will create."
+- **Imperative for steps.** "Select **Add Item**." Not "You should now select Add Item."
+- State the outcome before the procedure. Lead each section with what the reader gets.
+- Avoid "simply", "just", "easy", and "obviously". If a step is easy the reader will notice; if
+  it is not, the word is an insult.
+- Expand every acronym on first use in each document, including familiar ones. Readers arrive
+  from search engines, part-way down the page.
+
+### Structure
+
+- One level-one heading per document, matching the title. Sentence case for all headings.
+- Numbered lists only for ordered steps. Bulleted lists for everything else.
+- Open every how-to and demo guide with **Prerequisites** — required access, service tier,
+  licenses, tool versions, prior setup — and an estimate of how long the walkthrough takes.
+- Close with **Verify**, showing how the reader confirms success and what output to expect, and
+  **Clean up**, showing how to tear the environment down. A demo guide with no teardown section
+  leaves billable resources running.
+- One action per step. If a step contains "and", it is two steps.
+
+### Code and commands
+
+- Tag every fence with a language: `bash`, `json`, `yaml`, `hcl`, `text`.
+- No `$` or `%` prompt characters — they break a copy and paste.
+- Put commands and their output in separate blocks. A combined block cannot be copied.
+- Break long commands across lines with `\` continuations, one option per line.
+- Prefer a runnable command over a schematic one. Where it cannot be runnable, say so instead of
+  leaving the reader to discover it.
+
+### Terminology
+
+- Use the current official product name on first reference, then a defined short form. Verify it
+  against F5 product marketing before publishing; names change, and a stale name dates content
+  immediately.
+- One term per concept per document, never varied for style. "Origin pool" throughout, not
+  alternating with "backend pool" and "server group".
+- User interface elements in **bold**, matching the product's own capitalization. File paths,
+  values, field names, and command options in `code`.
+- The `Lint Code Base` gate enforces house terminology through textlint. Reproduce it locally
+  before pushing prose, as described in `CONTRIBUTING.md`.
+
+## Pre-publish checklist
+
+- [ ] Every public-facing address is in TEST-NET-1/2/3, `2001:db8::/32`, or `3fff::/20`
+- [ ] Every private address is RFC 1918 and consistent across the document
+- [ ] Every domain is `example.com`, `example.net`, `example.org`, a reserved top-level domain,
+      or F5-owned
+- [ ] Every ASN and MAC address is in the documentation range
+- [ ] No ACME; organizations follow the `Example` pattern
+- [ ] No real person's name, email address, or contact details
+- [ ] No credential, token, key, or certificate material — live, expired, or otherwise
+- [ ] No real tenant, namespace, or account identifier
+- [ ] Screenshots checked against the list above and verified flat
+- [ ] Every command can be copied and run; every fence is language-tagged
+- [ ] Prerequisites, Verify, and Clean up sections present
+- [ ] Product names current
+- [ ] Secret scan clean (`gitleaks detect`)
+
+### Detection heuristics
+
+Neither command is authoritative and both need a human pass, but they catch the common misses.
+
+Flag IPv4 literals outside the documentation and private ranges:
+
+```bash
+rg -oN --no-heading '\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b' . \
+  | grep -Ev '(192\.0\.2\.|198\.51\.100\.|203\.0\.113\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.|100\.6[4-9]\.|127\.0\.0\.|0\.0\.0\.0|255\.255\.)'
+```
+
+Expect false positives from network masks, version strings, and timestamps.
+
+Flag hostnames in links that are neither reserved nor an approved reference:
+
+```bash
+rg -oN --no-heading 'https?://[a-zA-Z0-9.-]+' . \
+  | grep -Ev 'example\.(com|net|org)|\.(example|test|invalid|internal|localhost)\b|localhost|f5\.com|github\.com|rfc-editor\.org|ietf\.org|icann\.org|cloudflare\.com|google\.com|microsoft\.com'
+```
+
+Extend the allowlist with legitimate reference domains as you go.
+
+## References
+
+Reservations:
+
+- [RFC 5737](https://www.rfc-editor.org/rfc/rfc5737.html) — IPv4 address blocks reserved for documentation
+- [RFC 3849](https://www.rfc-editor.org/rfc/rfc3849.html) — IPv6 address prefix reserved for documentation
+- [RFC 9637](https://www.rfc-editor.org/rfc/rfc9637.html) — Expanding the IPv6 documentation space (`3fff::/20`)
+- [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606.html) — Reserved top level DNS names
+- [RFC 6761](https://www.rfc-editor.org/rfc/rfc6761.html) — Special-use domain names
+- [RFC 5398](https://www.rfc-editor.org/rfc/rfc5398.html) — Autonomous system number reservation for documentation use
+- [RFC 7042](https://www.rfc-editor.org/rfc/rfc7042.html) — IANA considerations and IETF protocol usage for IEEE 802 parameters
+- [ICANN reserves `.internal` for private use](https://www.icann.org/en/announcements/details/icann-seeks-feedback-on-proposed-top-level-domain-string-for-private-use-24-01-2024-en)
+
+Prior art in vendor style guides:
+
+- [Cloudflare Style Guide — example values](https://developers.cloudflare.com/style-guide/formatting/example-values)
+- [Google developer documentation style guide — example domains and names](https://developers.google.com/style/examples)
+- [Microsoft Writing Style Guide — fictitious names, domains, and addresses](https://learn.microsoft.com/en-us/writing-style-guide-msft-internal/legal-content/fictitious-names-domains-and-addresses)

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -16,7 +16,7 @@ The workflow iterates the `managed_files.files` array from the [central config](
 The managed files manifest includes:
 - Caller workflows (`enforce-repo-settings.yml`, `github-pages-deploy.yml`, `require-linked-issue.yml`)
 - Issue and PR templates
-- `CONTRIBUTING.md`, `CLAUDE.md`, `.editorconfig`, `.gitignore`, `LICENSE`
+- `CONTRIBUTING.md`, `CLAUDE.md`, `STYLE_GUIDE.md`, `.editorconfig`, `.gitignore`, `LICENSE`
 - `.pre-commit-config.yaml`
 
 ## Dynamic dependabot.yml generation


### PR DESCRIPTION
## Summary

Adds `STYLE_GUIDE.md` and distributes it as a managed file to all 38 downstream repos. The
fleet had no rule for which example values are safe to publish, so every author and every AI
assistant improvised.

The headline change is retiring **ACME** as the placeholder organization. It fails on two
independent grounds: it is a live trademark held by several operating companies (unlike
trademark-cleared placeholders such as Microsoft's Contoso or Google's Altostrat), and in
networking and TLS content the name already means RFC 8555 — the certificate issuance protocol
behind Let's Encrypt and behind automated certificate management in F5 Distributed Cloud. "ACME
certificate renewal" in one of our documents is a genuine ambiguity, not a style quibble.

## Related Issue

Closes #873

## Changes

- **`STYLE_GUIDE.md`** (new, 302 lines) covering: reserved network identifiers
  (RFC 5737 / 3849 / 9637 / 2606 / 6761 / 5398 / 7042 and ICANN's `.internal`), fictitious
  organizations and people, credential placeholders and screenshot sanitization, prose and
  structure conventions, and a pre-publish checklist with `ripgrep` detection heuristics.
- **`.github/config/repo-settings.json`** — `{"src": "STYLE_GUIDE.md", "dest": "STYLE_GUIDE.md"}`
  added to `managed_files.files[]`.
- **`.claude/governance.json`** — `STYLE_GUIDE.md` added to `protected_files[]`, so the
  PreToolUse hook blocks direct edits in downstream clones. Required for parity: Test 3.1 of
  `tests/test-protect-managed-files.sh` asserts every managed destination is also protected.
- **`CONTRIBUTING.md`** — new `### Documentation content` subsection under Engineering Standards.
- **`CLAUDE.md`** — matching Engineering Standards bullet, so agents fleet-wide are pointed at it.
- **`docs/file-sync.mdx`** — added to the managed-file inventory list.

`managed-files-manifest.json` is deliberately **not** touched — `Build Managed Files Manifest`
regenerates it on merge. `docs/configuration.mdx` holds only a truncated illustrative excerpt of
the managed-file list, so it needs no update.

No repo is opted out via `skip_files`: a documentation style guide applies to every repo in the
fleet, and a root-level Markdown file is an established managed pattern (`CONTRIBUTING.md`,
`CLAUDE.md`).

## Verification evidence

**1. Shell unit tests — all 22 suites, 0 failures** (the gate that matters here, since the
governance parity assertion is what a mis-registered managed file trips):

```
OK   test-check-repo-hygiene.sh
OK   test-check-review-deps.sh
OK   test-claude-review-retry.sh
OK   test-dispatch-matrix.sh
OK   test-fetch-governed.sh                   9 passed, 0 failed
OK   test-governed-script-source.sh           12 passed, 0 failed
OK   test-inlined-helpers-match.sh
OK   test-linter-configs.sh                   118 passed, 0 failed
OK   test-locale-lint.sh                      10 passed, 0 failed
OK   test-pages-staleness-guard.sh
OK   test-parse-verdict.sh
OK   test-pr-author-trusted.sh
OK   test-preflight-fleet.sh                  12 passed, 0 failed
OK   test-protect-managed-files.sh            122 passed, 0 failed
OK   test-readme-generation.sh                9 passed, 0 failed
OK   test-require-linked-issue-exemptions.sh
OK   test-retry-stdout.sh                     22 passed, 0 failed
OK   test-review-layer-routing.sh
OK   test-review-slot.sh
OK   test-reviewer-comment-count.sh
OK   test-sync-managed-files.sh               7 passed, 0 failed
OK   test-translation-suspension.sh           12 passed, 0 failed
--- suites: 22 ok, 0 failed ---
```

Governance parity confirmed independently:

```
$ python3 -c "..."
managed count: 47 | STYLE_GUIDE.md present: True
protected count: 49 | STYLE_GUIDE.md present: True
parity (every dest protected): True
```

**2. `pre-commit run --files` on all six changed files:**

```
GOVERNANCE: never commit directly to main...................................Passed
Repository-specific hooks...................................................Passed
Repository hygiene..........................................................Passed
Locale lint.................................................................Passed
check for added large files.................................................Passed
Markdown lint...............................................................Passed
Biome lint (JS/TS/JSON).....................................................Passed
Spelling check..............................................................Passed
EditorConfig check..........................................................Passed
Infrastructure security scan................................................Passed
Secrets detection...........................................................Passed
```

**3. textlint — the CI-only prose/terminology gate `pre-commit` does not run**, reproduced
locally per `CONTRIBUTING.md`:

```
$ npx --yes --package textlint --package textlint-rule-terminology textlint -c .textlintrc \
    STYLE_GUIDE.md CONTRIBUTING.md CLAUDE.md
textlint: 0 problems
```

It initially flagged one real violation — `Incorrect term: "snake case", use "snake_case"` at
`STYLE_GUIDE.md:140`. Fixed at source by rewording to "capitals and underscores", not by
excluding the rule.

**4. The guide passes its own detection heuristics.** Both commands from its Pre-publish
checklist, run against the guide itself, return no findings — so the document it prescribes is
one the document itself would accept:

```
$ rg -oN --no-heading '\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b' STYLE_GUIDE.md CONTRIBUTING.md CLAUDE.md | grep -Ev '(...documentation and private ranges...)'
(no output)
$ rg -oN --no-heading 'https?://[a-zA-Z0-9.-]+' STYLE_GUIDE.md | grep -Ev '(...reserved and approved reference domains...)'
(no output)
```

**5. CI run** — linked below once the checks report; auto-merge is armed and will squash only
when every required check is green.

## Post-merge verification (tracked, not yet done)

Propagation is not complete at merge. After `Build Managed Files Manifest` regenerates the
manifest and `Dispatch Downstream Enforcement` fans out, I will confirm `STYLE_GUIDE.md`
actually landed by reading it back from a sample of downstream repos — a green dispatch is not
proof the file arrived.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued) — in progress, see above
- [x] Follows project conventions

### Note on the TDD checkbox

This is a docs-and-config change, so there was no new test to write first. The relevant test
already existed — `tests/test-protect-managed-files.sh` Test 3.1 — and it is what determined the
shape of the change: registering the file in `repo-settings.json` alone would have failed it, so
`governance.json` was updated in the same commit. Verified green above rather than newly authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
