### PR TITLE
fix(governance): require uniform shell test gate

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -33,8 +33,8 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues", "lint / Lint Code Base"],
-        "self_contexts": ["Check linked issues", "Lint Code Base"]
+        "contexts": ["check / Check linked issues", "lint / Lint Code Base", "lint / Shell Unit Tests"],
+        "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
       "required_pull_request_reviews": null,
       "restrictions": null,
@@ -53,7 +53,7 @@
     },
     "xcsh": {
       "additional_contexts": ["check", "pii-guard", "test"],
-      "excluded_required_contexts": ["lint / Lint Code Base"]
+      "excluded_required_contexts": ["lint / Lint Code Base", "lint / Shell Unit Tests"]
     },
     "vscode-xcsh": {
       "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]
@@ -71,9 +71,6 @@
         "Validate Shell Scripts",
         "Validate Terraform Examples"
       ]
-    },
-    "mcn": {
-      "additional_contexts": ["lint / Shell Unit Tests"]
     },
     "api-specs-enriched": {
       "additional_contexts": ["Contract-diff gate", "Run pytest suite"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended**, and the translation-freshness audit still runs but no longer gates a merge — see CONTRIBUTING.md.
+- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended**, and the translation-freshness audit still runs but no longer gates a merge — see CONTRIBUTING.md.
 
 ## Two review layers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ If a branch falls behind `main` while its PR is open, use the **Update branch** 
 1. Push your branch and open a PR against `main`
 2. **Link the issue** — use `Closes #42` in the PR description, or link from the sidebar
 3. Fill out the PR template (it loads automatically)
-4. The `Check linked issues` and `Lint Code Base` CI checks will block merge if no issue is linked or linting fails
+4. The `Check linked issues`, `Lint Code Base`, and `Shell Unit Tests` CI checks block merge if the issue link, lint, or repository shell tests fail
 
 ## Step 5: Review and Merge
 
@@ -390,7 +390,7 @@ The `main` branch is protected. The following rules are enforced:
 
 - No direct pushes to `main` — all changes go through PRs
 - No force pushes
-- Required status checks: `Check linked issues` and `Lint Code Base` must pass, plus any repo-specific contexts. The `review / claude-review` check is **suspended**. `audit / Translation freshness` still runs but **no longer gates a merge**
+- Required status checks: `Check linked issues`, `Lint Code Base`, and `Shell Unit Tests` must pass, plus any repo-specific contexts. The `review / claude-review` check is **suspended**. `audit / Translation freshness` still runs but **no longer gates a merge**
 - Admin enforcement enabled — these rules apply to everyone
 
 ## AI Assistant Guidelines

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -38,7 +38,7 @@ The enforcement workflow needs admin access to modify branch protection and Page
 
 ## Self-detection
 
-Docs-control is both the provider and consumer of its own governance config. When `enforce-repo-settings.yml` runs on docs-control itself (via the `push` trigger), it detects this by comparing `managed_files.source_repo` against `github.repository`. This triggers the `self_contexts` override in branch protection -- docs-control uses workflows directly (check name: `Check linked issues`), while downstream repositories use caller wrappers (check name: `check / Check linked issues`). See the [configuration page](./configuration/) for details on `contexts` vs `self_contexts`.
+Docs-control is both the provider and consumer of its own governance config. When `enforce-repo-settings.yml` runs on docs-control itself (via the `push` trigger), it detects this by comparing `managed_files.source_repo` against `github.repository`. This triggers the `self_contexts` override in branch protection -- docs-control uses workflows directly (for example, `Shell Unit Tests`), while downstream repositories use caller wrappers (for example, `lint / Shell Unit Tests`). See the [configuration page](./configuration/) for details on `contexts` vs `self_contexts`.
 
 ## Repository layout
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -39,8 +39,12 @@ The central configuration file drives all enforcement, sync, and dispatch behavi
       "enforce_admins": true,
       "required_status_checks": {
         "strict": false,
-        "contexts": ["check / Check linked issues"],
-        "self_contexts": ["Check linked issues"]
+        "contexts": [
+          "check / Check linked issues",
+          "lint / Lint Code Base",
+          "lint / Shell Unit Tests"
+        ],
+        "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
       "required_pull_request_reviews": null,
       "restrictions": null,
@@ -105,8 +109,8 @@ An array of branch protection rules. Each entry specifies a `branch` name and th
 Key fields:
 - `enforce_admins: true` -- protection rules apply to repository administrators too
 - `required_status_checks.strict: false` -- branches don't need to be up-to-date before merging
-- `required_status_checks.contexts` -- the check names downstream repositories must pass (e.g., `check / Check linked issues`)
-- `required_status_checks.self_contexts` -- the check names docs-control itself must pass (e.g., `Check linked issues`)
+- `required_status_checks.contexts` -- the check names downstream repositories must pass (for example, `check / Check linked issues` and `lint / Shell Unit Tests`)
+- `required_status_checks.self_contexts` -- the check names docs-control itself must pass (for example, `Check linked issues` and `Shell Unit Tests`)
 - `required_pull_request_reviews: null` -- no PR review approval required
 - `restrictions: null` -- no push restrictions beyond branch protection
 
@@ -115,6 +119,12 @@ Key fields:
 When a downstream repository uses a caller workflow, the status check name becomes `<caller_job_key> / <reusable_job_name>`. For example, the `require-linked-issue.yml` caller has job key `check`, so the check name is `check / Check linked issues`. But when docs-control runs the same workflow directly (via the `pull_request_target` trigger), the check name is just `Check linked issues`.
 
 The `self_contexts` field stores the check names that apply to docs-control itself. During [enforcement](./settings-enforcement/), the workflow detects whether it's running on the source repository and swaps `self_contexts` into `contexts` before applying branch protection. The `self_contexts` field is always stripped before sending the payload to the GitHub API.
+
+`Shell Unit Tests` is the uniform repository-test gate. The reusable workflow always reports it: consumer repositories run every `tests/test-*.sh` file, while a repository with no matching tests reports success with an explicit no-tests message. This makes repository shell tests required by default instead of relying on per-repository opt-in lists.
+
+The `xcsh` override excludes both Super-Linter contexts because that repository does not call the reusable Super-Linter workflow; its native `check`, `pii-guard`, and `test` contexts remain required. Live verification must prove an exclusion is necessary before it is added.
+
+Do not require a context from a workflow with `paths` or `paths-ignore` filters. GitHub leaves that context pending when the workflow does not start. Broad security tools must run in an unfiltered pull-request workflow or in a scheduled full-tree audit; the managed workflow-security audit uses the latter model for `zizmor`. A job-level condition is safe because a skipped job still reports a successful check.
 
 ### `topics`
 

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -142,6 +142,8 @@ When a downstream repository uses a caller workflow, the GitHub Actions status c
 | Caller job key | Reusable job name | Resulting check name |
 |---|---|---|
 | `check` | `Check linked issues` | `check / Check linked issues` |
+| `lint` | `Lint Code Base` | `lint / Lint Code Base` |
+| `lint` | `Shell Unit Tests` | `lint / Shell Unit Tests` |
 
 This is why docs-control's [configuration](./configuration/) has both `contexts` (for downstream repositories) and `self_contexts` (for docs-control itself) -- the check names differ depending on whether the workflow runs directly or through a caller.
 

--- a/scripts/verify-required-contexts.sh
+++ b/scripts/verify-required-contexts.sh
@@ -36,6 +36,7 @@ set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
+REPOS_FILE="$REPO_ROOT/.github/config/downstream-repos.json"
 OWNER="f5-sales-demo"
 SAMPLE=5        # recent PRs to inspect per repo
 MIN_SAMPLES=3   # below this the evidence is inconclusive, not clean
@@ -44,28 +45,38 @@ MAX_AGE_DAYS=30 # newest sample older than this predates current workflows
 PROBLEMS=0
 CHECKED=0
 
+required_contexts_for_repo() {
+  jq -r --arg repo "$1" '
+    (.branch_protection[0].required_status_checks.contexts // []) as $base
+    | (.repo_overrides[$repo].additional_contexts // []) as $additional
+    | (.repo_overrides[$repo].excluded_required_contexts // []) as $excluded
+    | (($base + $additional | unique) - $excluded)[]
+  ' "$SETTINGS"
+}
+
+KNOWN_REPOS=$(jq -r '.[]' "$REPOS_FILE")
+
 if [ "$#" -gt 0 ]; then
   REPOS="$*"
-  # An explicitly named repository with nothing to check is almost always a typo, and
-  # silently reporting "0 problems" for it is the same failure this script exists to
-  # remove. Reject it before any work starts.
+  # Reject typos before any API work. Every governed repository now has the uniform
+  # base contexts, so an override is no longer required for a repository to be valid.
   for arg in "$@"; do
-    if ! jq -e --arg r "$arg" '.repo_overrides[$r].additional_contexts // empty' "$SETTINGS" >/dev/null 2>&1; then
-      echo "ERROR: '$arg' has no additional_contexts in $SETTINGS — nothing to verify." >&2
-      echo "       Known: $(jq -r '.repo_overrides | to_entries[] | select(.value.additional_contexts) | .key' "$SETTINGS" | tr '\n' ' ')" >&2
+    if ! grep -qxF "$arg" <<<"$KNOWN_REPOS"; then
+      echo "ERROR: '$arg' is not listed in $REPOS_FILE." >&2
+      echo "       Known: $(tr '\n' ' ' <<<"$KNOWN_REPOS")" >&2
       exit 2
     fi
   done
 else
-  REPOS=$(jq -r '.repo_overrides | to_entries[] | select(.value.additional_contexts) | .key' "$SETTINGS")
+  REPOS="$KNOWN_REPOS"
   if [ -z "$REPOS" ]; then
-    echo "ERROR: no repository declares additional_contexts — refusing to report success." >&2
+    echo "ERROR: no governed repositories are listed in $REPOS_FILE." >&2
     exit 2
   fi
 fi
 
 for repo in $REPOS; do
-  contexts=$(jq -r --arg r "$repo" '.repo_overrides[$r].additional_contexts // [] | .[]' "$SETTINGS")
+  contexts=$(required_contexts_for_repo "$repo")
   [ -z "$contexts" ] && continue
 
   echo "=== $repo ==="
@@ -213,7 +224,7 @@ echo ""
 # The two passes are complementary. Pass 1 catches names that resolve to nothing;
 # pass 2 catches names that resolve to something which can decline to run at all.
 for repo in $REPOS; do
-  contexts=$(jq -r --arg r "$repo" '.repo_overrides[$r].additional_contexts // [] | .[]' "$SETTINGS")
+  contexts=$(required_contexts_for_repo "$repo")
   [ -z "$contexts" ] && continue
 
   # Fail loudly on API trouble. Skipping quietly would let pass 2 examine nothing

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -254,6 +254,62 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 7e: the uniform shell-test job gates every governed PR
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 7e: uniform shell-test required context ==="
+
+if echo "$BASE_CTX" | jq -e 'index("lint / Shell Unit Tests") != null' >/dev/null; then
+  pass "7e.1 downstream branch protection requires Shell Unit Tests"
+else
+  fail "7e.1 downstream branch protection requires Shell Unit Tests" \
+    "lint / Shell Unit Tests is absent from the base contexts"
+fi
+
+SELF_CTX=$(jq -c \
+  '.branch_protection[0].required_status_checks.self_contexts // []' \
+  "$REPO_SETTINGS")
+if echo "$SELF_CTX" | jq -e 'index("Shell Unit Tests") != null' >/dev/null; then
+  pass "7e.2 docs-control branch protection requires Shell Unit Tests"
+else
+  fail "7e.2 docs-control branch protection requires Shell Unit Tests" \
+    "Shell Unit Tests is absent from self_contexts"
+fi
+
+MCN_CONTEXTS=$(jq -c '.repo_overrides.mcn.additional_contexts // []' "$REPO_SETTINGS")
+if echo "$MCN_CONTEXTS" | jq -e 'index("lint / Shell Unit Tests") == null' >/dev/null; then
+  pass "7e.3 mcn does not duplicate the uniform base context"
+else
+  fail "7e.3 mcn does not duplicate the uniform base context" \
+    "remove the obsolete mcn-only Shell Unit Tests override"
+fi
+
+REQUIRED_CONTEXT_VERIFIER="$REPO_ROOT/scripts/verify-required-contexts.sh"
+if grep -qF 'downstream-repos.json' "$REQUIRED_CONTEXT_VERIFIER"; then
+  pass "7e.4 live verification covers the complete governed fleet"
+else
+  fail "7e.4 live verification covers the complete governed fleet" \
+    "verify-required-contexts.sh still checks only repository overrides"
+fi
+
+if grep -qF 'required_status_checks.contexts' "$REQUIRED_CONTEXT_VERIFIER"; then
+  pass "7e.5 live verification includes uniform base contexts"
+else
+  fail "7e.5 live verification includes uniform base contexts" \
+    "verify-required-contexts.sh ignores the base required contexts"
+fi
+
+XCSH_EXCLUDED=$(jq -c '.repo_overrides.xcsh.excluded_required_contexts // []' \
+  "$REPO_SETTINGS")
+if echo "$XCSH_EXCLUDED" | jq -e \
+  'index("lint / Shell Unit Tests") != null' >/dev/null; then
+  pass "7e.6 xcsh opts out of the Super-Linter shell context it does not emit"
+else
+  fail "7e.6 xcsh opts out of the Super-Linter shell context it does not emit" \
+    "fleet verification proves xcsh never reports lint / Shell Unit Tests"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # SECTION 5e: super-linter disables validators not applicable to the
 #             ecosystem's language mix (TS/Rust/Python/Markdown/Astro)
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Make repository shell tests a default protected-branch gate so they cannot fail while a pull request still merges.

## Related Issue

Closes #877

## Changes

- require `lint / Shell Unit Tests` across governed downstream repositories and `Shell Unit Tests` in docs-control
- retain the proven `xcsh` opt-out because it does not call Super-Linter and already requires its native `check`, `pii-guard`, and `test` contexts
- expand live required-context verification from override-only repositories to all 38 governed repositories
- document the uniform gate and the policy for workflow-level path filters

## Verification evidence

- TDD regression: 3 configuration assertions and 2 verifier-coverage assertions failed before implementation; all 129 linter-configuration assertions pass afterward.
- `bash scripts/verify-required-contexts.sh`: 37 repositories reported `lint / Shell Unit Tests` on all five sampled pull requests; the only failure was the proven `xcsh` non-caller, and its targeted verification passes after the explicit opt-out.
- all `tests/test-*.sh` pass
- `pre-commit run --all-files` passes
- full textlint passes
- staged PII enforcement is clean; the single audit prompt is the visually and metadata-reviewed generic hero SVG
- staged and 461-commit Gitleaks scans report no leaks

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions

