### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-01T04:06:08Z",
-  "source_commit": "3ee0f455dcf3d0d80237ffbf820ebf2036e1f0bf",
+  "generated_at": "2026-08-01T04:39:19Z",
+  "source_commit": "2cc5a82d940dcfc9e42f162eb7c59bcda71cc090",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -239,8 +239,8 @@
     "scripts/check_pii.py": {
       "src": "scripts/check_pii.py",
       "dest": "scripts/check_pii.py",
-      "sha": "5852cc80f1e058288301e0bd0f5a8354868f3dda",
-      "size": 22204
+      "sha": "3090c7bd55b763cafab42ac64cfc46899c5f8524",
+      "size": 22210
     },
     "scripts/check-pii.sh": {
       "src": "scripts/check-pii.sh",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.