### PR TITLE
fix: recognize safe composite identity values

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -191,6 +191,8 @@ SAFE_IDENTITY_VALUES = {
     "demo",
     "demo-app",
     "example-corp",
+    "library",
+    "production",
     "shared",
     "staging",
     "system",
@@ -278,11 +280,21 @@ def placeholder_value(value: str) -> bool:
         return True
     if re.fullmatch(r"example(?:[-_.][a-z0-9]+)*", lower):
         return True
-    if lower in SAFE_PERSON_NAMES:
-        return True
-    if value.startswith(("$", "{", "<", "{{", "[%", "*", "&")):
-        return True
-    return bool(re.fullmatch(r"[A-Z][A-Z0-9_]*", value))
+    first, separator, second = value.partition("|")
+    safe_composite = bool(
+        first
+        and separator
+        and second
+        and "|" not in second
+        and placeholder_value(first)
+        and placeholder_value(second)
+    )
+    return (
+        safe_composite
+        or lower in SAFE_PERSON_NAMES
+        or value.startswith(("$", "{", "<", "{{", "[%", "*", "&"))
+        or bool(re.fullmatch(r"[A-Z][A-Z0-9_]*", value))
+    )
 
 
 def is_nonliteral_code_expression(path: str, match: re.Match[str]) -> bool:

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -227,6 +227,25 @@ git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm schematic
 assert_clean "generic environment and schema identities" "$repo" --scope head --mode enforce
 
+repo=$(new_repo composite-schematic-identities)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: example-corp|staging
+account_name: example-partners|production
+namespace: library
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm composite-schematic
+assert_clean "composite and public schema identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo composite-customer-identifiers)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: real-customer|staging
+account_name: example-corp|real-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm composite-customer
+assert_violation "composite literal customer identifiers" "$repo" --scope head --mode enforce
+
 repo=$(new_repo sensitive-query)
 printf 'redirect=/done?email=person%%40customer.local\n' >"${repo}/config.ini"
 git -C "$repo" add config.ini


### PR DESCRIPTION
## Summary

- recognize two-component tenant/environment values only when both components are approved placeholders
- recognize generic production vocabulary and Docker Hub's canonical public namespace as non-identifying
- retain enforcement when either composite component contains a literal organization identifier

## Verification

- failing regression observed before implementation
- full managed PII scanner suite
- Ruff check and formatting at 88 and 100 columns
- full pre-commit suite

Closes #905