### PR TITLE
fix(governance): lint PII scanner at canonical source

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -24,11 +24,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # This managed scanner is synced verbatim into repositories that retain
-      # repo-specific Ruff settings. Check the same bytes at every fleet line
-      # lengths so a canonical file cannot pass here and fail after sync.
+      # This scanner is managed and synced verbatim. Enforce its portability
+      # where it is authored; checking a downstream caller's stale copy blocks
+      # an unrelated PR with a file that repository is forbidden to edit. The
+      # three canonical widths still guard every Ruff configuration in the fleet.
       - name: Check managed PII scanner format at 88 columns
-        if: hashFiles('scripts/check_pii.py') != ''
+        if: github.repository == 'f5-sales-demo/docs-control' && hashFiles('scripts/check_pii.py') != ''
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.16.0"
@@ -36,7 +37,7 @@ jobs:
           src: scripts/check_pii.py
 
       - name: Check managed PII scanner format at 100 columns
-        if: hashFiles('scripts/check_pii.py') != ''
+        if: github.repository == 'f5-sales-demo/docs-control' && hashFiles('scripts/check_pii.py') != ''
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.16.0"
@@ -44,7 +45,7 @@ jobs:
           src: scripts/check_pii.py
 
       - name: Check managed PII scanner format at 120 columns
-        if: hashFiles('scripts/check_pii.py') != ''
+        if: github.repository == 'f5-sales-demo/docs-control' && hashFiles('scripts/check_pii.py') != ''
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
         with:
           version: "0.16.0"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -890,11 +890,9 @@ rm -rf "$GI_TMP"
 echo ""
 echo "=== Section 12: managed PII scanner Ruff portability ==="
 
-# The scanner is synced verbatim into repositories that intentionally retain
-# repo-specific Ruff settings. Ruff's formatter may join lines at wider columns
-# that it splits at docs-control's canonical 88 columns, so every fleet width
-# must check the exact same bytes. These action steps are the executable regression;
-# Super-Linter still checks the caller repository's native Ruff configuration.
+# The scanner is synced verbatim, so its formatter portability is enforced where
+# it is authored. Rechecking a caller's stale managed copy deadlocks unrelated
+# downstream PRs: they are forbidden to fix it, while the sync PR cannot land.
 for width in 88 100 120; do
   if python3 - "$REPO_ROOT/.github/workflows/super-linter.yml" "$width" <<'PY'; then
 import sys
@@ -914,7 +912,10 @@ if len(matching) != 1:
 step = matching[0]
 expected = {
     "uses": "astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89",
-    "if": "hashFiles('scripts/check_pii.py') != ''",
+    "if": (
+        "github.repository == 'f5-sales-demo/docs-control' && "
+        "hashFiles('scripts/check_pii.py') != ''"
+    ),
 }
 if any(step.get(key) != value for key, value in expected.items()):
     raise SystemExit(1)
@@ -927,10 +928,10 @@ if inputs.get("src") != "scripts/check_pii.py":
 if inputs.get("args") != f"format --check --config=line-length={width}":
     raise SystemExit(1)
 PY
-    pass "12.x super-linter checks PII scanner at ${width} columns"
+    pass "12.x docs-control checks canonical PII scanner at ${width} columns"
   else
-    fail "12.x super-linter checks PII scanner at ${width} columns" \
-      "missing or incorrectly pinned Ruff action step"
+    fail "12.x docs-control checks canonical PII scanner at ${width} columns" \
+      "missing, incorrectly pinned, or not source-repository scoped"
   fi
 done
 


### PR DESCRIPTION
## Summary

Prevent stale synchronized PII-scanner bytes from blocking unrelated downstream PRs that are forbidden to edit managed files.

## Related issue

Closes #943

## Changes

- retain Ruff format checks at 88, 100, and 120 columns
- scope all three checks to `f5-sales-demo/docs-control`, where the managed scanner is authored and reviewed
- strengthen the regression test so every width must carry the source-repository condition
- leave required contexts, the downstream shell-test gate, and downstream managed-file guards unchanged

## Verification evidence

- TDD: section 12 reported three failures before implementation and now passes at all three widths
- all 24 `tests/test-*.sh` suites pass
- `pre-commit run --all-files` passes
- the configured local `codex:verified-code-review` command is unavailable in this environment, so no substitute PR-diff reviewer was used

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally — evidence above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
