### PR TITLE
fix: preserve PII identity enforcement across structured prefixes

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -71,6 +71,8 @@ SOURCE_CODE_SUFFIXES = {
     ".ts",
     ".tsx",
 }
+DOCUMENTATION_PROSE_SUFFIXES = {".adoc", ".asciidoc", ".md", ".mdx", ".rst", ".txt"}
+JQ_SOURCE_SUFFIXES = {".jq"}
 
 EMAIL_RE = re.compile(
     r"(?<![-A-Za-z0-9._%+/])"
@@ -95,7 +97,7 @@ PERSON_FIELD_RE = re.compile(
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
 IDENTITY_FIELD_RE = re.compile(
-    r"(?i)(?:^|[,{\s])(?P<key_quote>['\"]?)"
+    r"(?i)(?P<delimiter>^|[,{\[\s])(?P<key_quote>['\"]?)"
     r"(?P<key>tenant(?:_name|_id)?|customer(?:_name|_id)?|account(?:_name|_id)?|"
     r"subscription(?:_name|_id)|project(?:_name|_id)|namespace)"
     r"(?P=key_quote)\s*(?P<separator>[:=])\s*(?P<quote>['\"`]?)"
@@ -148,6 +150,20 @@ NUMERIC_LITERAL_RE = re.compile(
     r"[0-9][0-9_]*(?:\.[0-9_]+)?"
     r");?"
 )
+ISO_TIMESTAMP_PREFIX_RE = re.compile(
+    r"^\s*[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})?(?:\s|$)",
+)
+LOG_LEVEL_PREFIX_RE = re.compile(
+    r"(?:^|[\s|])(?:trace|debug|info|warn(?:ing)?|error|fatal|critical)(?:[\s:\]]|$)",
+    re.IGNORECASE,
+)
+MARKDOWN_STRUCTURAL_PREFIX_RE = re.compile(r"^\s*(?:>|[-+*]|[0-9]+[.)]|\|)(?:\s|$)")
+PROSE_IDENTITY_PREFIX_RE = re.compile(
+    r"(?:^|\s)(?:a|all|an|any|each|every|no|one|our|the|their|these|this|those|your)\s*$",
+    re.IGNORECASE,
+)
+JQ_COMMAND_PREFIX_RE = re.compile(r"(?:^|[|;&(]\s*)jq(?:\s|$)", re.IGNORECASE)
 
 SAFE_EMAIL_DOMAINS = {"example.com", "example.net", "example.org"}
 PROVENANCE_EMAIL_DOMAINS = {"noreply.github.com", "users.noreply.github.com"}
@@ -309,24 +325,42 @@ def placeholder_value(value: str) -> bool:
     )
 
 
-def is_structured_identity_field(line: str, match: re.Match[str]) -> bool:
+def is_structured_identity_field(
+    path: str,
+    line: str,
+    match: re.Match[str],
+) -> bool:
     """Return whether an identity-shaped token occurs in field syntax, not prose."""
-    if match.group("separator") == "=":
+    if match.group("separator") == "=" or match.group("delimiter") in {",", "{", "["}:
         return True
-    before = line[: match.start()].rstrip()
-    if not before:
-        return True
-    return before.endswith(("{", "[", ",")) or before in {"-", "+", "*"}
+    prefix = line[: match.start()]
+    prose_label = (
+        bool(prefix.strip())
+        and PurePosixPath(path).suffix.lower() in DOCUMENTATION_PROSE_SUFFIXES
+        and not MARKDOWN_STRUCTURAL_PREFIX_RE.match(prefix)
+        and not ISO_TIMESTAMP_PREFIX_RE.match(prefix)
+        and not LOG_LEVEL_PREFIX_RE.search(prefix)
+        and bool(PROSE_IDENTITY_PREFIX_RE.search(prefix))
+    )
+    return not prose_label
 
 
-def is_nonliteral_code_expression(path: str, match: re.Match[str]) -> bool:
+def is_nonliteral_code_expression(
+    path: str,
+    line: str,
+    match: re.Match[str],
+) -> bool:
     """Return whether a structured field is executable or type syntax, not data."""
     if match.group("quote"):
         return False
     value = normalized_value(match.group("value"))
+    suffix = PurePosixPath(path).suffix.lower()
     if value.startswith("."):
-        return True
-    if PurePosixPath(path).suffix.lower() not in SOURCE_CODE_SUFFIXES:
+        prefix = line[: match.start()]
+        is_source_expression = suffix in SOURCE_CODE_SUFFIXES | JQ_SOURCE_SUFFIXES
+        is_jq_command = bool(JQ_COMMAND_PREFIX_RE.search(prefix))
+        return is_source_expression or is_jq_command
+    if suffix not in SOURCE_CODE_SUFFIXES:
         return False
     return not bool(NUMERIC_LITERAL_RE.fullmatch(value))
 
@@ -417,7 +451,7 @@ def scan_contacts(
             value = normalized_value(match.group("value"))
             if NUMERIC_LITERAL_RE.fullmatch(value):
                 continue
-            if is_nonliteral_code_expression(path, match):
+            if is_nonliteral_code_expression(path, line, match):
                 continue
             if not placeholder_value(value):
                 add_finding(
@@ -458,9 +492,9 @@ def scan_structured_identity(
 ) -> None:
     """Scan structured fields for customer identifiers and personal records."""
     for match in IDENTITY_FIELD_RE.finditer(line):
-        if not is_structured_identity_field(line, match):
+        if not is_structured_identity_field(path, line, match):
             continue
-        if is_nonliteral_code_expression(path, match):
+        if is_nonliteral_code_expression(path, line, match):
             continue
         if not placeholder_value(match.group("value")):
             add_finding(
@@ -472,7 +506,7 @@ def scan_structured_identity(
             )
 
     for match in ADDRESS_FIELD_RE.finditer(line):
-        if is_nonliteral_code_expression(path, match):
+        if is_nonliteral_code_expression(path, line, match):
             continue
         if not placeholder_value(match.group("value")):
             add_finding(

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -139,6 +139,12 @@ git -C "$repo" add fixture.mdx
 git -C "$repo" commit -qm prose-labels
 assert_clean "identity words used as prose labels" "$repo" --scope head --mode enforce
 
+repo=$(new_repo prose-shaped-structured-data)
+printf 'Every tenant: tenant-literal\n' >"${repo}/fixture.yaml"
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm structured-prefix
+assert_violation "prose-shaped prefixes outside documentation" "$repo" --scope head --mode enforce
+
 repo=$(new_repo expression-shaped-literals)
 cat >"${repo}/fixture.mdx" <<'EOF'
 ```yaml
@@ -239,6 +245,66 @@ printf 'tenant: real-customer\n' >"${repo}/fixture.yaml"
 git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm tenant
 assert_violation "literal customer tenant" "$repo" --scope head --mode enforce
+
+repo=$(new_repo compact-json-after-field)
+printf '{"status":"active","tenant":"tenant-literal"}\n' >"${repo}/fixture.json"
+git -C "$repo" add fixture.json
+git -C "$repo" commit -qm compact-json
+assert_violation "compact JSON tenant after another field" "$repo" --scope head --mode enforce
+
+repo=$(new_repo nested-compact-json)
+printf '{"metadata":{"namespace":"namespace-literal"}}\n' >"${repo}/fixture.json"
+git -C "$repo" add fixture.json
+git -C "$repo" commit -qm nested-json
+assert_violation "nested compact JSON namespace" "$repo" --scope head --mode enforce
+
+repo=$(new_repo bracket-delimited-flow-yaml)
+printf '[tenant: tenant-literal]\n' >"${repo}/fixture.yaml"
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm flow-yaml
+assert_violation "bracket-delimited YAML tenant" "$repo" --scope head --mode enforce
+
+repo=$(new_repo log-level-prefix)
+printf 'INFO tenant: tenant-literal\n' >"${repo}/fixture.mdx"
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm log-prefix
+assert_violation "tenant after a log-level prefix" "$repo" --scope head --mode enforce
+
+repo=$(new_repo timestamp-prefix)
+printf '2026-08-01T12:34:56Z customer_id: customer-record\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm timestamp-prefix
+assert_violation "customer identifier after an ISO timestamp" "$repo" --scope head --mode enforce
+
+repo=$(new_repo markdown-blockquote)
+printf '> tenant: tenant-literal\n' >"${repo}/fixture.mdx"
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm blockquote
+assert_violation "tenant inside a Markdown blockquote" "$repo" --scope head --mode enforce
+
+repo=$(new_repo indented-yaml-list)
+printf 'items:\n  - tenant: tenant-literal\n' >"${repo}/fixture.yaml"
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm yaml-list
+assert_violation "tenant inside an indented YAML list" "$repo" --scope head --mode enforce
+
+repo=$(new_repo markdown-table)
+printf '| tenant: tenant-literal |\n' >"${repo}/fixture.mdx"
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm markdown-table
+assert_violation "tenant inside a Markdown table" "$repo" --scope head --mode enforce
+
+repo=$(new_repo decorated-log-prefix)
+printf '2026-08-01T12:34:56Z INFO api-component tenant: tenant-literal\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm decorated-log
+assert_violation "tenant after a decorated log prefix" "$repo" --scope head --mode enforce
+
+repo=$(new_repo dot-prefixed-yaml-literal)
+printf 'namespace: .namespace-literal\n' >"${repo}/fixture.yaml"
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm dot-literal
+assert_violation "dot-prefixed YAML identity literal" "$repo" --scope head --mode enforce
 
 repo=$(new_repo suffixed-customer-identifiers)
 printf 'project_id: customer-project\nsubscription_name: customer-plan\n' >"${repo}/fixture.yaml"


### PR DESCRIPTION
## Summary

Close structured-prefix false negatives in the canonical PII scanner while preserving the narrow documentation-prose and executable-expression controls.

## Related Issue

Closes #926

## Changes

- Classify consumed JSON/YAML delimiters, including compact comma, brace, and bracket forms.
- Restrict prose-label exemptions to documentation suffixes and grammatical prose prefixes.
- Keep Markdown structure, timestamps, log prefixes, and decorated log lines enforceable.
- Limit dot-prefixed exemptions to source/JQ expressions.
- Add independent synthetic regressions for all affected contexts and negative controls.

## Verification evidence

- Confirmed every new regression failed before its implementation; the bracket-delimited YAML case specifically returned clean before the final delimiter change.
- `bash tests/test-check-pii.sh` — passed, including all new and existing scanner cases.
- Every `tests/*.sh` suite — 24/24 passed on Python 3.14.6.
- `ruff check scripts/check_pii.py` — passed.
- `ruff format --check` at 88, 100, and 120 columns — passed.
- `pre-commit run --all-files` — all applicable hooks passed.
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean.
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean on committed HEAD.
- `gitleaks git --redact --no-banner .` — 473 commits scanned, no leaks.
- `bash scripts/check-repo-hygiene.sh --include-paths` — clean.
- Audit mode reported only `docs/images/hero.svg`; source, metadata, embedded strings, and rendered pixels were reviewed and contain no PII.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
