### PR TITLE
fix: distinguish contact emails from URI syntax

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -73,10 +73,10 @@ SOURCE_CODE_SUFFIXES = {
 }
 
 EMAIL_RE = re.compile(
-    r"(?<![A-Za-z0-9._%+\-])"
-    r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@"
+    r"(?<![-A-Za-z0-9._%+/])"
+    r"[A-Za-z0-9][-A-Za-z0-9.!#$%&'*+=?^_`{|}~]*[A-Za-z0-9]@"
     r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
-    r"[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"[A-Za-z]{2,63}"
 )
 HOME_RE = re.compile(
     r"(?<![A-Za-z0-9_.-])(?:"
@@ -124,6 +124,10 @@ PROVENANCE_TRAILER_RE = re.compile(
     r"^(?:Co-authored-by|Signed-off-by|Reviewed-by|Acked-by|Tested-by):",
     re.IGNORECASE,
 )
+URI_USERINFO_PREFIX_RE = re.compile(
+    r"(?i)\b(?P<scheme>[a-z][a-z0-9+.-]*):(?://)?[^\s/]*$",
+)
+PRINTABLE_ASCII_RE = re.compile(rb"[\x20-\x7e]{4,}")
 NUMERIC_LITERAL_RE = re.compile(
     r"[+-]?(?:"
     r"0[xX][0-9A-Fa-f_]+|0[bB][01_]+|0[oO][0-7_]+|"
@@ -246,6 +250,12 @@ def safe_email(value: str) -> bool:
     )
 
 
+def is_uri_userinfo(line: str, match: re.Match[str]) -> bool:
+    """Return whether an address-shaped value belongs to URI authority userinfo."""
+    prefix = URI_USERINFO_PREFIX_RE.search(line[: match.start()])
+    return bool(prefix and prefix.group("scheme").lower() != "mailto")
+
+
 def safe_home_user(user: str) -> bool:
     """Return whether a home path uses a documented portable placeholder."""
     if user.isdigit() or user in SAFE_HOME_USERS:
@@ -341,7 +351,7 @@ def scan_contacts(
     """Scan one line for contact details, home paths, and person names."""
     if not legal_path and not provenance_trailer:
         for match in EMAIL_RE.finditer(line):
-            if not safe_email(match.group(0)):
+            if not safe_email(match.group(0)) and not is_uri_userinfo(line, match):
                 add_finding(
                     findings,
                     path=path,
@@ -490,9 +500,11 @@ def looks_binary(data: bytes) -> bool:
 
 def scan_binary(path: str, data: bytes, findings: set[Finding]) -> None:
     """Inspect ASCII-compatible binary metadata without rendering the file."""
-    # Latin-1 preserves every byte, allowing high-confidence ASCII metadata to
-    # be found without loading or rendering an untrusted media file.
-    text = data.decode("latin-1")
+    # Keep only printable metadata runs. Treating every byte as Latin-1 lets
+    # compression noise masquerade as contact syntax across arbitrary bytes.
+    text = "\n".join(
+        (match.group(0).decode("ascii") for match in PRINTABLE_ASCII_RE.finditer(data)),
+    )
     scan_text(path, text, findings)
     if SENSITIVE_MEDIA_TAG_RE.search(text):
         add_finding(

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -104,6 +104,18 @@ git -C "$repo" add workflow.yaml
 git -C "$repo" commit -qm action
 assert_clean "GitHub action references are not emails" "$repo" --scope head --mode enforce
 
+repo=$(new_repo non-contact-at-syntax)
+cat >"${repo}/fixture.txt" <<'EOF'
+clone=https://x-access-token:${TOKEN}@github.com/example/repository.git
+credential=https://user:secret@github.com/example/repository.git
+ssh=ssh://git@gitlab.com/example/repository.git
+patch=owner/repository@1.2.3.patch
+anchor=`@line.chunk.path
+EOF
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm syntax
+assert_clean "URI, package, and anchor syntax are not contact emails" "$repo" --scope head --mode enforce
+
 repo=$(new_repo email)
 printf 'email: person@customer.local\n' >"${repo}/fixture.yaml"
 git -C "$repo" add fixture.yaml
@@ -281,6 +293,18 @@ printf '\x89PNG\r\n\x1a\nAuthor\x00person@customer.local\x00' >"${repo}/screen.p
 git -C "$repo" add screen.png
 git -C "$repo" commit -qm metadata
 assert_violation "PII-shaped binary metadata" "$repo" --scope head --mode enforce
+
+repo=$(new_repo binary-package-syntax)
+printf '\x89PNG\r\n\x1a\nowner/repository@1.2.3.patch\x00' >"${repo}/screen.png"
+git -C "$repo" add screen.png
+git -C "$repo" commit -qm metadata
+assert_clean "email-like binary package syntax is not contact metadata" "$repo" --scope head --mode enforce
+
+repo=$(new_repo binary-compression-token)
+printf '\x89PNG\r\n\x1a\nA@b.Co\x00' >"${repo}/screen.png"
+git -C "$repo" add screen.png
+git -C "$repo" commit -qm metadata
+assert_clean "short binary compression token is not contact metadata" "$repo" --scope head --mode enforce
 
 repo=$(new_repo odd-filename)
 printf 'email: person@customer.local\n' >"${repo}/- odd name.yaml"


### PR DESCRIPTION
## Summary

- distinguish contact addresses from URI authority credentials, SSH/package coordinates, and anchors
- scan printable binary metadata runs instead of arbitrary decoded bytes
- retain high-confidence text and binary contact-address detection with regression coverage

## Verification

- all 23 PII scanner shell suites
- Ruff check and format
- full pre-commit suite

Closes #901