### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-31T02:13:53Z",
-  "source_commit": "e5d0eea5defb3891dd4c7779ff71f3488f35af7d",
+  "generated_at": "2026-07-31T07:49:17Z",
+  "source_commit": "f87852f4b0fe28adede8aba6fc6027f031b4f862",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -239,8 +239,8 @@
     "scripts/check_pii.py": {
       "src": "scripts/check_pii.py",
       "dest": "scripts/check_pii.py",
-      "sha": "3308b5829885d8e067e7b06c794f1cf310865b26",
-      "size": 17481
+      "sha": "6501fa9897b3731a683eb191c2305f3a5408df36",
+      "size": 17695
     },
     "scripts/check-pii.sh": {
       "src": "scripts/check-pii.sh",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.