### PR TITLE
fix: make the managed PII scanner portable downstream

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Detect PII-shaped values in tracked Git content without reading the worktree.
 
 The scanner deliberately has two modes:
@@ -335,7 +334,6 @@ def add_finding(
     path: str,
     line: int,
     category: str,
-    severity: str = "high",
     message: str,
 ) -> None:
     """Add one redacted and deduplicated finding."""
@@ -344,7 +342,27 @@ def add_finding(
             path=redact_path(path),
             line=line,
             category=category,
-            severity=severity,
+            severity="high",
+            message=message,
+        )
+    )
+
+
+def add_review_finding(
+    findings: set[Finding],
+    *,
+    path: str,
+    line: int,
+    category: str,
+    message: str,
+) -> None:
+    """Add one redacted and deduplicated manual-review finding."""
+    findings.add(
+        Finding(
+            path=redact_path(path),
+            line=line,
+            category=category,
+            severity="review",
             message=message,
         )
     )
@@ -370,12 +388,11 @@ def scan_contacts(
     path: str,
     line_number: int,
     line: str,
-    legal_path: bool,
-    provenance_trailer: bool,
+    attribution_context: bool,
     findings: set[Finding],
 ) -> None:
     """Scan one line for contact details, home paths, and person names."""
-    if not legal_path and not provenance_trailer:
+    if not attribution_context:
         for match in EMAIL_RE.finditer(line):
             if not safe_email(match.group(0)) and not is_uri_userinfo(line, match):
                 add_finding(
@@ -500,12 +517,11 @@ def scan_public_ips(
             attribute = None
         if attribute is not None:
             continue
-        add_finding(
+        add_review_finding(
             findings,
             path=path,
             line=line_number,
             category="public-ip-review",
-            severity="review",
             message="globally routable unicast IPv4 address is outside documentation ranges",
         )
 
@@ -521,8 +537,7 @@ def scan_text(path: str, text: str, findings: set[Finding]) -> None:
             path,
             line_number,
             line,
-            legal_path,
-            provenance_trailer,
+            legal_path or provenance_trailer,
             findings,
         )
         scan_structured_identity(path, line_number, line, findings)
@@ -591,12 +606,11 @@ def scan_blob(path: str, data: bytes, findings: set[Finding]) -> None:
         return
     suffix = PurePosixPath(path).suffix.lower()
     if suffix in MEDIA_SUFFIXES:
-        add_finding(
+        add_review_finding(
             findings,
             path=path,
             line=0,
             category="media-review",
-            severity="review",
             message="media requires metadata, OCR, and visual review",
         )
     if suffix in MEDIA_SUFFIXES - TEXT_MEDIA_SUFFIXES:

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -6,11 +6,26 @@ set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SCANNER="${REPO_ROOT}/scripts/check-pii.sh"
+PYTHON_SCANNER="${REPO_ROOT}/scripts/check_pii.py"
 
 FAIL=0
 WORK=$(mktemp -d)
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
+
+if [ -x "$PYTHON_SCANNER" ]; then
+  echo "[FAIL] Python scanner is executable — invoke it through the shell wrapper"
+  FAIL=1
+else
+  echo "[OK] Python scanner is a non-executable module"
+fi
+
+if head -n 1 "$PYTHON_SCANNER" | grep -q '^#!'; then
+  echo "[FAIL] Python scanner has a shebang — invoke it through the shell wrapper"
+  FAIL=1
+else
+  echo "[OK] Python scanner has no executable shebang"
+fi
 
 new_repo() {
   local dir="${WORK}/$1"


### PR DESCRIPTION
## Summary

Makes the managed PII scanner pass consumer repositories' default Python lint configuration and aligns its entry-point metadata with the `100644` mode produced by governed sync.

Closes #917

## Changes

- Split high-confidence and review-only finding construction so default Pylint sees at most five arguments.
- Combine legal/provenance attribution state before contact scanning, removing the second default Pylint argument-count failure.
- Treat `scripts/check_pii.py` as the non-executable module it is: remove the shebang and normalize mode to `100644`.
- Add regression checks for the wrapper-only entry-point contract.

## Verification

- Regression test failed first on the executable mode and shebang, then passed after implementation.
- `tests/test-check-pii.sh` passed.
- `tests/test-check-repo-hygiene.sh` passed.
- `tests/test-linter-configs.sh` passed: 122 checks.
- Ruff 0.15.17 and 0.16.1 format checks passed at 88 and 100 columns; Ruff lint passed.
- Pylint 4.0.6 passed with 10.00/10 under default settings.
- `pre-commit run --all-files` passed every applicable hook.