### PR TITLE
fix: keep PII scanner formatting portable

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       # This managed scanner is synced verbatim into repositories that retain
-      # repo-specific Ruff settings. Check the same bytes at both fleet line
+      # repo-specific Ruff settings. Check the same bytes at every fleet line
       # lengths so a canonical file cannot pass here and fail after sync.
       - name: Check managed PII scanner format at 88 columns
         if: hashFiles('scripts/check_pii.py') != ''
@@ -41,6 +41,14 @@ jobs:
         with:
           version: "0.16.0"
           args: format --check --config=line-length=100
+          src: scripts/check_pii.py
+
+      - name: Check managed PII scanner format at 120 columns
+        if: hashFiles('scripts/check_pii.py') != ''
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.16.0"
+          args: format --check --config=line-length=120
           src: scripts/check_pii.py
 
       # Deterministic portability guard, run natively on the runner (Super-Linter

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -126,7 +126,8 @@ PDF_AUTHOR_RE = re.compile(
     re.IGNORECASE,
 )
 SENSITIVE_MEDIA_TAG_RE = re.compile(
-    r"GPSLatitude|GPSLongitude|OwnerName|CameraOwnerName", re.IGNORECASE
+    r"GPSLatitude|GPSLongitude|OwnerName|CameraOwnerName",
+    re.IGNORECASE,
 )
 MEDIA_AUTHOR_METADATA_RE = re.compile(
     r"(?:^|\n)(?:Author|Artist|Creator|OwnerName|CameraOwnerName)"
@@ -294,14 +295,10 @@ def placeholder_value(value: str) -> bool:
     if re.fullmatch(r"example(?:[-_.][a-z0-9]+)*", lower):
         return True
     first, separator, second = value.partition("|")
-    safe_composite = bool(
-        first
-        and separator
-        and second
-        and "|" not in second
-        and placeholder_value(first)
-        and placeholder_value(second)
-    )
+    if first and separator and second and "|" not in second:
+        safe_composite = placeholder_value(first) and placeholder_value(second)
+    else:
+        safe_composite = False
     return (
         safe_composite
         or lower in SAFE_PERSON_NAMES
@@ -440,7 +437,10 @@ def scan_contacts(
 
 
 def scan_structured_identity(
-    path: str, line_number: int, line: str, findings: set[Finding]
+    path: str,
+    line_number: int,
+    line: str,
+    findings: set[Finding],
 ) -> None:
     """Scan structured fields for customer identifiers and personal records."""
     for match in IDENTITY_FIELD_RE.finditer(line):
@@ -648,10 +648,8 @@ def render_text(findings: Sequence[Finding], *, scope: str, mode: str) -> str:
         location = finding.path
         if finding.line:
             location = f"{location}:{finding.line}"
-        lines.append(
-            f"::error file={finding.path},line={finding.line}::"
-            f"[{finding.category}] {finding.message} ({location})"
-        )
+        annotation = f"[{finding.category}] {finding.message} ({location})"
+        lines.append(f"::error file={finding.path},line={finding.line}::{annotation}")
     lines.append(f"PII {mode}: {len(findings)} finding(s) in {scope} scope.")
     return "\n".join(lines)
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -750,11 +750,11 @@ echo ""
 echo "=== Section 12: managed PII scanner Ruff portability ==="
 
 # The scanner is synced verbatim into repositories that intentionally retain
-# repo-specific Ruff settings. Ruff's formatter may join lines at 100 columns
-# that it splits at docs-control's canonical 88 columns, so both widths must
-# check the exact same bytes. These action steps are the executable regression;
+# repo-specific Ruff settings. Ruff's formatter may join lines at wider columns
+# that it splits at docs-control's canonical 88 columns, so every fleet width
+# must check the exact same bytes. These action steps are the executable regression;
 # Super-Linter still checks the caller repository's native Ruff configuration.
-for width in 88 100; do
+for width in 88 100 120; do
   if python3 - "$REPO_ROOT/.github/workflows/super-linter.yml" "$width" <<'PY'; then
 import sys
 


### PR DESCRIPTION
## Summary

Make the managed PII scanner use one Ruff-stable representation across the fleet's 88-, 100-, and 120-column configurations, and permanently exercise all three widths in the reusable lint workflow.

## Related Issue

Closes #920

## Changes

- stabilize the four width-sensitive scanner layouts without suppressions or behavior changes
- add a pinned 120-column Ruff format step beside the existing 88/100 checks
- extend the workflow regression test to require all three checks

## Verification evidence

- TDD reproduction: Ruff 0.16.0 at 120 columns reported the four unstable layouts before the scanner fix
- Ruff 0.15.17 and 0.16.0: all six format checks pass at 88/100/120 columns
- `bash tests/test-check-pii.sh`: passed
- `uv run --python 3.13 --with pyyaml bash tests/test-linter-configs.sh`: 123 passed, 0 failed
- Ruff check: passed
- Pylint 4.0.6: 10.00/10
- `pre-commit run --all-files`: every applicable hook passed, including Actions security, secrets, shell, YAML, actionlint, and Checkov
- managed PII enforcement: clean
- managed PII audit: one media-review asset inspected through source, metadata, OCR, and rendered pixels; clean
- Gitleaks: 472 commits scanned, no leaks
- CI: all 19 reported checks passed in [run 30684208193](https://github.com/f5-sales-demo/docs-control/actions/runs/30684208193)

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
