### PR TITLE
fix: narrow customer identity fields

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -97,7 +97,7 @@ PERSON_FIELD_RE = re.compile(
 IDENTITY_FIELD_RE = re.compile(
     r"(?i)(?:^|[,{\s])['\"]?"
     r"(?P<key>tenant(?:_name|_id)?|customer(?:_name|_id)?|account(?:_name|_id)?|"
-    r"subscription(?:_name|_id)?|project(?:_name|_id)?|namespace)"
+    r"subscription(?:_name|_id)|project(?:_name|_id)|namespace)"
     r"['\"]?\s*[:=]\s*(?P<quote>['\"`]?)"
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
@@ -168,6 +168,7 @@ SAFE_PERSON_NAMES = {
     "rosario l.",
 }
 SCHEMA_SENTINELS = {
+    "0",
     "any",
     "boolean",
     "integer",
@@ -264,6 +265,8 @@ def placeholder_value(value: str) -> bool:
         return True
     lower = value.lower()
     if lower in SCHEMA_SENTINELS or lower in SAFE_IDENTITY_VALUES_LOWER:
+        return True
+    if re.fullmatch(r"example(?:[-_.][a-z0-9]+)*", lower):
         return True
     if lower in SAFE_PERSON_NAMES:
         return True

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -85,6 +85,11 @@ full_name: Dana R.
 tenant: example-corp
 namespace: demo-app
 account_id: 123456789012
+project_id: example-project
+subscription_name: example-plan
+customer_id: 0
+project: agent
+subscription: 000000
 client_ip: 192.0.2.10
 origin_ip: 198.51.100.20
 service_ip: 203.0.113.30
@@ -146,6 +151,12 @@ printf 'tenant: real-customer\n' >"${repo}/fixture.yaml"
 git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm tenant
 assert_violation "literal customer tenant" "$repo" --scope head --mode enforce
+
+repo=$(new_repo suffixed-customer-identifiers)
+printf 'project_id: customer-project\nsubscription_name: customer-plan\n' >"${repo}/fixture.yaml"
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm identifiers
+assert_violation "suffixed project and subscription identifiers" "$repo" --scope head --mode enforce
 
 repo=$(new_repo code-expressions)
 cat >"${repo}/fixture.ts" <<'EOF'


### PR DESCRIPTION
Fixes #898

Restrict project and subscription detection to explicitly identity-bearing `_id` / `_name` fields. Recognize the documentation-approved `example-*` pattern and zero schema sentinel while retaining strict tenant, customer, account, and nonzero numeric enforcement.

Verification:
- `bash tests/test-check-pii.sh`
- all 23 `tests/*.sh` suites
- `pre-commit run --all-files`