### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-30T21:41:15Z",
-  "source_commit": "d79fad4395c0de5806e9d4e431368069b6604eda",
+  "generated_at": "2026-07-31T02:13:53Z",
+  "source_commit": "e5d0eea5defb3891dd4c7779ff71f3488f35af7d",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -65,20 +65,20 @@
     "CONTRIBUTING.md": {
       "src": "CONTRIBUTING.md",
       "dest": "CONTRIBUTING.md",
-      "sha": "32efee7efe0f69306a79eb6f12ced3b3b120a808",
-      "size": 37813
+      "sha": "079cdddec3a0f5b9298f25ca449c8de6e7d859c1",
+      "size": 40623
     },
     "CLAUDE.md": {
       "src": "CLAUDE.md",
       "dest": "CLAUDE.md",
-      "sha": "e9cb53db5f247c3705a5666a0939e9c80d434437",
-      "size": 7823
+      "sha": "33364b797fd140da1f9a2f8b336476a3c0a9eaa3",
+      "size": 8447
     },
     "STYLE_GUIDE.md": {
       "src": "STYLE_GUIDE.md",
       "dest": "STYLE_GUIDE.md",
-      "sha": "9962e1aa5881713e58fca88769f1b366ae6eda84",
-      "size": 15432
+      "sha": "7ed9920a4166dbf95812ef026b77f8d7f8be7682",
+      "size": 18259
     },
     ".editorconfig": {
       "src": ".editorconfig",
@@ -236,17 +236,35 @@
       "sha": "5f3df07f0053ff38c7d1ac5d0fd2e1cdbeb2d7d4",
       "size": 6930
     },
+    "scripts/check_pii.py": {
+      "src": "scripts/check_pii.py",
+      "dest": "scripts/check_pii.py",
+      "sha": "3308b5829885d8e067e7b06c794f1cf310865b26",
+      "size": 17481
+    },
+    "scripts/check-pii.sh": {
+      "src": "scripts/check-pii.sh",
+      "dest": "scripts/check-pii.sh",
+      "sha": "3ccea87ab18f4241d208e19d52a16d6f877c34e5",
+      "size": 4014
+    },
     "tests/test-check-repo-hygiene.sh": {
       "src": "tests/test-check-repo-hygiene.sh",
       "dest": "tests/test-check-repo-hygiene.sh",
       "sha": "8a9c6ed71110c1b1f602ea6c218bce4453c5b129",
       "size": 8518
     },
+    "tests/test-check-pii.sh": {
+      "src": "tests/test-check-pii.sh",
+      "dest": "tests/test-check-pii.sh",
+      "sha": "0a977e4621f1f5f02f8fc2fb07e7a90bb521d61b",
+      "size": 8422
+    },
     ".claude/governance.json": {
       "src": ".claude/governance.json",
       "dest": ".claude/governance.json",
-      "sha": "7fb97607677d59584f7281086ada33c3126409b8",
-      "size": 4719
+      "sha": "8363c737164f17858c97f5a9ab8e2b05c98a5ea9",
+      "size": 4806
     },
     ".claude/settings.json": {
       "src": ".claude/settings.json",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.