### PR TITLE
fix: make PII fixtures pass repository hygiene

### DIFF
--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 SCANNER="${REPO_ROOT}/scripts/check-pii.sh"
 PYTHON_SCANNER="${REPO_ROOT}/scripts/check_pii.py"
+SYNTHETIC_USER=realperson
 
 FAIL=0
 WORK=$(mktemp -d)
@@ -216,19 +217,19 @@ git -C "$repo" commit -qm numeric-name
 assert_clean "numeric person fields are not names" "$repo" --scope head --mode enforce
 
 repo=$(new_repo home-path)
-printf 'cache=/Users/realperson/.cache/tool\n' >"${repo}/config.ini"
+printf 'cache=/Users/%s/.cache/tool\n' "$SYNTHETIC_USER" >"${repo}/config.ini"
 git -C "$repo" add config.ini
 git -C "$repo" commit -qm path
 assert_violation "personal home path" "$repo" --scope head --mode enforce
 
 repo=$(new_repo placeholder-paths)
-printf 'mac=/Users/you/work ci=/home/runner/work variable=/home/${USERNAME}/work route=/home/index\n' >"${repo}/config.ini"
+printf 'mac=/Users/you/work ci=/home/runner/work variable=/home/${USERNAME}/work route=/home/%s\n' index >"${repo}/config.ini"
 git -C "$repo" add config.ini
 git -C "$repo" commit -qm paths
 assert_clean "placeholder, CI, and variable home paths" "$repo" --scope head --mode enforce
 
 repo=$(new_repo embedded-home-tokens)
-printf 'keys=Shift+page/home/end route=service/Users/list windows=prefixC:\\Users\\record\n' >"${repo}/config.ini"
+printf 'keys=Shift+page/%s/%s route=service/%s/%s windows=prefixC:\\%s\\%s\n' home end Users list Users record >"${repo}/config.ini"
 git -C "$repo" add config.ini
 git -C "$repo" commit -qm tokens
 assert_clean "embedded home-like tokens are not absolute paths" "$repo" --scope head --mode enforce
@@ -413,7 +414,7 @@ git -C "$repo" commit -qm odd
 assert_violation "option-like filename containing spaces" "$repo" --scope head --mode enforce
 
 repo=$(new_repo symlink)
-ln -s /Users/realperson/private "${repo}/linked"
+ln -s "/Users/${SYNTHETIC_USER}/private" "${repo}/linked"
 git -C "$repo" add linked
 git -C "$repo" commit -qm symlink
 assert_clean "scanner does not dereference symlinks" "$repo" --scope head --mode enforce

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -849,6 +849,19 @@ PY
   fi
 done
 
+# ════════════════════════════════════════════════════════════════════
+# SECTION 13: managed security fixtures satisfy repository hygiene
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 13: managed security fixture hygiene ==="
+
+if (cd "$REPO_ROOT" && bash scripts/check-repo-hygiene.sh --include-paths >/dev/null); then
+  pass "13.1 managed security fixtures contain no literal machine-specific paths"
+else
+  fail "13.1 managed security fixtures contain no literal machine-specific paths" \
+    "the opt-in repository hygiene scan rejected governed source"
+fi
+
 # If a future assertion generates a temp file, it must clean up.
 TMPS_BEFORE=$(find /tmp -maxdepth 1 -name 'test-linter-configs-*' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$TMPS_BEFORE" = "0" ]; then


### PR DESCRIPTION
## Summary

Construct the managed synthetic home-path fixtures from separated segments so the repository-hygiene gate can scan governed source without weakening either security check. Add an integration regression that exercises the opt-in hygiene scan against docs-control itself.

## Related Issue

Closes #929

## Changes

- Preserve every generated PII fixture and rejection assertion.
- Remove literal machine-specific path shapes from governed test source.
- Add repository-hygiene coverage to the linter configuration suite.

## Verification evidence

- `PATH=/opt/homebrew/bin:$PATH bash tests/test-linter-configs.sh`: 130 passed, 0 failed.
- All 23 `tests/test-*.sh` files passed.
- `PATH=/opt/homebrew/bin:$PATH pre-commit run --all-files`: all applicable hooks passed.
- Repository-wide textlint passed.
- `gitleaks detect --redact --no-banner`: 463 commits scanned, no leaks found.
- Staged and HEAD PII enforcement passed. HEAD audit raised one media-review prompt; metadata, source text, and visual review confirmed the generic product documentation icon is clean.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions