### PR TITLE
fix: exclude translated source catalogs from codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,9 +169,9 @@ repos:
         types: [text]
         # codespell's own `skip` list only applies during its directory
         # traversal; when pre-commit passes explicit file paths it is bypassed.
-        # Filter translation dirs here so their foreign-language words
-        # (e.g. German "Referenz") never reach codespell. See issue #579.
-        exclude: ^docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/
+        # Filter translation docs and source catalogs here so their
+        # foreign-language words never reach codespell. See issues #579 and #934.
+        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|src/i18n/.*translations)
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -137,6 +137,30 @@ for word in doesnt forin invokable takin defaul ser anc checkin sevice; do
   fi
 done
 
+# pre-commit passes explicit paths, bypassing .codespellrc's skip list. Its
+# hook-level regex must filter both translated docs and translated source
+# catalogs while leaving English docs and i18n implementation code checked.
+CODESPELL_EXCLUDE=$(awk '
+  /- id: codespell$/ { in_codespell = 1; next }
+  in_codespell && /exclude:/ { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }
+' "$REPO_ROOT/.pre-commit-config.yaml")
+
+for path in docs/fr/guide.md src/i18n/mega-menu-translations.ts; do
+  if [[ "$path" =~ $CODESPELL_EXCLUDE ]]; then
+    pass "5.x codespell pre-commit excludes '$path'"
+  else
+    fail "5.x codespell pre-commit excludes '$path'" "not matched by hook exclude regex"
+  fi
+done
+
+for path in docs/en/guide.md src/i18n/translator.ts; do
+  if [[ "$path" =~ $CODESPELL_EXCLUDE ]]; then
+    fail "5.x codespell pre-commit checks '$path'" "unexpectedly matched by hook exclude regex"
+  else
+    pass "5.x codespell pre-commit checks '$path'"
+  fi
+done
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 7c: excluded_required_contexts entries must use the fully-
 #             qualified "workflow / job" form that matches the actual


### PR DESCRIPTION
## Summary

- exclude translated TypeScript catalogs from the governed codespell pre-commit hook
- keep English documentation and i18n implementation files covered
- add positive and negative regression cases to the linter configuration suite

## Verification

- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin bash tests/test-linter-configs.sh`: 134 passed
- `pre-commit run --all-files --show-diff-on-failure`: passed
- staged PII, repository-hygiene, and Gitleaks checks: clean

Closes #934