### PR TITLE
fix: make managed PII scanner formatting portable

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -32,7 +32,7 @@ jobs:
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.16.0"
-          args: 'format --check --config "line-length = 88"'
+          args: format --check --config=line-length=88
           src: scripts/check_pii.py
 
       - name: Check managed PII scanner format at 100 columns
@@ -40,7 +40,7 @@ jobs:
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.16.0"
-          args: 'format --check --config "line-length = 100"'
+          args: format --check --config=line-length=100
           src: scripts/check_pii.py
 
       # Deterministic portability guard, run natively on the runner (Super-Linter

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,6 +24,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      # This managed scanner is synced verbatim into repositories that retain
+      # repo-specific Ruff settings. Check the same bytes at both fleet line
+      # lengths so a canonical file cannot pass here and fail after sync.
+      - name: Check managed PII scanner format at 88 columns
+        if: hashFiles('scripts/check_pii.py') != ''
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.16.0"
+          args: 'format --check --config "line-length = 88"'
+          src: scripts/check_pii.py
+
+      - name: Check managed PII scanner format at 100 columns
+        if: hashFiles('scripts/check_pii.py') != ''
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.16.0"
+          args: 'format --check --config "line-length = 100"'
+          src: scripts/check_pii.py
+
       # Deterministic portability guard, run natively on the runner (Super-Linter
       # cannot see git object modes from inside its container). Cheap and first, so
       # a committed absolute symlink or hardcoded home directory fails fast.

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -88,7 +88,8 @@ QUERY_RE = re.compile(
 )
 IPV4_RE = re.compile(r"(?<![A-Za-z0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![A-Za-z0-9.])")
 PDF_AUTHOR_RE = re.compile(
-    r"/(?:Author|Subject)\s*\((?P<value>[^)]{2,})\)", re.IGNORECASE
+    r"/(?:Author|Subject)\s*\((?P<value>[^)]{2,})\)",
+    re.IGNORECASE,
 )
 SENSITIVE_MEDIA_TAG_RE = re.compile(
     r"GPSLatitude|GPSLongitude|OwnerName|CameraOwnerName", re.IGNORECASE
@@ -153,10 +154,12 @@ SAFE_IDENTITY_VALUES = {
     "shared",
     "system",
 }
-DOCUMENTATION_NETWORKS = tuple(
-    ipaddress.ip_network(value)
-    for value in ("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")
+DOCUMENTATION_NETWORKS = (
+    ipaddress.ip_network("192.0.2.0/24"),
+    ipaddress.ip_network("198.51.100.0/24"),
+    ipaddress.ip_network("203.0.113.0/24"),
 )
+SAFE_IDENTITY_VALUES_LOWER = {item.lower() for item in SAFE_IDENTITY_VALUES}
 
 
 @dataclass(frozen=True, order=True)
@@ -224,9 +227,7 @@ def placeholder_value(value: str) -> bool:
     if not value:
         return True
     lower = value.lower()
-    if lower in SCHEMA_SENTINELS or lower in {
-        item.lower() for item in SAFE_IDENTITY_VALUES
-    }:
+    if lower in SCHEMA_SENTINELS or lower in SAFE_IDENTITY_VALUES_LOWER:
         return True
     if lower in SAFE_PERSON_NAMES:
         return True
@@ -274,9 +275,8 @@ def redact_path(path: str) -> str:
 
     redacted = HOME_RE.sub(replace_home, redacted)
     if redacted != path:
-        digest = hashlib.sha256(path.encode("utf-8", "surrogateescape")).hexdigest()[
-            :12
-        ]
+        encoded_path = path.encode("utf-8", "surrogateescape")
+        digest = hashlib.sha256(encoded_path).hexdigest()[:12]
         return f"{redacted} [path-sha256:{digest}]"
     return redacted
 
@@ -358,7 +358,10 @@ def scan_structured_identity(
 
 
 def scan_query_parameters(
-    path: str, line_number: int, line: str, findings: set[Finding]
+    path: str,
+    line_number: int,
+    line: str,
+    findings: set[Finding],
 ) -> None:
     """Scan URL query parameters for embedded identity values."""
     for match in QUERY_RE.finditer(line):
@@ -377,7 +380,10 @@ def scan_query_parameters(
 
 
 def scan_public_ips(
-    path: str, line_number: int, line: str, findings: set[Finding]
+    path: str,
+    line_number: int,
+    line: str,
+    findings: set[Finding],
 ) -> None:
     """Report public IPv4 values outside documentation-reserved networks."""
     for match in IPV4_RE.finditer(line):
@@ -403,9 +409,9 @@ def scan_text(path: str, text: str, findings: set[Finding]) -> None:
     """Apply structured and line-oriented detectors to one text blob."""
     legal_path = is_legal_attribution_path(path)
     for line_number, line in enumerate(text.splitlines(), 1):
-        provenance_trailer = bool(
-            path.startswith("<commit:") and PROVENANCE_TRAILER_RE.match(line)
-        )
+        is_commit_message = path.startswith("<commit:")
+        trailer_match = PROVENANCE_TRAILER_RE.match(line)
+        provenance_trailer = bool(is_commit_message and trailer_match)
         scan_contacts(
             path,
             line_number,
@@ -479,10 +485,11 @@ def scan(input_dir: Path) -> set[Finding]:
 
 def selected_findings(findings: Iterable[Finding], mode: str) -> list[Finding]:
     """Filter advisory results from enforcement mode and sort the remainder."""
-    selected = [
-        finding for finding in findings if mode == "audit" or finding.severity == "high"
-    ]
-    return sorted(selected)
+
+    def should_include(finding: Finding) -> bool:
+        return mode == "audit" or finding.severity == "high"
+
+    return sorted(filter(should_include, findings))
 
 
 def render_text(findings: Sequence[Finding], *, scope: str, mode: str) -> str:
@@ -507,7 +514,9 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input-dir", required=True, type=Path)
     parser.add_argument(
-        "--scope", choices=("staged", "head", "history"), default="head"
+        "--scope",
+        choices=("staged", "head", "history"),
+        default="head",
     )
     parser.add_argument("--mode", choices=("audit", "enforce"), default="audit")
     parser.add_argument("--format", choices=("text", "json"), default="text")

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -748,7 +748,7 @@ echo "=== Section 12: managed PII scanner Ruff portability ==="
 # check the exact same bytes. These action steps are the executable regression;
 # Super-Linter still checks the caller repository's native Ruff configuration.
 for width in 88 100; do
-  if python3 - "$REPO_ROOT/.github/workflows/super-linter.yml" "$width" <<'PY'
+  if python3 - "$REPO_ROOT/.github/workflows/super-linter.yml" "$width" <<'PY'; then
 import sys
 
 import yaml
@@ -779,7 +779,6 @@ if inputs.get("src") != "scripts/check_pii.py":
 if inputs.get("args") != f"format --check --config=line-length={width}":
     raise SystemExit(1)
 PY
-  then
     pass "12.x super-linter checks PII scanner at ${width} columns"
   else
     fail "12.x super-linter checks PII scanner at ${width} columns" \

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -736,6 +736,57 @@ fi
 
 rm -rf "$GI_TMP"
 
+# ════════════════════════════════════════════════════════════════════
+# SECTION 12: managed PII scanner is formatter-portable
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 12: managed PII scanner Ruff portability ==="
+
+# The scanner is synced verbatim into repositories that intentionally retain
+# repo-specific Ruff settings. Ruff's formatter may join lines at 100 columns
+# that it splits at docs-control's canonical 88 columns, so both widths must
+# check the exact same bytes. These action steps are the executable regression;
+# Super-Linter still checks the caller repository's native Ruff configuration.
+for width in 88 100; do
+  if python3 - "$REPO_ROOT/.github/workflows/super-linter.yml" "$width" <<'PY'
+import sys
+
+import yaml
+
+workflow_path, width = sys.argv[1:]
+with open(workflow_path, encoding="utf-8") as workflow_file:
+    workflow = yaml.safe_load(workflow_file)
+
+expected_name = f"Check managed PII scanner format at {width} columns"
+steps = workflow["jobs"]["lint"]["steps"]
+matching = [step for step in steps if step.get("name") == expected_name]
+if len(matching) != 1:
+    raise SystemExit(1)
+
+step = matching[0]
+expected = {
+    "uses": "astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89",
+    "if": "hashFiles('scripts/check_pii.py') != ''",
+}
+if any(step.get(key) != value for key, value in expected.items()):
+    raise SystemExit(1)
+
+inputs = step.get("with", {})
+if inputs.get("version") != "0.16.0":
+    raise SystemExit(1)
+if inputs.get("src") != "scripts/check_pii.py":
+    raise SystemExit(1)
+if inputs.get("args") != f'format --check --config "line-length = {width}"':
+    raise SystemExit(1)
+PY
+  then
+    pass "12.x super-linter checks PII scanner at ${width} columns"
+  else
+    fail "12.x super-linter checks PII scanner at ${width} columns" \
+      "missing or incorrectly pinned Ruff action step"
+  fi
+done
+
 # If a future assertion generates a temp file, it must clean up.
 TMPS_BEFORE=$(find /tmp -maxdepth 1 -name 'test-linter-configs-*' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$TMPS_BEFORE" = "0" ]; then

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -776,7 +776,7 @@ if inputs.get("version") != "0.16.0":
     raise SystemExit(1)
 if inputs.get("src") != "scripts/check_pii.py":
     raise SystemExit(1)
-if inputs.get("args") != f'format --check --config "line-length = {width}"':
+if inputs.get("args") != f"format --check --config=line-length={width}":
     raise SystemExit(1)
 PY
   then


### PR DESCRIPTION
## Summary

Make the canonical managed PII scanner formatter-stable across the Ruff configurations retained by governed repositories, and enforce that portability in the reusable lint workflow.

## Related Issue

Closes #884
Part of #878

## Changes

- Restructure formatter-sensitive expressions without changing scanner behavior.
- Add pinned Ruff 0.16.0 checks for the exact scanner bytes at both 88 and 100 columns.
- Add a governance regression that requires both reusable workflow checks and their pinned configuration.

## Verification evidence

- TDD red state: `tests/test-linter-configs.sh` reported 119 passed and 2 failed before the workflow checks were added.
- `ruff format --check --config 'line-length = 88' scripts/check_pii.py` — 1 file already formatted.
- `ruff format --check --config 'line-length = 100' scripts/check_pii.py` — 1 file already formatted.
- `ruff check scripts/check_pii.py` — all checks passed.
- `bash tests/test-check-pii.sh` — all 27 scanner scenarios passed.
- `uv run --python 3.13 --with pyyaml bash tests/test-linter-configs.sh` — 121 passed.
- All `tests/test-*.sh` scripts passed under Python 3.13; governance integrity 122/122, fleet preflight 12/12, and managed sync 7/7 passed.
- `uvx mypy --config-file .mypy.ini scripts/check_pii.py` — no issues.
- `uvx pylint --rcfile .python-lint scripts/check_pii.py` — 10.00/10.
- `pre-commit run --all-files` — every applicable hook passed.
- Staged PII enforcement and gitleaks — zero findings.
- `git diff --check` — passed.
- CI: [Super-Linter run 30613962251](https://github.com/f5-sales-demo/docs-control/actions/runs/30613962251) passed every validator; linked-issue and shell-unit checks passed.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
