### PR TITLE
fix: parse documentation identity syntax precisely

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -95,10 +95,10 @@ PERSON_FIELD_RE = re.compile(
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
 IDENTITY_FIELD_RE = re.compile(
-    r"(?i)(?:^|[,{\s])['\"]?"
+    r"(?i)(?:^|[,{\s])(?P<key_quote>['\"]?)"
     r"(?P<key>tenant(?:_name|_id)?|customer(?:_name|_id)?|account(?:_name|_id)?|"
     r"subscription(?:_name|_id)|project(?:_name|_id)|namespace)"
-    r"['\"]?\s*[:=]\s*(?P<quote>['\"`]?)"
+    r"(?P=key_quote)\s*(?P<separator>[:=])\s*(?P<quote>['\"`]?)"
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
 ADDRESS_FIELD_RE = re.compile(
@@ -294,6 +294,8 @@ def placeholder_value(value: str) -> bool:
         return True
     if re.fullmatch(r"example(?:[-_.][a-z0-9]+)*", lower):
         return True
+    if re.fullmatch(r"x[A-Z][A-Z0-9_]*x", value):
+        return True
     first, separator, second = value.partition("|")
     if first and separator and second and "|" not in second:
         safe_composite = placeholder_value(first) and placeholder_value(second)
@@ -307,13 +309,25 @@ def placeholder_value(value: str) -> bool:
     )
 
 
+def is_structured_identity_field(line: str, match: re.Match[str]) -> bool:
+    """Return whether an identity-shaped token occurs in field syntax, not prose."""
+    if match.group("separator") == "=":
+        return True
+    before = line[: match.start()].rstrip()
+    if not before:
+        return True
+    return before.endswith(("{", "[", ",")) or before in {"-", "+", "*"}
+
+
 def is_nonliteral_code_expression(path: str, match: re.Match[str]) -> bool:
     """Return whether a structured field is executable or type syntax, not data."""
-    if PurePosixPath(path).suffix.lower() not in SOURCE_CODE_SUFFIXES:
-        return False
     if match.group("quote"):
         return False
     value = normalized_value(match.group("value"))
+    if value.startswith("."):
+        return True
+    if PurePosixPath(path).suffix.lower() not in SOURCE_CODE_SUFFIXES:
+        return False
     return not bool(NUMERIC_LITERAL_RE.fullmatch(value))
 
 
@@ -444,6 +458,8 @@ def scan_structured_identity(
 ) -> None:
     """Scan structured fields for customer identifiers and personal records."""
     for match in IDENTITY_FIELD_RE.finditer(line):
+        if not is_structured_identity_field(line, match):
+            continue
         if is_nonliteral_code_expression(path, match):
             continue
         if not placeholder_value(match.group("value")):

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -115,6 +115,42 @@ git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm synthetic
 assert_clean "reserved synthetic values" "$repo" --scope head --mode enforce
 
+repo=$(new_repo documentation-expressions)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+curl "https://example.com/api/config/namespaces/xEXAMPLE_NAMESPACEx/resources" \
+  | jq '{namespace: .metadata.namespace}'
+jq -n '{metadata: {namespace: "xEXAMPLE_NAMESPACEx"}}'
+jq -n '{detail: "Namespace: write denied — create it before continuing"}'
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm expressions
+assert_clean "schematic variables and documentation expressions" "$repo" --scope head --mode enforce
+
+repo=$(new_repo documentation-prose-labels)
+cat >"${repo}/fixture.mdx" <<'EOF'
+<Note>
+Every customer: "Use the documented example tenant." Continue with the setup instructions.
+</Note>
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm prose-labels
+assert_clean "identity words used as prose labels" "$repo" --scope head --mode enforce
+
+repo=$(new_repo expression-shaped-literals)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```yaml
+namespace: xcustomer-namespacex
+```
+```json
+{"namespace": ".customer-namespace"}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm literals
+assert_violation "expression-shaped identity literals remain enforced" "$repo" --scope head --mode enforce
+
 repo=$(new_repo public-ip-contexts)
 cat >"${repo}/fixture.txt" <<'EOF'
 rfc6598=100.64.0.1/10


### PR DESCRIPTION
## Summary

Correct the canonical managed PII scanner so documentation expressions and prose labels are classified precisely while literal identity values remain enforced. The only remaining historical `csd` enforcement finding was safely classified as MDX prose without exposing its matched content; the updated scanner is clean across reachable `csd` history.

## Related Issue

Closes #923

## Changes

- require balanced quotes around structured identity keys
- recognize the established uppercase schematic variable form only
- treat unquoted dot-prefixed property expressions as executable syntax
- require colon-delimited identity labels to occur in structured field positions rather than mid-prose
- add positive and adversarial regression fixtures for each parsing boundary

## Verification evidence

- TDD: the new prose-label fixture failed with one `customer-identifier` finding before implementation and passes afterward
- `bash tests/test-check-pii.sh` — passed
- `bash tests/test-linter-configs.sh` under Python 3.14 — 123 passed, 0 failed
- Ruff 0.15.17 and 0.16.0 format checks at 88, 100, and 120 columns — passed
- Ruff 0.15.17 and 0.16.0 lint — passed
- `pylint 4.0.6 scripts/check_pii.py` — 10.00/10
- `pre-commit run --all-files` — all applicable hooks passed
- `gitleaks git --redact --no-banner` — 460 commits scanned, no leaks
- canonical scanner against `docs-control` HEAD — zero enforcement findings
- exact updated scanner against `csd` HEAD and reachable history — zero enforcement findings

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
