### PR TITLE
fix: ignore numeric values in person-name fields

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -347,9 +347,12 @@ def scan_contacts(
                     message="email address does not use a documentation-reserved domain",
                 )
         for match in PERSON_FIELD_RE.finditer(line):
+            value = normalized_value(match.group("value"))
+            if NUMERIC_LITERAL_RE.fullmatch(value):
+                continue
             if is_nonliteral_code_expression(path, match):
                 continue
-            if not placeholder_value(match.group("value")):
+            if not placeholder_value(value):
                 add_finding(
                     findings,
                     path=path,

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -117,6 +117,12 @@ git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm name
 assert_violation "literal structured person name" "$repo" --scope head --mode enforce
 
+repo=$(new_repo numeric-person-fields)
+printf 'first_name: 101\nlast_name: "202"\n' >"${repo}/fixture.yaml"
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm numeric-name
+assert_clean "numeric person fields are not names" "$repo" --scope head --mode enforce
+
 repo=$(new_repo home-path)
 printf 'cache=/Users/realperson/.cache/tool\n' >"${repo}/config.ini"
 git -C "$repo" add config.ini


### PR DESCRIPTION
Fixes #896

Numeric schema values cannot contain a person name. Ignore them only in person-name fields while preserving the existing strict treatment of numeric customer identifiers.

Verification:
- `bash tests/test-check-pii.sh`
- all 23 `tests/*.sh` suites
- `pre-commit run --all-files`