### PR TITLE
fix(governance): enforce the PII guard

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -52,7 +52,7 @@
       "additional_contexts": ["Run plugin test suites"]
     },
     "xcsh": {
-      "additional_contexts": ["check", "test"],
+      "additional_contexts": ["check", "pii-guard", "test"],
       "excluded_required_contexts": ["lint / Lint Code Base"]
     },
     "vscode-xcsh": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -552,6 +552,10 @@ either result green. Fix operational and example data at the source. A legally r
 authoritative upstream attribution must stay in its original context and must never be copied into a
 fixture or example.
 
+The `pii-guard` check requires zero enforcement findings; there is no accepted-findings baseline.
+Run `bun run pii:gate` against tracked `HEAD`, or `bun run pii:gate -- --scope staged` before a commit
+to scan the index. Empty, malformed, or failed scanner output is an operational error, never a pass.
+
 ### Clean branches
 
 - A branch is for trial-and-error: guess, probe, refactor, and learn freely while you

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -50,6 +50,7 @@ MEDIA_SUFFIXES = {
     ".webm",
     ".webp",
 }
+TEXT_MEDIA_SUFFIXES = {".svg"}
 SOURCE_CODE_SUFFIXES = {
     ".c",
     ".cc",
@@ -127,6 +128,11 @@ PDF_AUTHOR_RE = re.compile(
 )
 SENSITIVE_MEDIA_TAG_RE = re.compile(
     r"GPSLatitude|GPSLongitude|OwnerName|CameraOwnerName", re.IGNORECASE
+)
+MEDIA_AUTHOR_METADATA_RE = re.compile(
+    r"(?:^|\n)(?:Author|Artist|Creator|OwnerName|CameraOwnerName)"
+    r"(?:\s*[:=]\s*|\n+)(?P<value>[^\r\n]+)",
+    re.IGNORECASE,
 )
 PROVENANCE_TRAILER_RE = re.compile(
     r"^(?:Co-authored-by|Signed-off-by|Reviewed-by|Acked-by|Tested-by):",
@@ -316,11 +322,11 @@ def is_nonliteral_code_expression(path: str, match: re.Match[str]) -> bool:
 
 
 def safe_phone(value: str) -> bool:
-    """Return whether a phone number is in NANP's fictional 0100-0199 range."""
+    """Return whether a phone number uses NANP's fictional 555-0100--0199 block."""
     digits = re.sub(r"\D", "", value)
-    if len(digits) == len("18005550100") and digits.startswith("1"):
+    if len(digits) in {8, 11} and digits.startswith("1"):
         digits = digits[1:]
-    return len(digits) == len("8005550100") and digits.startswith("80055501")
+    return bool(re.fullmatch(r"(?:[2-9][0-9]{2})?55501[0-9]{2}", digits))
 
 
 def add_finding(
@@ -529,14 +535,37 @@ def looks_binary(data: bytes) -> bool:
     return b"\0" in data[:8192]
 
 
-def scan_binary(path: str, data: bytes, findings: set[Finding]) -> None:
+def scan_binary(path: str, data: bytes, findings: set[Finding], *, media: bool) -> None:
     """Inspect ASCII-compatible binary metadata without rendering the file."""
     # Keep only printable metadata runs. Treating every byte as Latin-1 lets
     # compression noise masquerade as contact syntax across arbitrary bytes.
     text = "\n".join(
         (match.group(0).decode("ascii") for match in PRINTABLE_ASCII_RE.finditer(data)),
     )
-    scan_text(path, text, findings)
+    if not media:
+        scan_text(path, text, findings)
+        return
+
+    for metadata in MEDIA_AUTHOR_METADATA_RE.finditer(text):
+        value = metadata.group("value")
+        emails = list(EMAIL_RE.finditer(value))
+        for email in emails:
+            if not safe_email(email.group(0)):
+                add_finding(
+                    findings,
+                    path=path,
+                    line=0,
+                    category="email",
+                    message="media metadata contains a non-reserved email address",
+                )
+        if not emails and not placeholder_value(value):
+            add_finding(
+                findings,
+                path=path,
+                line=0,
+                category="media-author",
+                message="binary media contains literal author metadata",
+            )
     if SENSITIVE_MEDIA_TAG_RE.search(text):
         add_finding(
             findings,
@@ -570,8 +599,11 @@ def scan_blob(path: str, data: bytes, findings: set[Finding]) -> None:
             severity="review",
             message="media requires metadata, OCR, and visual review",
         )
+    if suffix in MEDIA_SUFFIXES - TEXT_MEDIA_SUFFIXES:
+        scan_binary(path, data, findings, media=True)
+        return
     if looks_binary(data):
-        scan_binary(path, data, findings)
+        scan_binary(path, data, findings, media=False)
         return
     scan_text(path, data.decode("utf-8", "replace"), findings)
 

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -81,6 +81,8 @@ repo=$(new_repo reserved-values)
 cat >"${repo}/fixture.yaml" <<'EOF'
 email: dana@example.com
 phone: 800-555-0107
+mobile: +1-555-0100
+telephone: +1 212-555-0199
 full_name: Dana R.
 tenant: example-corp
 namespace: demo-app
@@ -346,6 +348,12 @@ printf '\x89PNG\r\n\x1a\nA@b.Co\x00' >"${repo}/screen.png"
 git -C "$repo" add screen.png
 git -C "$repo" commit -qm metadata
 assert_clean "short binary compression token is not contact metadata" "$repo" --scope head --mode enforce
+
+repo=$(new_repo media-compression-email)
+printf 'RIFFfixture@bytes.invalidWEBP' >"${repo}/screen.webp"
+git -C "$repo" add screen.webp
+git -C "$repo" commit -qm media
+assert_clean "email-shaped media bytes without a metadata key are ignored" "$repo" --scope head --mode enforce
 
 repo=$(new_repo odd-filename)
 printf 'email: person@customer.local\n' >"${repo}/- odd name.yaml"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -172,6 +172,13 @@ else
     "unmatched:\n$MISSING"
 fi
 
+XCSH_CONTEXTS=$(jq -c '.repo_overrides.xcsh.additional_contexts // []' "$REPO_SETTINGS")
+if echo "$XCSH_CONTEXTS" | jq -e 'index("pii-guard") != null' >/dev/null; then
+  pass "7c.2 xcsh requires the pii-guard check"
+else
+  fail "7c.2 xcsh requires the pii-guard check" "pii-guard is not in xcsh additional_contexts"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 7d: additional_contexts must name checks that ALWAYS run
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- require the always-running pii-guard context for xcsh
- document that the enforcement gate requires zero findings and has no baseline
- accept the reserved NANP 555-0100 through 555-0199 forms
- scan non-SVG media through keyed metadata checks instead of interpreting compression bytes as general text
- add regression coverage for the required context and scanner behavior

Fixes #902.

## Verification

- PATH=/opt/homebrew/bin:$PATH bash tests/test-check-pii.sh
- PATH=/opt/homebrew/bin:$PATH bash tests/test-linter-configs.sh
- PATH=/opt/homebrew/bin:$PATH pre-commit run --all-files
- npx --yes --package textlint --package textlint-rule-terminology textlint -c .textlintrc CONTRIBUTING.md
- PATH=/opt/homebrew/bin:$PATH bash scripts/check-pii.sh --scope staged --mode enforce