### PR TITLE
fix(governance): run shfmt in managed pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,6 +121,7 @@ repos:
           - git+https://github.com/scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb # v3.13.1-1
         args: ["--write", "--indent", "2"]
         types: [shell]
+        exclude_types: [csh, tcsh]
 
   # ===========================================================================
   # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,7 @@ repos:
   # do not depend on a contributor having shfmt installed globally.
   # ===========================================================================
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.13.1-1
+    rev: 05c1426671b9237fb5e1444dd63aa5731bec0dfb # v3.13.1-1
     hooks:
       - id: shfmt
         name: Shell format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,19 @@ repos:
         types: [markdown]
 
   # ===========================================================================
+  # Shell formatting — pinned to Super-Linter's SHELL_SHFMT v3.13.1.
+  # The prebuilt hook installs its own binary, so local and pre-commit.ci runs
+  # do not depend on a contributor having shfmt installed globally.
+  # ===========================================================================
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        name: Shell format
+        args: ["--write", "--indent", "2"]
+        types: [shell]
+
+  # ===========================================================================
   # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)
   # Replaces: shellcheck in super-linter
   # (was passing SHELLCHECK_OPTS="-e SC2016")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,14 +107,18 @@ repos:
 
   # ===========================================================================
   # Shell formatting — pinned to Super-Linter's SHELL_SHFMT v3.13.1.
-  # The prebuilt hook installs its own binary, so local and pre-commit.ci runs
-  # do not depend on a contributor having shfmt installed globally.
+  # The local Python hook installs the mirror's checksum-verified binary without
+  # requiring a global shfmt. Keeping the dependency under repo: local prevents
+  # pre-commit.ci's weekly autoupdater from advancing it ahead of Super-Linter.
   # ===========================================================================
-  - repo: https://github.com/scop/pre-commit-shfmt
-    rev: 05c1426671b9237fb5e1444dd63aa5731bec0dfb # v3.13.1-1
+  - repo: local
     hooks:
       - id: shfmt
         name: Shell format
+        entry: shfmt
+        language: python
+        additional_dependencies:
+          - git+https://github.com/scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb # v3.13.1-1
         args: ["--write", "--indent", "2"]
         types: [shell]
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -755,11 +755,11 @@ print(json.dumps(result))
 ")
 
 if echo "$SHFMT_CONFIG" | jq -e \
-  '.repo_found and .hook_found and .rev == "v3.13.1-1"' >/dev/null; then
-  pass "9.2 shfmt uses the pinned v3.13.1-1 prebuilt hook"
+  '.repo_found and .hook_found and .rev == "05c1426671b9237fb5e1444dd63aa5731bec0dfb"' >/dev/null; then
+  pass "9.2 shfmt uses the immutable v3.13.1-1 prebuilt hook commit"
 else
-  fail "9.2 shfmt uses the pinned v3.13.1-1 prebuilt hook" \
-    "expected scop/pre-commit-shfmt@v3.13.1-1 with hook id shfmt, got $SHFMT_CONFIG"
+  fail "9.2 shfmt uses the immutable v3.13.1-1 prebuilt hook commit" \
+    "expected scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb with hook id shfmt, got $SHFMT_CONFIG"
 fi
 
 if echo "$SHFMT_CONFIG" | jq -e \

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -743,6 +743,7 @@ result = {
     'additional_dependencies': None,
     'args': None,
     'types': None,
+    'exclude_types': None,
     'ci_skipped': 'shfmt' in cfg.get('ci', {}).get('skip', []),
 }
 for repo in cfg.get('repos', []):
@@ -756,6 +757,7 @@ for repo in cfg.get('repos', []):
             result['additional_dependencies'] = hook.get('additional_dependencies')
             result['args'] = hook.get('args')
             result['types'] = hook.get('types')
+            result['exclude_types'] = hook.get('exclude_types')
 print(json.dumps(result))
 ")
 
@@ -778,11 +780,12 @@ else
 fi
 
 if echo "$SHFMT_CONFIG" | jq -e \
-  '.types == ["shell"] and (.ci_skipped | not)' >/dev/null; then
-  pass "9.4 shfmt covers shell files locally and in pre-commit.ci"
+  '.types == ["shell"] and .exclude_types == ["csh", "tcsh"] and
+   (.ci_skipped | not)' >/dev/null; then
+  pass "9.4 shfmt covers Bourne shell files locally and in pre-commit.ci"
 else
-  fail "9.4 shfmt covers shell files locally and in pre-commit.ci" \
-    "expected types=[shell] and no ci.skip entry, got $SHFMT_CONFIG"
+  fail "9.4 shfmt covers Bourne shell files locally and in pre-commit.ci" \
+    "expected types=[shell], exclude_types=[csh,tcsh], and no ci.skip entry, got $SHFMT_CONFIG"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -727,6 +727,57 @@ else
     "expected pass_filenames=True (or absent), got '$ECC_PASS'"
 fi
 
+# Shell formatting must fail locally before Super-Linter's SHELL_SHFMT gate.
+# Use the prebuilt mirror rather than a language: system hook so contributors
+# and pre-commit.ci get the same formatter version without a local prerequisite.
+SHFMT_CONFIG=$(python3 -c "
+import json, yaml
+cfg = yaml.safe_load(open('$REPO_ROOT/.pre-commit-config.yaml'))
+result = {
+    'repo_found': False,
+    'rev': None,
+    'hook_found': False,
+    'args': None,
+    'types': None,
+    'ci_skipped': 'shfmt' in cfg.get('ci', {}).get('skip', []),
+}
+for repo in cfg.get('repos', []):
+    if repo.get('repo') != 'https://github.com/scop/pre-commit-shfmt':
+        continue
+    result['repo_found'] = True
+    result['rev'] = repo.get('rev')
+    for hook in repo.get('hooks', []):
+        if hook.get('id') == 'shfmt':
+            result['hook_found'] = True
+            result['args'] = hook.get('args')
+            result['types'] = hook.get('types')
+print(json.dumps(result))
+")
+
+if echo "$SHFMT_CONFIG" | jq -e \
+  '.repo_found and .hook_found and .rev == "v3.13.1-1"' >/dev/null; then
+  pass "9.2 shfmt uses the pinned v3.13.1-1 prebuilt hook"
+else
+  fail "9.2 shfmt uses the pinned v3.13.1-1 prebuilt hook" \
+    "expected scop/pre-commit-shfmt@v3.13.1-1 with hook id shfmt, got $SHFMT_CONFIG"
+fi
+
+if echo "$SHFMT_CONFIG" | jq -e \
+  '.args == ["--write", "--indent", "2"]' >/dev/null; then
+  pass "9.3 shfmt auto-formats with the CI-equivalent two-space style"
+else
+  fail "9.3 shfmt auto-formats with the CI-equivalent two-space style" \
+    "expected --write --indent 2, got $SHFMT_CONFIG"
+fi
+
+if echo "$SHFMT_CONFIG" | jq -e \
+  '.types == ["shell"] and (.ci_skipped | not)' >/dev/null; then
+  pass "9.4 shfmt covers shell files locally and in pre-commit.ci"
+else
+  fail "9.4 shfmt covers shell files locally and in pre-commit.ci" \
+    "expected types=[shell] and no ci.skip entry, got $SHFMT_CONFIG"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 10: secrets_manifest schema validity
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -728,38 +728,45 @@ else
 fi
 
 # Shell formatting must fail locally before Super-Linter's SHELL_SHFMT gate.
-# Use the prebuilt mirror rather than a language: system hook so contributors
-# and pre-commit.ci get the same formatter version without a local prerequisite.
+# Install the prebuilt mirror as a local Python hook so contributors and
+# pre-commit.ci get the same formatter version without a local prerequisite,
+# while pre-commit.ci's weekly autoupdater cannot rewrite its pinned revision.
 SHFMT_CONFIG=$(python3 -c "
 import json, yaml
 cfg = yaml.safe_load(open('$REPO_ROOT/.pre-commit-config.yaml'))
 result = {
-    'repo_found': False,
+    'repo': None,
     'rev': None,
     'hook_found': False,
+    'entry': None,
+    'language': None,
+    'additional_dependencies': None,
     'args': None,
     'types': None,
     'ci_skipped': 'shfmt' in cfg.get('ci', {}).get('skip', []),
 }
 for repo in cfg.get('repos', []):
-    if repo.get('repo') != 'https://github.com/scop/pre-commit-shfmt':
-        continue
-    result['repo_found'] = True
-    result['rev'] = repo.get('rev')
     for hook in repo.get('hooks', []):
         if hook.get('id') == 'shfmt':
+            result['repo'] = repo.get('repo')
+            result['rev'] = repo.get('rev')
             result['hook_found'] = True
+            result['entry'] = hook.get('entry')
+            result['language'] = hook.get('language')
+            result['additional_dependencies'] = hook.get('additional_dependencies')
             result['args'] = hook.get('args')
             result['types'] = hook.get('types')
 print(json.dumps(result))
 ")
 
 if echo "$SHFMT_CONFIG" | jq -e \
-  '.repo_found and .hook_found and .rev == "05c1426671b9237fb5e1444dd63aa5731bec0dfb"' >/dev/null; then
-  pass "9.2 shfmt uses the immutable v3.13.1-1 prebuilt hook commit"
+  '.hook_found and .repo == "local" and .rev == null and
+   .entry == "shfmt" and .language == "python" and
+   .additional_dependencies == ["git+https://github.com/scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb"]' >/dev/null; then
+  pass "9.2 shfmt uses an immutable auto-installed dependency outside autoupdate"
 else
-  fail "9.2 shfmt uses the immutable v3.13.1-1 prebuilt hook commit" \
-    "expected scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb with hook id shfmt, got $SHFMT_CONFIG"
+  fail "9.2 shfmt uses an immutable auto-installed dependency outside autoupdate" \
+    "expected a local Python hook pinned to scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb, got $SHFMT_CONFIG"
 fi
 
 if echo "$SHFMT_CONFIG" | jq -e \


### PR DESCRIPTION
## Summary

Add shfmt to the canonical managed pre-commit configuration so shell formatting failures are corrected before the required Super-Linter gate.

## Related Issue

Closes #876

## Changes

- add an auto-installed shfmt v3.13.1 hook with two-space indentation, matching `SHELL_SHFMT`
- pin the checksum-verifying mirror by immutable commit and keep it under `repo: local`, outside weekly pre-commit autoupdates
- preserve upstream exclusions for C shell and tcsh files
- add regression coverage for the installation source, immutable pin, arguments, file types, exclusions, and pre-commit.ci participation

## Verification evidence

- TDD: the initial hook assertions failed 130/3 before implementation and passed 133/133 afterward
- review regression: immutable-pin assertion failed 132/1 on the mutable tag, then passed on commit `05c1426671b9237fb5e1444dd63aa5731bec0dfb`
- updater regression: the same assertion failed 132/1 while the hook was autoupdate-managed, then passed with the pinned local Python dependency
- C-shell regression: assertion 9.4 failed 132/1 without exclusions, then passed with `exclude_types: [csh, tcsh]`
- every `tests/test-*.sh` suite passes after the final change and after rebasing onto current `origin/main`
- `pre-commit run --all-files` passes, including `Shell format`
- verified review: 3 rounds, 3 confirmed findings fixed; final gate `done: true`, `findingsClear: true`, `escalate: false`

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
