### PR TITLE
fix: require home-path token boundaries

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -79,8 +79,10 @@ EMAIL_RE = re.compile(
     r"[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
 )
 HOME_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])(?:"
     r"(?P<prefix>/Users/|/home/)(?P<user>[A-Za-z0-9._${}<>-]+)"
     r"|(?P<winprefix>[A-Za-z]:\\+(?:Users)\\+)(?P<winuser>[A-Za-z0-9._${}<>-]+)"
+    r")"
 )
 PHONE_FIELD_RE = re.compile(
     r"(?i)(?:^|[,{\s])['\"]?(?:phone(?:_number)?|mobile|telephone|fax)['\"]?"

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -129,6 +129,12 @@ git -C "$repo" add config.ini
 git -C "$repo" commit -qm paths
 assert_clean "placeholder, CI, and variable home paths" "$repo" --scope head --mode enforce
 
+repo=$(new_repo embedded-home-tokens)
+printf 'keys=Shift+page/home/end route=service/Users/list windows=prefixC:\\Users\\record\n' >"${repo}/config.ini"
+git -C "$repo" add config.ini
+git -C "$repo" commit -qm tokens
+assert_clean "embedded home-like tokens are not absolute paths" "$repo" --scope head --mode enforce
+
 repo=$(new_repo tenant)
 printf 'tenant: real-customer\n' >"${repo}/fixture.yaml"
 git -C "$repo" add fixture.yaml


### PR DESCRIPTION
Fixes #893

Require personal home paths to begin at a standalone token boundary so slash-separated prose is not mistaken for filesystem identity data. The regression covers POSIX and Windows lookalikes while the existing absolute-path enforcement remains intact.

Verification:
- `bash tests/test-check-pii.sh`
- all 23 `tests/*.sh` suites
- `pre-commit run --all-files`