### PR TITLE
fix(governance): classify consumer shell unit tests

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -76,6 +76,33 @@
       "additional_contexts": ["Contract-diff gate", "Run pytest suite"]
     }
   },
+  "consumer_shell_tests": {
+    "profiles": {
+      "devcontainer": {
+        "unit": [
+          { "path": "tests/test-check-pii.sh", "args": [] },
+          { "path": "tests/test-check-repo-hygiene.sh", "args": [] },
+          { "path": "tests/test-fetch-governed.sh", "args": [] },
+          { "path": "tests/test-hook-neutralization.sh", "args": ["--unit-only"] },
+          { "path": "tests/test-inlined-helpers-match.sh", "args": [] }
+        ],
+        "environment": [
+          {
+            "path": "tests/test-firecrawl.sh",
+            "reason": "requires Redis, PostgreSQL, Playwright, and Firecrawl inside the running devcontainer"
+          },
+          {
+            "path": "tests/test-lsp-coverage.sh",
+            "reason": "requires the image's installed language servers and Claude plugin settings"
+          },
+          {
+            "path": "tests/test-npx-resolution.sh",
+            "reason": "requires the image's preinstalled npm toolchain and resolution links"
+          }
+        ]
+      }
+    }
+  },
   "topics": [],
   "pages": {
     "enabled": true,

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -409,6 +409,10 @@ jobs:
         if: hashFiles('tests/test-linter-configs.sh') != ''
         run: bash tests/test-linter-configs.sh
 
+      - name: Run consumer shell-test selector test
+        if: hashFiles('tests/test-consumer-shell-tests.sh') != ''
+        run: bash tests/test-consumer-shell-tests.sh
+
       - name: Run README generation test
         if: hashFiles('tests/test-readme-generation.sh') != ''
         run: bash tests/test-readme-generation.sh
@@ -449,26 +453,41 @@ jobs:
         if: hashFiles('tests/test-require-linked-issue-exemptions.sh') != ''
         run: bash tests/test-require-linked-issue-exemptions.sh
 
-      # Consumer repos: auto-run their OWN tests/test-*.sh so a caller repo (e.g.
-      # code-review) gets shell-unit-test coverage through this reusable workflow
-      # without editing the enumerated list above. Skipped in docs-control itself,
-      # whose machinery tests are deliberately curated and enumerated above — a
-      # glob here would also pick up docs-control-only fixtures/orphans. In a
-      # workflow_call, github.repository is the CALLER's repo, so the gate is exact.
+      # Consumer repos: run their OWN hermetic tests/test-*.sh through canonical
+      # docs-control selection. The default remains every matching script. A repo
+      # that mixes unit and environment tests can have a complete, fail-closed
+      # profile in repo-settings.json; inventory drift then fails before execution.
+      # Fetch both runner and config from the same trusted canonical revision so a
+      # pull request cannot edit its own profile to evade the required context.
+      # Skipped in docs-control itself, whose tests are curated above.
       - name: Run consumer shell unit tests
         if: github.repository != 'f5-sales-demo/docs-control'
         shell: bash
         run: |
-          shopt -s nullglob
-          tests=(tests/test-*.sh)
-          if [ ${#tests[@]} -eq 0 ]; then
-            echo "No tests/test-*.sh present in ${GITHUB_REPOSITORY}; nothing to run."
-            exit 0
+          set -euo pipefail
+          remote="${GOVERNANCE_REMOTE:-https://github.com/f5-sales-demo/docs-control}"
+          gov_dir=$(mktemp -d)
+          trap 'rm -rf "$gov_dir"' EXIT
+          git init --quiet "$gov_dir"
+          if ! git -C "$gov_dir" fetch --no-tags --quiet --depth=1 "$remote" main 2>/dev/null; then
+            echo "::error::cannot reach canonical governance at ${remote} -- refusing to guess which consumer tests are safe"
+            exit 1
           fi
-          rc=0
-          for t in "${tests[@]}"; do
-            echo "::group::$t"
-            if bash "$t"; then echo "PASS: $t"; else echo "::error::FAIL: $t"; rc=1; fi
-            echo "::endgroup::"
+
+          canonical_sha=$(git -C "$gov_dir" rev-parse FETCH_HEAD)
+          runner=scripts/run-consumer-shell-tests.sh
+          config=.github/config/repo-settings.json
+          for artifact in "$runner" "$config"; do
+            if ! git -C "$gov_dir" cat-file -e "${canonical_sha}:${artifact}" 2>/dev/null; then
+              echo "::error::canonical governance @ ${canonical_sha} is missing ${artifact}"
+              exit 1
+            fi
           done
-          exit "$rc"
+
+          git -C "$gov_dir" archive "$canonical_sha" "$runner" "$config" |
+            tar -xf - -C "$gov_dir"
+          echo "Selecting consumer shell tests from canonical governance @ ${canonical_sha}"
+          bash "${gov_dir}/${runner}" \
+            --root "$GITHUB_WORKSPACE" \
+            --config "${gov_dir}/${config}" \
+            --repository "$GITHUB_REPOSITORY"

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -122,6 +122,17 @@ The `self_contexts` field stores the check names that apply to docs-control itse
 
 `Shell Unit Tests` is the uniform repository-test gate. The reusable workflow always reports it: consumer repositories run every `tests/test-*.sh` file, while a repository with no matching tests reports success with an explicit no-tests message. This makes repository shell tests required by default instead of relying on per-repository opt-in lists.
 
+#### Consumer shell-test profiles
+
+The default assumes every root-level `tests/test-*.sh` script is hermetic on an unprovisioned GitHub-hosted runner. A repository that also stores container or service integration tests under that glob needs a `consumer_shell_tests.profiles` entry in `repo-settings.json`.
+
+Each profile classifies the complete matching inventory:
+
+- `unit` entries contain a test `path` and an `args` array. The runner passes each argument literally, without shell evaluation.
+- `environment` entries contain a test `path` and a non-empty `reason` explaining why the bare-runner unit gate cannot execute it.
+
+The reusable workflow fetches the selector and configuration from the same docs-control `main` revision, logs that revision, and validates the inventory before running anything. Missing configuration, unsafe paths or arguments, duplicate paths, and unclassified or missing tests fail the required context. This makes a profile an audited classification contract rather than an ignore list. Repositories without a profile keep the broad default.
+
 The `xcsh` override excludes both Super-Linter contexts because that repository does not call the reusable Super-Linter workflow; its native `check`, `pii-guard`, and `test` contexts remain required. Live verification must prove an exclusion is necessary before it is added.
 
 Do not require a context from a workflow with `paths` or `paths-ignore` filters. GitHub leaves that context pending when the workflow does not start. Broad security tools must run in an unfiltered pull-request workflow or in a scheduled full-tree audit; the managed workflow-security audit uses the latter model for `zizmor`. A job-level condition is safe because a skipped job still reports a successful check.

--- a/scripts/run-consumer-shell-tests.sh
+++ b/scripts/run-consumer-shell-tests.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Run consumer shell unit tests from a trusted, fail-closed fleet profile.
+set -euo pipefail
+
+ROOT=""
+CONFIG=""
+REPOSITORY=""
+
+usage() {
+  echo "Usage: $0 --root PATH --config PATH --repository OWNER/REPO" >&2
+}
+
+die() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --root)
+    [ "$#" -ge 2 ] || {
+      usage
+      exit 2
+    }
+    ROOT="$2"
+    shift 2
+    ;;
+  --config)
+    [ "$#" -ge 2 ] || {
+      usage
+      exit 2
+    }
+    CONFIG="$2"
+    shift 2
+    ;;
+  --repository)
+    [ "$#" -ge 2 ] || {
+      usage
+      exit 2
+    }
+    REPOSITORY="$2"
+    shift 2
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+  esac
+done
+
+[ -d "$ROOT" ] || die "cannot read consumer repository root: $ROOT"
+[ -r "$CONFIG" ] || die "cannot read canonical shell-test configuration: $CONFIG"
+case "$REPOSITORY" in
+*[!A-Za-z0-9_./-]* | */*/* | /* | */) die "malformed repository name: $REPOSITORY" ;;
+*/*) ;;
+*) die "malformed repository name: $REPOSITORY" ;;
+esac
+
+if ! jq -e \
+  '.consumer_shell_tests | type == "object" and (.profiles | type == "object")' \
+  "$CONFIG" >/dev/null 2>&1; then
+  die "malformed canonical shell-test configuration: expected consumer_shell_tests.profiles object"
+fi
+
+repo_name=${REPOSITORY##*/}
+profile=$(jq -c --arg repo "$repo_name" \
+  '.consumer_shell_tests.profiles[$repo] // null' "$CONFIG") ||
+  die "malformed canonical shell-test configuration"
+
+shopt -s nullglob
+discovered=""
+for test_path in "$ROOT"/tests/test-*.sh; do
+  # Match the old glob contract, including symlinks, but not directories.
+  if [ -f "$test_path" ] || [ -L "$test_path" ]; then
+    relative=${test_path#"$ROOT"/}
+    discovered="${discovered}${relative}"$'\n'
+  fi
+done
+discovered=$(printf '%s' "$discovered" | sed '/^$/d' | LC_ALL=C sort)
+
+run_one() {
+  local path="$1"
+  shift
+  echo "::group::$path"
+  if (cd "$ROOT" && bash "$path" "$@"); then
+    echo "PASS: $path"
+    echo "::endgroup::"
+    return 0
+  fi
+  echo "::error::FAIL: $path"
+  echo "::endgroup::"
+  return 1
+}
+
+if [ "$profile" = "null" ]; then
+  if [ -z "$discovered" ]; then
+    echo "No tests/test-*.sh present in ${REPOSITORY}; nothing to run."
+    exit 0
+  fi
+
+  rc=0
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    run_one "$path" || rc=1
+  done <<<"$discovered"
+  exit "$rc"
+fi
+
+if ! jq -e '
+  type == "object" and
+  (.unit | type == "array") and
+  (.environment | type == "array") and
+  all(.unit[];
+    type == "object" and
+    (.path | type == "string") and
+    (.args | type == "array") and
+    all(.args[]; type == "string")) and
+  all(.environment[];
+    type == "object" and
+    (.path | type == "string") and
+    (.reason | type == "string" and test("[^[:space:]]")))
+' <<<"$profile" >/dev/null 2>&1; then
+  die "malformed shell-test profile for ${repo_name}"
+fi
+
+unsafe_path=$(jq -r '
+  [.unit[].path, .environment[].path][] |
+  select(test("^tests/test-[A-Za-z0-9._-]+[.]sh$") | not)
+' <<<"$profile" | sed -n '1p')
+[ -z "$unsafe_path" ] || die "unsafe test path in ${repo_name} profile: $unsafe_path"
+
+unsafe_arg=$(jq -r '
+  .unit[].args[] |
+  select(test("^--?[A-Za-z0-9][A-Za-z0-9._=-]*$") | not)
+' <<<"$profile" | sed -n '1p')
+[ -z "$unsafe_arg" ] || die "unsafe test argument in ${repo_name} profile: $unsafe_arg"
+
+duplicates=$(jq -r '[.unit[].path, .environment[].path][]' <<<"$profile" |
+  LC_ALL=C sort | uniq -d)
+[ -z "$duplicates" ] || die "duplicate test path in ${repo_name} profile: $duplicates"
+
+expected=$(jq -r '[.unit[].path, .environment[].path][]' <<<"$profile" | LC_ALL=C sort)
+if [ "$discovered" != "$expected" ]; then
+  {
+    echo "::error::${repo_name} test inventory does not match its canonical profile"
+    echo "--- discovered tests"
+    printf '%s\n' "$discovered"
+    echo "--- configured tests"
+    printf '%s\n' "$expected"
+  } >&2
+  exit 1
+fi
+
+rc=0
+unit_count=$(jq '.unit | length' <<<"$profile")
+index=0
+while [ "$index" -lt "$unit_count" ]; do
+  path=$(jq -r --argjson index "$index" '.unit[$index].path' <<<"$profile")
+  args_json=$(jq -c --argjson index "$index" '.unit[$index].args' <<<"$profile")
+  if [ "$args_json" = "[]" ]; then
+    run_one "$path" || rc=1
+  else
+    args=()
+    while IFS= read -r arg; do
+      args+=("$arg")
+    done < <(jq -r '.[]' <<<"$args_json")
+    run_one "$path" "${args[@]}" || rc=1
+  fi
+  index=$((index + 1))
+done
+
+while IFS=$'\t' read -r path reason; do
+  [ -n "$path" ] || continue
+  echo "::notice::Not run by the bare-runner unit profile: ${path} — ${reason}"
+done < <(jq -r '.environment[] | [.path, .reason] | @tsv' <<<"$profile")
+
+exit "$rc"

--- a/tests/test-consumer-shell-tests.sh
+++ b/tests/test-consumer-shell-tests.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Contract tests for the fail-closed consumer shell-test selector.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+RUNNER="${REPO_ROOT}/scripts/run-consumer-shell-tests.sh"
+SETTINGS="${REPO_ROOT}/.github/config/repo-settings.json"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0
+FAIL=0
+LAST_RC=0
+LAST_OUTPUT=""
+
+pass() {
+  echo "  [PASS] $1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  echo "  [FAIL] $1${2:+ — $2}"
+  FAIL=$((FAIL + 1))
+}
+
+assert_rc() {
+  local want="$1" label="$2"
+  if [ "$LAST_RC" -eq "$want" ]; then
+    pass "$label"
+  else
+    fail "$label" "expected rc=$want, got rc=$LAST_RC; output: $LAST_OUTPUT"
+  fi
+}
+
+assert_contains() {
+  local needle="$1" label="$2"
+  if grep -qF -- "$needle" <<<"$LAST_OUTPUT"; then
+    pass "$label"
+  else
+    fail "$label" "missing '$needle'; output: $LAST_OUTPUT"
+  fi
+}
+
+run_selector() {
+  local root="$1" config="$2" repository="$3"
+  LAST_RC=0
+  LAST_OUTPUT=$(TEST_LOG="${root}/executed.log" bash "$RUNNER" \
+    --root "$root" --config "$config" --repository "$repository" 2>&1) || LAST_RC=$?
+}
+
+new_root() {
+  local name="$1"
+  mkdir -p "${WORK}/${name}/tests"
+  printf '%s\n' "${WORK}/${name}"
+}
+
+write_probe() {
+  local root="$1" name="$2"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'printf "%s:%s\n" "$(basename "$0")" "$*" >> "$TEST_LOG"' \
+    >"${root}/tests/${name}"
+}
+
+write_config() {
+  local name="$1" body="$2"
+  printf '%s\n' "$body" >"${WORK}/${name}.json"
+  printf '%s\n' "${WORK}/${name}.json"
+}
+
+echo "=== Consumer shell-test selector ==="
+
+# Default behavior stays deliberately broad: every root-level test-*.sh runs.
+root=$(new_root default)
+write_probe "$root" test-b.sh
+write_probe "$root" test-a.sh
+config=$(write_config default '{"consumer_shell_tests":{"profiles":{}}}')
+run_selector "$root" "$config" f5-sales-demo/example
+assert_rc 0 "default profile succeeds"
+expected=$'test-a.sh:\ntest-b.sh:'
+actual=$(cat "${root}/executed.log" 2>/dev/null || true)
+if [ "$actual" = "$expected" ]; then
+  pass "default profile runs every test in stable order"
+else
+  fail "default profile runs every test in stable order" "got: $actual"
+fi
+
+# No tests is a valid, explicit success for an unprofiled repository.
+root=$(new_root empty)
+run_selector "$root" "$config" f5-sales-demo/empty
+assert_rc 0 "unprofiled repository with no tests succeeds"
+assert_contains "No tests/test-*.sh present" "no-tests result is visible"
+
+# A profile is an argv contract, not a shell command string.
+root=$(new_root profiled)
+write_probe "$root" test-unit.sh
+write_probe "$root" test-environment.sh
+config=$(write_config profiled '{
+  "consumer_shell_tests": {
+    "profiles": {
+      "profiled": {
+        "unit": [{"path":"tests/test-unit.sh","args":["--unit-only"]}],
+        "environment": [{"path":"tests/test-environment.sh","reason":"requires a running service"}]
+      }
+    }
+  }
+}')
+run_selector "$root" "$config" f5-sales-demo/profiled
+assert_rc 0 "profiled selection succeeds"
+actual=$(cat "${root}/executed.log" 2>/dev/null || true)
+if [ "$actual" = "test-unit.sh:--unit-only" ]; then
+  pass "profile invokes unit test with literal argv and not the environment test"
+else
+  fail "profile invokes unit test with literal argv and not the environment test" "got: $actual"
+fi
+assert_contains "requires a running service" "environment classification is reported"
+
+# Inventory comparison is fail-closed in both directions and happens before execution.
+root=$(new_root extra)
+write_probe "$root" test-unit.sh
+write_probe "$root" test-new.sh
+run_selector "$root" "$config" f5-sales-demo/profiled
+assert_rc 1 "unclassified test fails the profile"
+assert_contains "inventory does not match" "unclassified-test failure explains the drift"
+if [ ! -e "${root}/executed.log" ]; then
+  pass "inventory drift fails before any test executes"
+else
+  fail "inventory drift fails before any test executes"
+fi
+
+root=$(new_root missing)
+write_probe "$root" test-unit.sh
+run_selector "$root" "$config" f5-sales-demo/profiled
+assert_rc 1 "missing classified test fails the profile"
+assert_contains "inventory does not match" "missing-test failure explains the drift"
+
+# Duplicate and unsafe paths are rejected even if the inventory could otherwise match.
+root=$(new_root duplicate)
+write_probe "$root" test-unit.sh
+config=$(write_config duplicate '{
+  "consumer_shell_tests": {
+    "profiles": {
+      "duplicate": {
+        "unit": [{"path":"tests/test-unit.sh","args":[]}],
+        "environment": [{"path":"tests/test-unit.sh","reason":"duplicate"}]
+      }
+    }
+  }
+}')
+run_selector "$root" "$config" f5-sales-demo/duplicate
+assert_rc 1 "duplicate classified path fails"
+assert_contains "duplicate" "duplicate-path failure is explicit"
+
+config=$(write_config unsafe '{
+  "consumer_shell_tests": {
+    "profiles": {
+      "unsafe": {
+        "unit": [{"path":"tests/../test-unit.sh","args":[]}],
+        "environment": []
+      }
+    }
+  }
+}')
+run_selector "$root" "$config" f5-sales-demo/unsafe
+assert_rc 1 "unsafe test path fails"
+assert_contains "unsafe" "unsafe-path failure is explicit"
+
+# Canonical configuration is required and must have the expected schema.
+config=$(write_config malformed '{"consumer_shell_tests":{"profiles":[]}}')
+run_selector "$root" "$config" f5-sales-demo/example
+assert_rc 1 "malformed canonical profile map fails"
+assert_contains "malformed" "malformed configuration failure is explicit"
+
+run_selector "$root" "${WORK}/absent.json" f5-sales-demo/example
+assert_rc 1 "missing canonical configuration fails"
+assert_contains "cannot read" "missing configuration failure is explicit"
+
+run_selector "$root" "$config" f5-sales-demo/example/extra
+assert_rc 1 "malformed repository name fails"
+assert_contains "malformed repository" "repository-name failure is explicit"
+
+# The production profile accounts for the complete devcontainer inventory.
+if jq -e '
+  .consumer_shell_tests.profiles.devcontainer as $p |
+  ($p.unit | map(.path)) == [
+    "tests/test-check-pii.sh",
+    "tests/test-check-repo-hygiene.sh",
+    "tests/test-fetch-governed.sh",
+    "tests/test-hook-neutralization.sh",
+    "tests/test-inlined-helpers-match.sh"
+  ] and
+  ($p.unit[] | select(.path == "tests/test-hook-neutralization.sh") | .args) == ["--unit-only"] and
+  ($p.environment | map(.path)) == [
+    "tests/test-firecrawl.sh",
+    "tests/test-lsp-coverage.sh",
+    "tests/test-npx-resolution.sh"
+  ] and
+  all($p.environment[]; (.reason | type == "string" and length > 0))
+' "$SETTINGS" >/dev/null 2>&1; then
+  pass "canonical devcontainer profile classifies the complete inventory"
+else
+  fail "canonical devcontainer profile classifies the complete inventory"
+fi
+
+DOWNSTREAM="${REPO_ROOT}/.github/config/downstream-repos.json"
+if jq -e --slurpfile repos "$DOWNSTREAM" '
+  (.consumer_shell_tests.profiles | keys) as $profiles |
+  all($profiles[]; . as $profile | $repos[0] | index($profile) != null)
+' "$SETTINGS" >/dev/null 2>&1; then
+  pass "every canonical profile names a governed repository"
+else
+  fail "every canonical profile names a governed repository"
+fi
+
+WORKFLOW="${REPO_ROOT}/.github/workflows/super-linter.yml"
+if grep -qF 'scripts/run-consumer-shell-tests.sh' "$WORKFLOW" &&
+  grep -qF '.github/config/repo-settings.json' "$WORKFLOW" &&
+  grep -qF 'canonical_sha' "$WORKFLOW"; then
+  pass "reusable workflow executes runner and config from logged canonical revision"
+else
+  fail "reusable workflow executes runner and config from logged canonical revision"
+fi
+
+echo ""
+echo "=== Summary: $PASS passed, $FAIL failed ==="
+exit "$FAIL"


### PR DESCRIPTION
## Summary

Keep `lint / Shell Unit Tests` required while preventing bare GitHub runners from executing devcontainer-only integration suites.

## Related issue

Closes #941

## Changes

- add a canonical, fail-closed consumer shell-test selector that preserves the all-tests default
- add a complete devcontainer profile: five hermetic commands run, including hook neutralization with literal `--unit-only` argv; Firecrawl, LSP, and npx suites are classified as container-environment tests
- fetch the selector and profile from one logged docs-control `main` revision so a downstream PR cannot edit its own selection
- fail before execution on missing or malformed config, unsafe/duplicate paths, or any inventory drift
- document the profile contract and add 25 contract assertions

## Verification evidence

- TDD: the new suite initially reported 21 failures with no selector/profile; it now reports `25 passed, 0 failed`
- all 24 `tests/test-*.sh` suites pass with `PATH=/opt/homebrew/bin:$PATH`
- live devcontainer inventory run with GNU `stat`: all five hermetic entries pass; hook-neutralization reports `42 passed, 0 failed`; three environment suites emit explicit notices
- `pre-commit run --all-files` passes
- full textlint passes for `docs/configuration.mdx`
- ShellCheck and shfmt pass for both new shell files
- staged PII enforcement is clean; audit reports only the unchanged, previously metadata/OCR/visually reviewed generic `docs/images/hero.svg`
- the configured local `codex:verified-code-review` command is unavailable in this environment, so no substitute PR-diff reviewer was used

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running the actual devcontainer profile — evidence above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
