### PR TITLE
fix: classify unquoted source identity expressions

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -122,12 +122,11 @@ PROVENANCE_TRAILER_RE = re.compile(
     r"^(?:Co-authored-by|Signed-off-by|Reviewed-by|Acked-by|Tested-by):",
     re.IGNORECASE,
 )
-CODE_EXPRESSION_RE = re.compile(
-    r"[A-Za-z_$][A-Za-z0-9_$#]*"
-    r"(?:(?:\??\.|->|::)[A-Za-z_$#][A-Za-z0-9_$#]*|\[[^\]]+\])*"
-    r"(?:\([^;]*\))?"
-    r"(?:\s+(?:\?\?|&&|\|\||[+*/?:-])\s+.+)?"
-    r";?"
+NUMERIC_LITERAL_RE = re.compile(
+    r"[+-]?(?:"
+    r"0[xX][0-9A-Fa-f_]+|0[bB][01_]+|0[oO][0-7_]+|"
+    r"[0-9][0-9_]*(?:\.[0-9_]+)?"
+    r");?"
 )
 
 SAFE_EMAIL_DOMAINS = {"example.com", "example.net", "example.org"}
@@ -277,7 +276,7 @@ def is_nonliteral_code_expression(path: str, match: re.Match[str]) -> bool:
         return False
     if match.group("quote"):
         return False
-    return bool(CODE_EXPRESSION_RE.fullmatch(normalized_value(match.group("value"))))
+    return not bool(NUMERIC_LITERAL_RE.fullmatch(normalized_value(match.group("value"))))
 
 
 def safe_phone(value: str) -> bool:

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -276,7 +276,8 @@ def is_nonliteral_code_expression(path: str, match: re.Match[str]) -> bool:
         return False
     if match.group("quote"):
         return False
-    return not bool(NUMERIC_LITERAL_RE.fullmatch(normalized_value(match.group("value"))))
+    value = normalized_value(match.group("value"))
+    return not bool(NUMERIC_LITERAL_RE.fullmatch(value))
 
 
 def safe_phone(value: str) -> bool:

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -148,6 +148,9 @@ const context = {
   namespace: String(input.namespace),
   full_name: user.displayName,
 };
+const typed: { tenant: string | null } = context;
+const fallback = { namespace: status.activeNamespace ?? "default" };
+const indexed = { tenant: tenants["active"] };
 EOF
 cat >"${repo}/fixture.cpp" <<'EOF'
 auto namespace = context->namespace;
@@ -158,7 +161,10 @@ git -C "$repo" commit -qm expressions
 assert_clean "code types and expressions are not literal identity values" "$repo" --scope head --mode enforce
 
 repo=$(new_repo code-string-literal)
-printf 'const context = { tenant: "real-customer", full_name: "Jane Doe" };\n' >"${repo}/fixture.ts"
+cat >"${repo}/fixture.ts" <<'EOF'
+const context = { tenant: "real-customer", full_name: "Jane Doe" };
+const raw = { namespace: `real-customer` };
+EOF
 git -C "$repo" add fixture.ts
 git -C "$repo" commit -qm literal
 assert_violation "quoted identity literals in code" "$repo" --scope head --mode enforce


### PR DESCRIPTION
Closes #890.

## What changed

- In supported source-code formats, nonnumeric unquoted structured values are treated as executable/type syntax rather than serialized identity literals.
- Quoted and backtick string literals remain enforceable findings.
- Decimal, hexadecimal, octal, and binary numeric identity literals remain enforceable findings.
- Serialized/configuration/documentation formats retain unquoted-value enforcement.
- Regression tests cover type unions, fallbacks truncated at quoted operands, index access, backtick literals, numeric literals, and YAML literals.

There are no path exclusions, baselines, inline suppressions, disabled rules, or skipped files.

## Downstream evidence

Against f5-sales-demo/xcsh#2674 at `3b9eb5291`, the combined managed refinements reduce enforcement findings from 2,508 across 223 files to 985 across 123 enforcement-bearing files. The remaining findings stay visible for repository remediation.

## Verification

- `bash tests/test-check-pii.sh`: passed.
- `pre-commit run --all-files`: passed.
- All 23 `tests/test-*.sh` scripts passed under Python 3.13 with PyYAML.
- `git diff --check`: passed.