### PR TITLE
fix: distinguish public IPs from numeric syntax

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -113,6 +113,14 @@ QUERY_RE = re.compile(
     r"(?P<value>[^&#\s]+)"
 )
 IPV4_RE = re.compile(r"(?<![A-Za-z0-9.])(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?![A-Za-z0-9.])")
+DOTTED_VERSION_PREFIX_RE = re.compile(
+    r"(?i)(?:"
+    r"(?:chrome|headlesschrome|chromium|firefox|safari|edg|edge|opera)/\s*$"
+    r"|[A-Za-z0-9_.-]*version[A-Za-z0-9_.-]*\s*[:=]\s*['\"`]?\s*$"
+    r"|version[A-Za-z0-9_.-]*\)?\.to(?:be|equal)\(\s*['\"`]?\s*$"
+    r")"
+)
+SVG_PATH_ATTRIBUTE_RE = re.compile(r"(?:^|\s)d\s*=\s*(?P<quote>['\"])", re.IGNORECASE)
 PDF_AUTHOR_RE = re.compile(
     r"/(?:Author|Subject)\s*\((?P<value>[^)]{2,})\)",
     re.IGNORECASE,
@@ -465,15 +473,26 @@ def scan_public_ips(
     line: str,
     findings: set[Finding],
 ) -> None:
-    """Report public IPv4 values outside documentation-reserved networks."""
+    """Report globally routable unicast IPv4 values outside documentation ranges."""
     for match in IPV4_RE.finditer(line):
         try:
             address = ipaddress.ip_address(match.group(0))
         except ValueError:
             continue
-        if address.is_private or address.is_loopback or address.is_link_local:
+        if not address.is_global or address.is_multicast:
             continue
         if any(address in network for network in DOCUMENTATION_NETWORKS):
+            continue
+        prefix = line[max(0, match.start() - 96) : match.start()]
+        if DOTTED_VERSION_PREFIX_RE.search(prefix):
+            continue
+        for attribute in SVG_PATH_ATTRIBUTE_RE.finditer(line, 0, match.start()):
+            value = line[attribute.end() : match.start()]
+            if attribute.group("quote") not in value:
+                break
+        else:
+            attribute = None
+        if attribute is not None:
             continue
         add_finding(
             findings,
@@ -481,7 +500,7 @@ def scan_public_ips(
             line=line_number,
             category="public-ip-review",
             severity="review",
-            message="public IPv4 address is outside documentation-reserved ranges",
+            message="globally routable unicast IPv4 address is outside documentation ranges",
         )
 
 

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -98,6 +98,28 @@ git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm synthetic
 assert_clean "reserved synthetic values" "$repo" --scope head --mode enforce
 
+repo=$(new_repo public-ip-contexts)
+cat >"${repo}/fixture.txt" <<'EOF'
+rfc6598=100.64.0.1/10
+mdns=224.0.0.251
+browser=Mozilla/5.0 Chrome/136.0.0.0 Safari/537.36
+terminal={ TERM_PROGRAM_VERSION: "1.22.103.0" }
+EOF
+svg_coordinate="4.254."
+svg_coordinate+="141.138"
+printf '<svg><path d="M0 0 %s Z"/></svg>\n' "$svg_coordinate" >>"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm contexts
+assert_clean "protocol, version, and SVG coordinate syntax is not a public IP" "$repo" --scope head --mode audit
+
+repo=$(new_repo public-ip)
+public_ip="8.8."
+public_ip+="4.4"
+printf 'version=1; origin_ip=%s\n' "$public_ip" >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm public-ip
+assert_violation "globally routable unicast address" "$repo" --scope head --mode audit
+
 repo=$(new_repo action-reference)
 printf 'uses: f5-sales-demo/docs-control@main\nremote: git@github.com:f5-sales-demo/docs-control.git\n' >"${repo}/workflow.yaml"
 git -C "$repo" add workflow.yaml


### PR DESCRIPTION
## Summary

- restrict public-IP review findings to globally routable unicast IPv4 addresses
- recognize dotted browser and terminal versions from their local syntax
- recognize decimal coordinate sequences inside SVG path data
- preserve detection for genuine globally routable unicast values

## Verification

- `bash tests/test-check-pii.sh`
- `ruff check scripts/check_pii.py`
- `ruff format --check --line-length 88 scripts/check_pii.py`
- `ruff format --check --line-length 100 scripts/check_pii.py`
- `pre-commit run --all-files`

Fixes #910
