### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-07-31T11:44:04Z",
-  "source_commit": "1cb0586ba196ccf3826ecb3e7170415b67fb8e91",
+  "generated_at": "2026-07-31T12:14:21Z",
+  "source_commit": "328e6be213ba98f0146960778ce701918ec6316e",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -239,8 +239,8 @@
     "scripts/check_pii.py": {
       "src": "scripts/check_pii.py",
       "dest": "scripts/check_pii.py",
-      "sha": "86c84b8c8c73d6b7092f378b22048cc791b8966d",
-      "size": 18936
+      "sha": "3fd7fa23155ba36cd87e0fc33395a376b4fb6392",
+      "size": 18895
     },
     "scripts/check-pii.sh": {
       "src": "scripts/check-pii.sh",
@@ -257,8 +257,8 @@
     "tests/test-check-pii.sh": {
       "src": "tests/test-check-pii.sh",
       "dest": "tests/test-check-pii.sh",
-      "sha": "2e0ef88768adff4286d0f7ce50d51fe24aac02bf",
-      "size": 10243
+      "sha": "5ef5af6f22dcd9a2ebcbdd5cd735dd5edf2c1843",
+      "size": 10458
     },
     ".claude/governance.json": {
       "src": ".claude/governance.json",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.