### PR TITLE
fix: harden structured PII identity detection

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -11,6 +11,10 @@ Exit 0 means no findings, 1 means findings, and 2 means the scan could not run.
 Finding messages never contain the matched value.
 """
 
+# The scanner remains one auditable policy unit until the parser seams tracked in
+# issues #932, #933, #939, and #940 are implemented.
+# pylint: disable=too-many-lines
+
 from __future__ import annotations
 
 import argparse
@@ -984,6 +988,7 @@ def decode_jq_unicode_escapes(value: str) -> str:
     return "".join(decoded)
 
 
+# pylint: disable-next=too-many-locals
 def jq_output_strings(expression: str) -> list[str]:
     """Return jq strings that contribute to the field value, not control functions."""
     strings: list[str] = []
@@ -1032,6 +1037,7 @@ def jq_output_strings(expression: str) -> list[str]:
     return strings
 
 
+# pylint: disable-next=too-many-locals,too-many-statements
 def jq_output_numbers(expression: str) -> list[str]:
     """Return numeric literals that contribute to a jq field value."""
     numbers: list[str] = []
@@ -1427,6 +1433,7 @@ def scan_contacts(
             )
 
 
+# pylint: disable-next=too-many-arguments
 def scan_structured_identity(
     path: str,
     line_number: int,
@@ -1681,14 +1688,14 @@ def safe_yaml_block_content(value: str) -> bool:
 
 def scan_yaml_identity_blocks(path: str, text: str, findings: set[Finding]) -> None:
     """Inspect scalar bodies owned by YAML identity fields."""
-    active_block: tuple[int, str] | None = None
+    active_block_indent: int | None = None
+    block_key = ""
     for line_number, raw_line in enumerate(text.splitlines(), 1):
         line = ANSI_ESCAPE_RE.sub("", raw_line)
         stripped = line.strip()
         indentation = len(line) - len(line.lstrip())
-        if active_block and stripped:
-            block_indent, key = active_block
-            if indentation > block_indent:
+        if active_block_indent is not None and stripped:
+            if indentation > active_block_indent:
                 value = normalized_value(stripped)
                 if not safe_yaml_block_content(value):
                     add_finding(
@@ -1696,17 +1703,19 @@ def scan_yaml_identity_blocks(path: str, text: str, findings: set[Finding]) -> N
                         path=path,
                         line=line_number,
                         category="customer-identifier",
-                        message=f"{key} contains a literal organization identifier",
+                        message=f"{block_key} contains a literal organization identifier",
                     )
                 continue
-            active_block = None
+            active_block_indent = None
         for match in IDENTITY_FIELD_RE.finditer(line):
             value = normalized_value(match.group("value"))
             if re.fullmatch(r"[|>](?:[+-]?[1-9]?|[1-9][+-])", value):
-                active_block = (indentation, match.group("key"))
+                active_block_indent = indentation
+                block_key = match.group("key")
                 break
 
 
+# pylint: disable-next=too-many-locals,too-many-branches,too-many-statements
 def scan_text(path: str, text: str, findings: set[Finding]) -> None:
     """Apply structured and line-oriented detectors to one text blob."""
     text = ANSI_ESCAPE_RE.sub("", text)
@@ -1784,7 +1793,7 @@ def scan_text(path: str, text: str, findings: set[Finding]) -> None:
             and fence_close_column is not None
             and "\t" not in line[: close.start("marker")]
             and close.start("marker") <= fence_close_column
-            and close.group("marker")[0] == fence_marker[0]
+            and fence_marker.startswith(close.group("marker")[0])
             and len(close.group("marker")) >= len(fence_marker)
         )
         opening_fence = bool(fence and fence_marker is None)
@@ -1802,6 +1811,7 @@ def scan_text(path: str, text: str, findings: set[Finding]) -> None:
         suffix_is_source = suffix in SOURCE_CODE_SUFFIXES
         fence_is_source = effective_language in SOURCE_FENCE_LANGUAGES
         source_code = suffix_is_source or fence_is_source
+        spans: tuple[tuple[int, int], ...]
         if suffix == ".jq" or effective_language == "jq":
             spans = ((0, len(line)),)
             active_jq_quote = None

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -19,8 +19,10 @@ import ipaddress
 import json
 import re
 import sys
+import unicodedata
 import urllib.parse
 from dataclasses import asdict, dataclass
+from decimal import Decimal, InvalidOperation
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
@@ -56,8 +58,10 @@ SOURCE_CODE_SUFFIXES = {
     ".cpp",
     ".cs",
     ".go",
+    ".hcl",
     ".java",
     ".js",
+    ".jq",
     ".jsx",
     ".kt",
     ".kts",
@@ -68,11 +72,35 @@ SOURCE_CODE_SUFFIXES = {
     ".rb",
     ".rs",
     ".swift",
+    ".tf",
     ".ts",
     ".tsx",
 }
-DOCUMENTATION_PROSE_SUFFIXES = {".adoc", ".asciidoc", ".md", ".mdx", ".rst", ".txt"}
-JQ_SOURCE_SUFFIXES = {".jq"}
+PROSE_DOCUMENT_SUFFIXES = {".adoc", ".asciidoc", ".md", ".mdx", ".rst", ".txt"}
+SOURCE_FENCE_LANGUAGES = {
+    "c",
+    "cpp",
+    "csharp",
+    "go",
+    "hcl",
+    "java",
+    "javascript",
+    "js",
+    "jq",
+    "jsx",
+    "kotlin",
+    "php",
+    "py",
+    "python",
+    "rb",
+    "ruby",
+    "rust",
+    "swift",
+    "terraform",
+    "ts",
+    "tsx",
+    "typescript",
+}
 
 EMAIL_RE = re.compile(
     r"(?<![-A-Za-z0-9._%+/])"
@@ -97,12 +125,165 @@ PERSON_FIELD_RE = re.compile(
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
 IDENTITY_FIELD_RE = re.compile(
-    r"(?i)(?P<delimiter>^|[,{\[\s])(?P<key_quote>['\"]?)"
+    r"(?i)(?P<field_prefix>^|[^A-Za-z0-9_/-])"
+    r"(?P<key_open>[*_~`'\"]*)"
     r"(?P<key>tenant(?:_name|_id)?|customer(?:_name|_id)?|account(?:_name|_id)?|"
     r"subscription(?:_name|_id)|project(?:_name|_id)|namespace)"
-    r"(?P=key_quote)\s*(?P<separator>[:=])\s*(?P<quote>['\"`]?)"
+    r"(?P<key_close>[*_~`'\"]*)\s*(?P<separator>[:=])\s*(?P<quote>['\"`]?)"
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
+PROSE_IDENTITY_QUANTIFIER_RE = re.compile(
+    r"(?:^|\s)(?:any|each|every|no)$",
+    re.IGNORECASE,
+)
+PROSE_SAFE_LANGUAGE_RE = re.compile(
+    r"(?:use\s+the\s+documented\s+example\s+"
+    r"(?:tenant|customer|account|project|namespace)"
+    r"|use\s+the\s+synthetic\s+placeholder\s+value"
+    r"|use\s+the\s+customer['\u2019]s\s+documented\s+example\s+tenant"
+    r")[.!?]",
+    re.IGNORECASE,
+)
+PROSE_SAFE_CONTINUATION_RE = re.compile(
+    r"(?:continue\s+with\s+the\s+setup\s+instructions[.!?])?",
+    re.IGNORECASE,
+)
+JQ_COMMAND_RE = re.compile(
+    r"(?:^|[|;&(])\s*"
+    r"(?:[A-Za-z_][A-Za-z0-9_]*=[^\s]+\s+)*"
+    r"(?:(?:command(?:\s+--)?|exec(?:\s+--)?|nohup|"
+    r"(?:[^\s;|&]*/)?nice(?:\s+(?:-n\s+\S+|-[0-9]+))?|"
+    r"(?:[^\s;|&]*/)?timeout\s+\S+|"
+    r"stdbuf(?:(?:\s+-(?:i|o|e)\S+))*|"
+    r"(?:[^\s;|&]*/)?time(?:\s+-\S+)*|"
+    r"xargs(?:(?:\s+-(?:L|n|P)\s*[0-9]+)|(?:\s+(?:-0|--null))|"
+    r"(?:\s+-I(?:\s+\S+|\S+))|"
+    r"(?:\s+--max-args(?:=\S+|\s+\S+))|(?:\s+-r)|"
+    r"(?:\s+-d(?:\s+\S+|\S+))|(?:\s+--replace(?:=\S+)?))*|"
+    r"sudo(?:(?:\s+-[nEHSkK]+)|(?:\s+-(?:g|u)\s+\S+)|"
+    r"(?:\s+--group(?:=\S+|\s+\S+))|"
+    r"(?:\s+--user(?:=\S+|\s+\S+))|"
+    r"(?:\s+--preserve-env(?:=\S+)?)|(?:\s+--))*|"
+    r"(?:[^\s;|&]*/)?env(?:(?:\s+-i)|(?:\s+-u\s+\S+)|"
+    r"(?:\s+--ignore-environment)|"
+    r"(?:\s+--unset(?:=\S+|\s+\S+))|(?:\s+--))*)\s+"
+    r"(?:[A-Za-z_][A-Za-z0-9_]*=[^\s]+\s+)*"
+    r")*"
+    r"(?:[^\s;|&]*/)?jq(?:\s|$)"
+)
+FENCE_RE = re.compile(
+    r"^(?P<leading> {0,3})"
+    r"(?P<container>(?:(?:> ?|(?:[-+*]|[0-9]{1,9}[.)])[ \t]{1,4}))*)"
+    r"(?P<indent> {0,3})"
+    r"(?P<marker>`{3,}|~{3,})(?P<info>[^\r\n]*)$",
+)
+FENCE_CLOSE_RE = re.compile(
+    r"^\s*(?:>\s*)*(?:(?:[-+*]|[0-9]{1,9}[.)])\s+)*"
+    r"(?P<marker>`{3,}|~{3,})\s*$"
+)
+FENCE_CLASS_RE = re.compile(r"(?:^|[\s,])\.([A-Za-z0-9_+-]+)(?=[\s,]|$)")
+ANSI_ESCAPE_RE = re.compile(
+    r"(?:(?:\x1b\]|\x9d).*?(?:\x07|\x9c|\x1b\\)|"
+    r"(?:\x1b[PX^_]|[\x90\x98\x9e\x9f]).*?(?:\x9c|\x1b\\)|"
+    r"\x1b\[[0-?]*[ -/]*[@-~]|\x9b[0-?]*[ -/]*[@-~]|"
+    r"\x1b[ -/]*[0-~]|[\x80-\x9f])",
+    re.DOTALL,
+)
+ZERO_WIDTH_CONTROL_RE = re.compile(r"[\x01-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f]")
+YAML_ANCHOR_VALUE_RE = re.compile(r"&(?P<name>[A-Za-z0-9_.-]+)")
+YAML_TAG_CHARACTER = r"(?:%[0-9A-Fa-f]{2}|[!A-Za-z0-9_.:/+@;&=?$~,'()#*-])"
+YAML_TAG_RE = re.compile(rf"!(?:<[^>\r\n]+>|{YAML_TAG_CHARACTER}+)?\s+")
+YAML_BLOCK_START_RE = re.compile(
+    r":\s*(?:&(?P<anchor>[A-Za-z0-9_.-]+)\s+)?"
+    r"[|>](?:[+-]?[1-9]?|[1-9][+-])\s*$"
+)
+SAFE_BLOCK_PROSE_RE = re.compile(
+    r"(?:documented\s+example|synthetic\s+placeholder)\s+text[.!?]?",
+    re.IGNORECASE,
+)
+TEMPLATE_PLACEHOLDER_RE = re.compile(
+    r"(?:\$[A-Za-z_][A-Za-z0-9_]*|\$\{[^{}\s]+\}|"
+    r"\{[A-Za-z_][A-Za-z0-9_.-]*\}|<[A-Za-z_][A-Za-z0-9_.-]*>|"
+    r"\{\{\s*[^{}\r\n]+?\s*\}\}|\[%\s*[^%\r\n]+?\s*%\])"
+)
+SHELL_DOUBLE_ESCAPE_RE = re.compile(r'\\(["\\])')
+NON_OUTPUT_JQ_STRING_FUNCTIONS = {
+    "IN",
+    "all",
+    "any",
+    "bsearch",
+    "capture",
+    "combinations",
+    "contains",
+    "delpaths",
+    "endswith",
+    "error",
+    "getpath",
+    "group_by",
+    "has",
+    "in",
+    "index",
+    "indices",
+    "inside",
+    "isempty",
+    "ltrimstr",
+    "match",
+    "max_by",
+    "min_by",
+    "rindex",
+    "rtrimstr",
+    "scan",
+    "select",
+    "sort_by",
+    "split",
+    "splits",
+    "startswith",
+    "strptime",
+    "test",
+    "unique_by",
+    "paths",
+}
+NON_OUTPUT_JQ_NUMBER_FUNCTIONS = NON_OUTPUT_JQ_STRING_FUNCTIONS | {
+    "combinations",
+    "flatten",
+}
+POSITIONAL_JQ_OUTPUT_ARGUMENTS = {
+    "gsub": {1},
+    "limit": {1},
+    "nth": {1},
+    "setpath": {1},
+    "sub": {1},
+    "until": {1},
+}
+JQ_RANGE_OUTPUT_ARGUMENTS = {0, 1}
+JQ_NON_INDEX_KEYWORDS = {
+    "as",
+    "catch",
+    "do",
+    "elif",
+    "else",
+    "end",
+    "foreach",
+    "if",
+    "label",
+    "or",
+    "reduce",
+    "then",
+    "try",
+}
+SOURCE_COMMENT_EXPRESSION_RE = re.compile(
+    r"(?:[A-Za-z_$][A-Za-z0-9_$]*(?:\.|::|->))+[A-Za-z_$][A-Za-z0-9_$]*"
+    r"|[A-Za-z_$][A-Za-z0-9_$]*\s*\([^\r\n]*\)"
+)
+JQ_OPTION_ARITY = {
+    "--arg": 2,
+    "--argfile": 2,
+    "--argjson": 2,
+    "--indent": 1,
+    "--rawfile": 2,
+    "--slurpfile": 2,
+    "-L": 1,
+}
 ADDRESS_FIELD_RE = re.compile(
     r"(?i)(?:^|[,{\s])['\"]?"
     r"(?P<key>street_address|postal_address|postal_code|zip_code|date_of_birth|dob|"
@@ -147,23 +328,28 @@ PRINTABLE_ASCII_RE = re.compile(rb"[\x20-\x7e]{4,}")
 NUMERIC_LITERAL_RE = re.compile(
     r"[+-]?(?:"
     r"0[xX][0-9A-Fa-f_]+|0[bB][01_]+|0[oO][0-7_]+|"
-    r"[0-9][0-9_]*(?:\.[0-9_]+)?"
+    r"[0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+-]?[0-9][0-9_]*)?"
     r");?"
 )
-ISO_TIMESTAMP_PREFIX_RE = re.compile(
-    r"^\s*[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"
-    r"(?:\.[0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2})?(?:\s|$)",
+MAX_COMMONMARK_INDENT = 3
+DEFAULT_IGNORABLE_RANGES = (
+    (0x034F, 0x034F),
+    (0x115F, 0x1160),
+    (0x17B4, 0x17B5),
+    (0x180B, 0x180F),
+    (0x2060, 0x206F),
+    (0x3164, 0x3164),
+    (0xFE00, 0xFE0F),
+    (0xFFA0, 0xFFA0),
+    (0xFFF0, 0xFFF8),
+    (0x1BCA0, 0x1BCA3),
+    (0x1D173, 0x1D17A),
+    (0xE0000, 0xE0FFF),
 )
-LOG_LEVEL_PREFIX_RE = re.compile(
-    r"(?:^|[\s|])(?:trace|debug|info|warn(?:ing)?|error|fatal|critical)(?:[\s:\]]|$)",
-    re.IGNORECASE,
-)
-MARKDOWN_STRUCTURAL_PREFIX_RE = re.compile(r"^\s*(?:>|[-+*]|[0-9]+[.)]|\|)(?:\s|$)")
-PROSE_IDENTITY_PREFIX_RE = re.compile(
-    r"(?:^|\s)(?:a|all|an|any|each|every|no|one|our|the|their|these|this|those|your)\s*$",
-    re.IGNORECASE,
-)
-JQ_COMMAND_PREFIX_RE = re.compile(r"(?:^|[|;&(]\s*)jq(?:\s|$)", re.IGNORECASE)
+SURROGATE_ESCAPE_BASE = 0xDC00
+SURROGATE_ESCAPE_FIRST = 0xDC80
+SURROGATE_ESCAPE_C1_LAST = 0xDC9F
+SURROGATE_ESCAPE_LAST = 0xDCFF
 
 SAFE_EMAIL_DOMAINS = {"example.com", "example.net", "example.org"}
 PROVENANCE_EMAIL_DOMAINS = {"noreply.github.com", "users.noreply.github.com"}
@@ -210,8 +396,10 @@ SCHEMA_SENTINELS = {
     "number",
     "object",
     "optional",
+    "prefix",
     "required",
     "string",
+    "suffix",
     "unknown",
     "value",
 }
@@ -246,6 +434,15 @@ class Finding:
     message: str
 
 
+@dataclass
+class JqScope:
+    """One nested jq delimiter with its function argument position."""
+
+    opener: str
+    context: str
+    argument: int = 0
+
+
 def input_blobs(input_dir: Path) -> Iterator[tuple[str, bytes]]:
     """Read the shell-materialized path/blob pairs in deterministic order."""
 
@@ -270,6 +467,14 @@ def is_legal_attribution_path(path: str) -> bool:
 def is_excluded(path: str) -> bool:
     """Return whether a scanner implementation fixture must be self-excluded."""
     return path in EXCLUDED_PATHS
+
+
+def invisible_format_character(character: str) -> bool:
+    """Return whether Unicode renders a format mark without visible width."""
+    codepoint = ord(character)
+    ranges = (first <= codepoint <= last for first, last in DEFAULT_IGNORABLE_RANGES)
+    default_ignorable = any(ranges)
+    return unicodedata.category(character) == "Cf" or default_ignorable
 
 
 def safe_email(value: str) -> bool:
@@ -300,13 +505,104 @@ def normalized_value(value: str) -> str:
     return value.strip().strip("'\"").strip()
 
 
+def serialization_nesting(text: str) -> int:
+    """Count unmatched flow-collection delimiters outside quoted strings."""
+    nesting = 0
+    quote: str | None = None
+    escaped = False
+    for character in text:
+        if quote:
+            if character == quote and not escaped:
+                quote = None
+            escaped = character == "\\" and not escaped
+            if character != "\\":
+                escaped = False
+        elif character in {"'", '"'}:
+            quote = character
+        elif character in "[{":
+            nesting += 1
+        elif character in "]}" and nesting:
+            nesting -= 1
+    return nesting
+
+
+def structured_field_value(path: str, line: str, match: re.Match[str]) -> str:
+    """Read one field value without truncating quoted punctuation or YAML scalars."""
+    start = match.start("value")
+    quote = match.group("quote")
+    if quote:
+        index = start
+        while index < len(line):
+            backslashes = 0
+            before = index - 1
+            while before >= start and line[before] == "\\":
+                backslashes += 1
+                before -= 1
+            yaml_single_quote = quote == "'"
+            next_character_is_quote = index + 1 < len(line) and line[index + 1] == quote
+            doubled_yaml_quote = yaml_single_quote and next_character_is_quote
+            if line[index] == quote and doubled_yaml_quote:
+                index += 2
+                continue
+            if line[index] == quote and backslashes % 2 == 0:
+                return line[start:index]
+            index += 1
+        return line[start:]
+
+    yaml = PurePosixPath(path).suffix.lower() in {".yaml", ".yml"}
+    prefix = line[:start]
+    flow_context = serialization_nesting(prefix) > 0
+    placeholder = TEMPLATE_PLACEHOLDER_RE.match(line, start)
+    if placeholder:
+        raw_remainder = line[placeholder.end() :]
+        remainder = raw_remainder.lstrip()
+        whitespace_comment = raw_remainder != remainder and remainder.startswith("#")
+        flow_delimiter = bool(remainder) and remainder[0] in ",}]"
+        if not remainder or whitespace_comment or (flow_context and flow_delimiter):
+            return placeholder.group()
+
+    index = start
+    while index < len(line):
+        character = line[index]
+        if character in "}]`" or (character == "," and (not yaml or flow_context)):
+            break
+        if character == "#" and (index == start or line[index - 1].isspace()):
+            break
+        index += 1
+    return line[start:index]
+
+
+def unwrapped_identity_value(value: str) -> str:
+    """Remove YAML reference syntax and Markdown emphasis from a field value."""
+    value = normalized_value(value)
+    if tag := YAML_TAG_RE.match(value):
+        return unwrapped_identity_value(value[tag.end() :])
+    anchor = re.fullmatch(r"&[A-Za-z0-9_.-]+(?:\s+(.*))?", value)
+    if anchor:
+        return unwrapped_identity_value(anchor.group(1) or "")
+    strong_emphasis = re.fullmatch(r"(?:\*\*|__)(.+?)(?:\*\*|__)", value)
+    if strong_emphasis:
+        return unwrapped_identity_value(strong_emphasis.group(1))
+    emphasis = re.fullmatch(r"[*_](.+?)[*_]", value)
+    if emphasis:
+        return unwrapped_identity_value(emphasis.group(1))
+    alias = re.fullmatch(r"\*([A-Za-z0-9_.-]+)", value)
+    return unwrapped_identity_value(alias.group(1)) if alias else value
+
+
 def placeholder_value(value: str) -> bool:
     """Return whether a value is synthetic, schematic, or schema syntax."""
-    value = normalized_value(value)
+    value = unwrapped_identity_value(value)
     if not value:
         return True
     lower = value.lower()
-    if lower in SCHEMA_SENTINELS or lower in SAFE_IDENTITY_VALUES_LOWER:
+    if (
+        lower in SCHEMA_SENTINELS
+        or lower in SAFE_IDENTITY_VALUES_LOWER
+        or lower in {"false", "true", "~"}
+        or decimal_numeric_value(value) == 0
+        or bool(re.fullmatch(r"[|>](?:[+-]?[1-9]?|[1-9][+-])", value))
+    ):
         return True
     if re.fullmatch(r"example(?:[-_.][a-z0-9]+)*", lower):
         return True
@@ -320,49 +616,596 @@ def placeholder_value(value: str) -> bool:
     return (
         safe_composite
         or lower in SAFE_PERSON_NAMES
-        or value.startswith(("$", "{", "<", "{{", "[%", "*", "&"))
+        or bool(TEMPLATE_PLACEHOLDER_RE.fullmatch(value))
         or bool(re.fullmatch(r"[A-Z][A-Z0-9_]*", value))
     )
 
 
-def is_structured_identity_field(
-    path: str,
+def is_proven_prose_identity_label(path: str, line: str, match: re.Match[str]) -> bool:
+    """Return whether an identity-shaped token is demonstrably an ordinary prose label."""
+    if (
+        PurePosixPath(path).suffix.lower() not in PROSE_DOCUMENT_SUFFIXES
+        or match.group("separator") != ":"
+        or not match.group("field_prefix").isspace()
+        or bool(match.group("key_open"))
+        or bool(match.group("key_close"))
+    ):
+        return False
+    before = line[: match.start()].rstrip()
+    if not PROSE_IDENTITY_QUANTIFIER_RE.search(before):
+        return False
+    prose = line[match.start("separator") + 1 :].strip()
+    quote_pairs = {"'": "'", '"': '"', "\u2018": "\u2019", "\u201c": "\u201d"}
+    closing_quote = quote_pairs.get(prose[:1])
+    if closing_quote:
+        closing = prose.find(closing_quote, 1)
+        if closing < 0:
+            return False
+        trailing_prose = prose[closing + 1 :].strip()
+        if not PROSE_SAFE_CONTINUATION_RE.fullmatch(trailing_prose):
+            return False
+        prose = prose[1:closing]
+    return bool(PROSE_SAFE_LANGUAGE_RE.fullmatch(prose))
+
+
+def is_structured_identity_field(path: str, line: str, match: re.Match[str]) -> bool:
+    """Return whether an identity-shaped token should be enforced as structured data."""
+    key_open = match.group("key_open")
+    key_close = match.group("key_close")
+    whole_inline_field = key_open == "`" and "`" in line[match.end() :]
+    balanced_wrappers = sorted(key_open) == sorted(key_close)
+    if not balanced_wrappers and not whole_inline_field:
+        return False
+    if match.group("field_prefix") == "." and match.group("separator") != "=":
+        return False
+    return not is_proven_prose_identity_label(path, line, match)
+
+
+def is_source_comment(line: str, match: re.Match[str]) -> bool:
+    """Return whether a field-shaped token occurs after a source comment marker."""
+    prefix = line[: match.start("key")]
+    return bool(re.search(r"(?:^|[\s;])(?://|#|/\*|\*)\s*[^\r\n]*$", prefix))
+
+
+def match_is_in_spans(match: re.Match[str], spans: tuple[tuple[int, int], ...]) -> bool:
+    """Return whether a field key begins inside one of the supplied source spans."""
+    key_start = match.start("key")
+    return any(start <= key_start < end for start, end in spans)
+
+
+def jq_field_expression(line: str, start: int, shell_quote: str | None) -> str:
+    """Return one jq field expression, honoring strings and nested delimiters."""
+    expression = line[start:]
+    if shell_quote == '"':
+        expression = SHELL_DOUBLE_ESCAPE_RE.sub(r"\1", expression)
+    quote: str | None = None
+    escaped = False
+    nesting = 0
+    for index, character in enumerate(expression):
+        if quote:
+            if character == quote and not escaped:
+                quote = None
+            escaped = character == "\\" and not escaped
+            if character != "\\":
+                escaped = False
+            continue
+        if character in {"'", '"'}:
+            quote = character
+        elif character in "([{":
+            nesting += 1
+        elif character in ")]}":
+            if nesting:
+                nesting -= 1
+            elif character == "}":
+                return expression[:index]
+        elif character == "," and not nesting:
+            return expression[:index]
+    return expression
+
+
+def jq_bracket_is_index(prefix: str) -> bool:
+    """Return whether an opening bracket indexes a preceding jq filter."""
+    structured_filter = bool(
+        re.search(
+            r"(?:[)\]}]|\$[A-Za-z_]\w*|\.(?:[A-Za-z_]\w*)?|"
+            r"[A-Za-z_$]\w*(?:\.[A-Za-z_$]\w*)+)\s*$",
+            prefix,
+        )
+    )
+    bare_filter = re.search(r"([A-Za-z_]\w*)\s*$", prefix)
+    if not bare_filter:
+        return structured_filter
+    return structured_filter or bare_filter.group(1) not in JQ_NON_INDEX_KEYWORDS
+
+
+def decimal_numeric_value(value: str) -> Decimal | None:
+    """Parse a jq-compatible decimal literal for semantic comparisons."""
+    compact = value.replace("_", "").rstrip(";")
+    try:
+        return Decimal(compact)
+    except InvalidOperation:
+        return None
+
+
+def jq_arithmetic_literal_is_neutral(value: str) -> bool:
+    """Return whether a numeric operand is a conventional arithmetic modifier."""
+    numeric = decimal_numeric_value(value)
+    return numeric in {Decimal(-1), Decimal(0), Decimal(1)}
+
+
+def jq_interpolation_end(value: str, start: int) -> int | None:
+    """Return the closing parenthesis for one jq string interpolation."""
+    quote: str | None = None
+    escaped = False
+    depth = 1
+    index = start
+    while index < len(value):
+        character = value[index]
+        if quote:
+            if character == quote and not escaped:
+                quote = None
+            escaped = character == "\\" and not escaped
+            if character != "\\":
+                escaped = False
+        elif character in {"'", '"'}:
+            quote = character
+        elif character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if not depth:
+                return index
+        index += 1
+    return None
+
+
+def jq_string_end(value: str, start: int, quote: str) -> int:
+    """Return a jq string's closing quote without stopping inside interpolation."""
+    index = start
+    while index < len(value):
+        if value[index] == "\\":
+            run_end = index
+            while run_end < len(value) and value[run_end] == "\\":
+                run_end += 1
+            odd_backslashes = (run_end - index) % 2 == 1
+            interpolation = quote == '"' and odd_backslashes
+            interpolation = interpolation and value[run_end : run_end + 1] == "("
+            if interpolation:
+                closing = jq_interpolation_end(value, run_end + 1)
+                if closing is None:
+                    return len(value)
+                index = closing + 1
+                continue
+            escaped_character = (run_end - index) % 2 == 1 and run_end < len(value)
+            index = run_end + 1 if escaped_character else run_end
+            continue
+        if value[index] == quote:
+            return index
+        index += 1
+    return len(value)
+
+
+def jq_unwrap_outer_groups(value: str) -> str:
+    """Remove redundant parentheses enclosing an entire jq expression."""
+    candidate = value.strip()
+    while candidate.startswith("("):
+        closing = jq_interpolation_end(candidate, 1)
+        if closing != len(candidate) - 1:
+            break
+        candidate = candidate[1:closing].strip()
+    return candidate
+
+
+def jq_top_level_pipe_parts(value: str) -> list[str]:
+    """Split a jq expression only at pipelines outside strings and delimiters."""
+    parts: list[str] = []
+    quote: str | None = None
+    escaped = False
+    nesting = 0
+    start = 0
+    for index, character in enumerate(value):
+        if quote:
+            if character == quote and not escaped:
+                quote = None
+            escaped = character == "\\" and not escaped
+            if character != "\\":
+                escaped = False
+            continue
+        if character in {"'", '"'}:
+            quote = character
+        elif character in "([{":
+            nesting += 1
+        elif character in ")]}" and nesting:
+            nesting -= 1
+        elif character == "|" and not nesting:
+            parts.append(value[start:index].strip())
+            start = index + 1
+    parts.append(value[start:].strip())
+    return parts
+
+
+def jq_expression_is_identity_filter(value: str) -> bool:
+    """Return whether a jq expression is only grouped identity filters."""
+    candidate = jq_unwrap_outer_groups(value)
+    parts = jq_top_level_pipe_parts(candidate)
+    if len(parts) > 1:
+        return all(jq_expression_is_identity_filter(part) for part in parts)
+    return candidate == "."
+
+
+def jq_identity_constant_expression(value: str) -> str:
+    """Remove redundant groups and identity-only pipes from a jq expression."""
+    candidate = jq_unwrap_outer_groups(value)
+    while candidate:
+        parts = jq_top_level_pipe_parts(candidate)
+        if len(parts) == 1 or not jq_expression_is_identity_filter(parts[-1]):
+            break
+        candidate = jq_unwrap_outer_groups("|".join(parts[:-1]))
+    return candidate
+
+
+def jq_constant_string(value: str) -> str | None:
+    """Return the content of a simple constant jq interpolation expression."""
+    candidate = jq_identity_constant_expression(value)
+    if not candidate or candidate[0] not in {"'", '"'}:
+        return None
+    closing = jq_string_end(candidate, 1, candidate[0])
+    if closing != len(candidate) - 1:
+        return None
+    return candidate[1:closing]
+
+
+def jq_constant_scalar(value: str) -> str | None:
+    """Return a scalar jq interpolation followed only by identity filters."""
+    candidate = jq_identity_constant_expression(value)
+    if candidate in {"false", "null", "true"}:
+        return candidate
+    if NUMERIC_LITERAL_RE.fullmatch(candidate):
+        numeric = decimal_numeric_value(candidate)
+        return str(numeric) if numeric is not None else candidate.rstrip(";")
+    return None
+
+
+def jq_literal_fragments(value: str) -> list[str]:
+    """Remove real jq interpolations while retaining escaped interpolation text."""
+    fragments: list[str] = []
+    current: list[str] = []
+    index = 0
+    while index < len(value):
+        if value[index] != "\\":
+            current.append(value[index])
+            index += 1
+            continue
+        run_end = index
+        while run_end < len(value) and value[run_end] == "\\":
+            run_end += 1
+        backslashes = run_end - index
+        interpolation = run_end < len(value) and value[run_end] == "("
+        if not interpolation or backslashes % 2 == 0:
+            current.extend("\\" * backslashes)
+            index = run_end
+            continue
+        current.extend("\\" * (backslashes // 2))
+        closing = jq_interpolation_end(value, run_end + 1)
+        if closing is None:
+            current.extend(value[index:])
+            break
+        constant = jq_constant_string(value[run_end + 1 : closing])
+        if constant is not None:
+            nested_fragments = jq_literal_fragments(constant)
+            constant = nested_fragments[0] if len(nested_fragments) == 1 else None
+        if constant is None:
+            expression = value[run_end + 1 : closing]
+            constant = jq_constant_scalar(expression)
+        if constant is None:
+            fragments.append("".join(current))
+            current = []
+        else:
+            current.extend(constant)
+        index = closing + 1
+    fragments.append("".join(current))
+    return fragments
+
+
+def jq_open_scope(expression: str, index: int) -> JqScope:
+    """Classify a jq opening delimiter as a call, group, container, or index."""
+    opener = expression[index]
+    prefix = expression[:index]
+    if opener == "(":
+        function = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\s*$", prefix)
+        return JqScope(opener, function.group(1) if function else "group")
+    if opener == "[":
+        context = "index" if jq_bracket_is_index(prefix) else "array"
+        return JqScope(opener, context)
+    return JqScope(opener, "object")
+
+
+def jq_close_scope(scopes: list[JqScope], closer: str) -> None:
+    """Close a well-formed jq delimiter without corrupting outer context."""
+    opener = {")": "(", "]": "[", "}": "{"}[closer]
+    if scopes and scopes[-1].opener == opener:
+        scopes.pop()
+
+
+def jq_advance_argument(scopes: list[JqScope]) -> None:
+    """Advance only a semicolon's immediate function/group argument."""
+    if scopes and scopes[-1].opener == "(":
+        scopes[-1].argument += 1
+
+
+def jq_positional_roles(scopes: list[JqScope]) -> tuple[bool, bool]:
+    """Return whether active jq calls place a literal in output/control roles."""
+    output = False
+    control = False
+    for scope in scopes:
+        output_arguments = POSITIONAL_JQ_OUTPUT_ARGUMENTS.get(scope.context)
+        if output_arguments is None:
+            continue
+        if scope.argument in output_arguments:
+            output = True
+        else:
+            control = True
+    return output, control
+
+
+def jq_range_bound_is_identifier_sized(value: str) -> bool:
+    """Return whether a range bound is large enough to resemble an identifier."""
+    numeric = decimal_numeric_value(value)
+    return numeric is not None and abs(numeric) >= Decimal(100000)
+
+
+def decode_jq_unicode_escapes(value: str) -> str:
+    """Decode parity-valid jq Unicode escapes for placeholder comparison."""
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        if value[index] != "\\":
+            decoded.append(value[index])
+            index += 1
+            continue
+        run_end = index
+        while run_end < len(value) and value[run_end] == "\\":
+            run_end += 1
+        backslashes = run_end - index
+        escape_end = run_end + 5
+        unicode_escape = (
+            backslashes % 2 == 1
+            and escape_end <= len(value)
+            and value[run_end : run_end + 1] == "u"
+            and bool(re.fullmatch(r"[0-9A-Fa-f]{4}", value[run_end + 1 : escape_end]))
+        )
+        decoded.extend("\\" * (backslashes // 2))
+        if unicode_escape:
+            decoded.append(chr(int(value[run_end + 1 : escape_end], 16)))
+            index = escape_end
+        else:
+            decoded.extend("\\" * (backslashes % 2))
+            index = run_end
+    return "".join(decoded)
+
+
+def jq_output_strings(expression: str) -> list[str]:
+    """Return jq strings that contribute to the field value, not control functions."""
+    strings: list[str] = []
+    scopes: list[JqScope] = []
+    index = 0
+    while index < len(expression):
+        character = expression[index]
+        if character in "([{":
+            scopes.append(jq_open_scope(expression, index))
+            index += 1
+            continue
+        if character in ")]}":
+            jq_close_scope(scopes, character)
+            index += 1
+            continue
+        if character == ";":
+            jq_advance_argument(scopes)
+            index += 1
+            continue
+        if character not in {"'", '"'}:
+            index += 1
+            continue
+        string_start = index
+        quote = character
+        index = jq_string_end(expression, index + 1, quote)
+        value = expression[string_start + 1 : index]
+        active_functions = {scope.context for scope in scopes}
+        _, positional_control = jq_positional_roles(scopes)
+        prefix = expression[:string_start]
+        suffix = expression[index + 1 :]
+        comparison_before = bool(re.search(r"(?:==|!=|<=|>=|<|>)\s*$", prefix))
+        comparison_after = bool(re.match(r"\s*(?:==|!=|<=|>=|<|>)", suffix))
+        object_key = bool(re.match(r"\s*:", suffix))
+        control_string = bool(active_functions & NON_OUTPUT_JQ_STRING_FUNCTIONS)
+        comparison_string = comparison_before or comparison_after
+        predicate_input = bool(re.match(r"\s*\|\s*(?:IN|all|any|in|isempty)\b", suffix))
+        conditional_prefix = bool(re.search(r"\b(?:elif|if)\s*$", prefix))
+        suffix_has_then = bool(re.search(r"\bthen\b", suffix))
+        conditional_control = conditional_prefix and suffix_has_then
+        ignored_string = comparison_string or object_key or control_string
+        ignored_string = ignored_string or positional_control
+        ignored_string = ignored_string or predicate_input or conditional_control
+        if not ignored_string:
+            strings.append(value)
+        index += 1
+    return strings
+
+
+def jq_output_numbers(expression: str) -> list[str]:
+    """Return numeric literals that contribute to a jq field value."""
+    numbers: list[str] = []
+    scopes: list[JqScope] = []
+    index = 0
+    number_re = re.compile(
+        r"[+-]?(?:0[xX][0-9A-Fa-f_]+|0[bB][01_]+|0[oO][0-7_]+|"
+        r"[0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+-]?[0-9][0-9_]*)?)"
+    )
+    while index < len(expression):
+        character = expression[index]
+        if character in {"'", '"'}:
+            index = jq_string_end(expression, index + 1, character) + 1
+            continue
+        if character in "([{":
+            scopes.append(jq_open_scope(expression, index))
+            index += 1
+            continue
+        if character in ")]}":
+            jq_close_scope(scopes, character)
+            index += 1
+            continue
+        if character == ";":
+            jq_advance_argument(scopes)
+            index += 1
+            continue
+        number = number_re.match(expression, index)
+        if not number:
+            index += 1
+            continue
+        prefix = expression[:index]
+        suffix = expression[number.end() :]
+        leading_operator = number.group().startswith(("+", "-")) and bool(
+            re.search(r"(?:[A-Za-z0-9_$.)\]}])\s*$", prefix)
+        )
+        identifier_prefix = index > 0 and expression[index - 1].isalnum()
+        identifier_fragment = identifier_prefix and not leading_operator
+        comparison = bool(re.search(r"(?:==|!=|<=|>=|<|>)\s*$", prefix))
+        comparison = comparison or bool(re.match(r"\s*(?:==|!=|<=|>=|<|>)", suffix))
+        object_key = bool(re.match(r"\s*:", suffix))
+        active_functions = {scope.context for scope in scopes}
+        control_number = bool(active_functions & NON_OUTPUT_JQ_NUMBER_FUNCTIONS)
+        control_number = control_number or "index" in active_functions
+        range_scopes = [scope for scope in scopes if scope.context == "range"]
+        range_args = (scope.argument for scope in range_scopes)
+        range_control = any(arg not in JQ_RANGE_OUTPUT_ARGUMENTS for arg in range_args)
+        control_number = control_number or range_control
+        positional_output, positional_control = jq_positional_roles(scopes)
+        control_number = control_number or positional_control
+        object_value = bool(
+            re.search(
+                r"(?:^|[{,])\s*(?:[A-Za-z_]\w*|['\"][^'\"]+['\"])\s*:\s*$",
+                prefix,
+            )
+        )
+        literal_container = "array" in active_functions or object_value
+        output_branch = bool(re.search(r"(?:then|else|try|catch)\s*$", prefix))
+        output_function = bool(
+            active_functions
+            - NON_OUTPUT_JQ_NUMBER_FUNCTIONS
+            - POSITIONAL_JQ_OUTPUT_ARGUMENTS.keys()
+            - {"array", "group", "index", "object", "range"}
+        )
+        group_starts_literal = bool(re.search(r"(?:^|[(:,;])\s*$", prefix))
+        grouped_literal = "group" in active_functions and group_starts_literal
+        arithmetic = leading_operator or bool(re.search(r"[+*/%-]\s*$", prefix))
+        arithmetic = arithmetic or bool(re.match(r"\s*[+*/%-]", suffix))
+        dynamic_expression = bool(
+            re.search(
+                r"(?:\.[A-Za-z_]|\$[A-Za-z_]|(?:env|input)\b)",
+                expression,
+            )
+        )
+        pipe_output = bool(re.search(r"\|\s*$", prefix))
+        pipe_passthrough = bool(re.fullmatch(r"(?:\s*\|\s*\.)+\s*", suffix))
+        constant_arithmetic = arithmetic and not dynamic_expression
+        cancels_input = bool(re.search(r"(?:\*\s*0\b|\b0\s*\*)", expression))
+        cancels_dynamic_input = dynamic_expression and cancels_input
+        nonneutral = not jq_arithmetic_literal_is_neutral(number.group())
+        sensitive_arithmetic = arithmetic and (nonneutral or cancels_dynamic_input)
+        range_bound = any(s.argument in JQ_RANGE_OUTPUT_ARGUMENTS for s in range_scopes)
+        identifier_sized_range = jq_range_bound_is_identifier_sized(number.group())
+        range_output = range_bound and identifier_sized_range
+        output_literal = literal_container or output_branch or output_function
+        output_literal = (
+            output_literal
+            or grouped_literal
+            or positional_output
+            or range_output
+            or pipe_output
+            or pipe_passthrough
+            or constant_arithmetic
+            or sensitive_arithmetic
+        )
+        ignored = (
+            identifier_fragment
+            or comparison
+            or object_key
+            or control_number
+            or (arithmetic and dynamic_expression and not sensitive_arithmetic)
+        )
+        if output_literal and not ignored:
+            numbers.append(number.group())
+        index = number.end()
+    return numbers
+
+
+def jq_value_is_expression(
     line: str,
     match: re.Match[str],
+    jq_spans: tuple[tuple[int, int], ...],
 ) -> bool:
-    """Return whether an identity-shaped token occurs in field syntax, not prose."""
-    if match.group("separator") == "=" or match.group("delimiter") in {",", "{", "["}:
-        return True
-    prefix = line[: match.start()]
-    prose_label = (
-        bool(prefix.strip())
-        and PurePosixPath(path).suffix.lower() in DOCUMENTATION_PROSE_SUFFIXES
-        and not MARKDOWN_STRUCTURAL_PREFIX_RE.match(prefix)
-        and not ISO_TIMESTAMP_PREFIX_RE.match(prefix)
-        and not LOG_LEVEL_PREFIX_RE.search(prefix)
-        and bool(PROSE_IDENTITY_PREFIX_RE.search(prefix))
+    """Return whether a value inside a jq program is computed rather than literal."""
+    shell_quote: str | None = None
+    for span_start, span_end in jq_spans:
+        if span_start <= match.start("key") < span_end:
+            if span_start and line[span_start - 1] in {"'", '"'}:
+                shell_quote = line[span_start - 1]
+            break
+    expression = jq_field_expression(line, match.start("separator") + 1, shell_quote)
+    for quoted_value in jq_output_strings(expression):
+        for fragment in jq_literal_fragments(quoted_value):
+            decoded_fragment = decode_jq_unicode_escapes(fragment)
+            literal_fragment = decoded_fragment.strip(" -_.:/\\")
+            has_identity_text = any(map(str.isalnum, literal_fragment))
+            if not literal_fragment or not has_identity_text:
+                continue
+            repeated_example_root = literal_fragment.lower().count("example") > 1
+            numeric_suffix = bool(re.search(r"[A-Za-z][0-9]{6,}$", literal_fragment))
+            unsafe_composition = repeated_example_root or numeric_suffix
+            if unsafe_composition or not placeholder_value(literal_fragment):
+                return False
+    for number in jq_output_numbers(expression):
+        if not placeholder_value(number):
+            return False
+    fallback_numbers = re.findall(
+        r"//\s*([+-]?[0-9][0-9_]*(?:\.[0-9_]+)?"
+        r"(?:[eE][+-]?[0-9][0-9_]*)?)",
+        expression,
     )
-    return not prose_label
+    return all(placeholder_value(number) for number in fallback_numbers)
 
 
 def is_nonliteral_code_expression(
-    path: str,
     line: str,
     match: re.Match[str],
+    *,
+    source_code: bool,
+    jq_spans: tuple[tuple[int, int], ...],
+    value_override: str | None = None,
 ) -> bool:
     """Return whether a structured field is executable or type syntax, not data."""
-    if match.group("quote"):
+    value = normalized_value(value_override or match.group("value"))
+    numeric_literal = bool(NUMERIC_LITERAL_RE.fullmatch(value))
+    in_jq_filter = match_is_in_spans(match, jq_spans)
+    in_source_comment = (source_code or in_jq_filter) and is_source_comment(line, match)
+    if numeric_literal:
         return False
-    value = normalized_value(match.group("value"))
-    suffix = PurePosixPath(path).suffix.lower()
-    if value.startswith("."):
-        prefix = line[: match.start()]
-        is_source_expression = suffix in SOURCE_CODE_SUFFIXES | JQ_SOURCE_SUFFIXES
-        is_jq_command = bool(JQ_COMMAND_PREFIX_RE.search(prefix))
-        return is_source_expression or is_jq_command
-    if suffix not in SOURCE_CODE_SUFFIXES:
-        return False
-    return not bool(NUMERIC_LITERAL_RE.fullmatch(value))
+    if in_source_comment:
+        expression = value.rstrip(";").strip()
+        return bool(SOURCE_COMMENT_EXPRESSION_RE.fullmatch(expression))
+    groups = match.groupdict()
+    inline_key_opener = groups.get("key_open") == "`"
+    inline_key_closer = bool(groups.get("key_close"))
+    inline_field_closer = "`" in line[match.end() :]
+    unclosed_inline_key = inline_key_opener and not inline_key_closer
+    whole_inline_field = unclosed_inline_key and inline_field_closer
+    if whole_inline_field:
+        expression = value.rstrip(";").strip()
+        named_expression = bool(SOURCE_COMMENT_EXPRESSION_RE.fullmatch(expression))
+        return expression.startswith(".") or named_expression
+    if in_jq_filter:
+        return jq_value_is_expression(line, match, jq_spans)
+    return source_code and not bool(match.group("quote"))
 
 
 def safe_phone(value: str) -> bool:
@@ -429,12 +1272,106 @@ def redact_path(path: str) -> str:
     return redacted
 
 
+def closing_shell_quote(line: str, start: int, quote: str) -> int | None:
+    """Find the end of one shell-quoted jq filter on a physical line."""
+    index = start
+    while index < len(line):
+        backslashes = 0
+        before = index - 1
+        while before >= 0 and line[before] == "\\":
+            backslashes += 1
+            before -= 1
+        quote_is_unescaped = quote == "'" or backslashes % 2 == 0
+        if line[index] == quote and quote_is_unescaped:
+            return index
+        index += 1
+    return None
+
+
+def shell_words(
+    line: str,
+    start: int,
+) -> list[tuple[int, int, int, str | None, bool]]:
+    """Split a shell command into word spans without evaluating its contents."""
+    words: list[tuple[int, int, int, str | None, bool]] = []
+    index = start
+    while index < len(line):
+        while index < len(line) and line[index].isspace():
+            index += 1
+        if index >= len(line) or line[index] in ";|&":
+            break
+        quote = line[index] if line[index] in {"'", '"'} else None
+        if quote:
+            content_start = index + 1
+            closing = closing_shell_quote(line, content_start, quote)
+            if closing is None:
+                words.append((content_start, len(line), len(line), quote, False))
+                break
+            words.append((content_start, closing, closing + 1, quote, True))
+            index = closing + 1
+            continue
+        content_start = index
+        while index < len(line):
+            if line[index].isspace() or line[index] in ";|&":
+                break
+            index += 1
+        words.append((content_start, index, index, None, True))
+    return words
+
+
+def jq_program_word(
+    line: str,
+    words: list[tuple[int, int, int, str | None, bool]],
+) -> tuple[int, int, int, str | None, bool] | None:
+    """Return jq's filter word after consuming options and their arguments."""
+    index = 0
+    while index < len(words):
+        word = words[index]
+        word_text = line[word[0] : word[1]]
+        if word_text == "--":
+            return words[index + 1] if index + 1 < len(words) else None
+        if not word_text.startswith("-") or word_text == "-":
+            return word
+        option = word_text.split("=", 1)[0]
+        index += 1 + JQ_OPTION_ARITY.get(option, 0)
+    return None
+
+
+def jq_filter_spans(
+    line: str,
+    active_quote: str | None,
+) -> tuple[tuple[tuple[int, int], ...], str | None]:
+    """Locate shell-quoted jq programs without leaking across command boundaries."""
+    spans: list[tuple[int, int]] = []
+    cursor = 0
+    if active_quote:
+        closing = closing_shell_quote(line, 0, active_quote)
+        if closing is None:
+            return ((0, len(line)),), active_quote
+        spans.append((0, closing))
+        cursor = closing + 1
+
+    while command := JQ_COMMAND_RE.search(line, cursor):
+        program = jq_program_word(line, shell_words(line, command.end()))
+        if program is None:
+            break
+        content_start, content_end, raw_end, quote, closed = program
+        spans.append((content_start, content_end))
+        if not closed:
+            return tuple(spans), quote
+        cursor = raw_end
+    return tuple(spans), None
+
+
 def scan_contacts(
     path: str,
     line_number: int,
     line: str,
     attribution_context: bool,
     findings: set[Finding],
+    *,
+    source_code: bool,
+    jq_spans: tuple[tuple[int, int], ...],
 ) -> None:
     """Scan one line for contact details, home paths, and person names."""
     if not attribution_context:
@@ -448,10 +1385,16 @@ def scan_contacts(
                     message="email address does not use a documentation-reserved domain",
                 )
         for match in PERSON_FIELD_RE.finditer(line):
-            value = normalized_value(match.group("value"))
+            value = structured_field_value(path, line, match)
             if NUMERIC_LITERAL_RE.fullmatch(value):
                 continue
-            if is_nonliteral_code_expression(path, line, match):
+            if is_nonliteral_code_expression(
+                line,
+                match,
+                source_code=source_code,
+                jq_spans=jq_spans,
+                value_override=value,
+            ):
                 continue
             if not placeholder_value(value):
                 add_finding(
@@ -489,14 +1432,43 @@ def scan_structured_identity(
     line_number: int,
     line: str,
     findings: set[Finding],
+    *,
+    source_code: bool,
+    jq_spans: tuple[tuple[int, int], ...],
+    yaml_aliases: dict[str, bool],
+    yaml_alias_events: tuple[tuple[int, str, bool], ...],
 ) -> None:
     """Scan structured fields for customer identifiers and personal records."""
     for match in IDENTITY_FIELD_RE.finditer(line):
         if not is_structured_identity_field(path, line, match):
             continue
-        if is_nonliteral_code_expression(path, line, match):
+        value = structured_field_value(path, line, match)
+        jq_literal = match_is_in_spans(match, jq_spans) and not jq_value_is_expression(
+            line,
+            match,
+            jq_spans,
+        )
+        if is_nonliteral_code_expression(
+            line,
+            match,
+            source_code=source_code,
+            jq_spans=jq_spans,
+            value_override=value,
+        ):
             continue
-        if not placeholder_value(match.group("value")):
+        alias = None
+        if not match.group("quote"):
+            alias = re.fullmatch(r"\*([A-Za-z0-9_.-]+)", normalized_value(value))
+        if alias:
+            aliases_at_value = yaml_aliases.copy()
+            for position, name, safe in yaml_alias_events:
+                if position >= match.start("value"):
+                    break
+                aliases_at_value[name] = safe
+            safe_alias = aliases_at_value.get(alias.group(1), False)
+        else:
+            safe_alias = None
+        if jq_literal or not (safe_alias if alias else placeholder_value(value)):
             add_finding(
                 findings,
                 path=path,
@@ -506,9 +1478,16 @@ def scan_structured_identity(
             )
 
     for match in ADDRESS_FIELD_RE.finditer(line):
-        if is_nonliteral_code_expression(path, line, match):
+        value = structured_field_value(path, line, match)
+        if is_nonliteral_code_expression(
+            line,
+            match,
+            source_code=source_code,
+            jq_spans=jq_spans,
+            value_override=value,
+        ):
             continue
-        if not placeholder_value(match.group("value")):
+        if not placeholder_value(value):
             add_finding(
                 findings,
                 path=path,
@@ -576,10 +1555,262 @@ def scan_public_ips(
         )
 
 
+def parse_fence_language(info: str) -> str:
+    """Extract a language from CommonMark, Pandoc, or RMarkdown fence info."""
+    info = info.strip()
+    if not info:
+        return ""
+    if info.startswith("{") and info.endswith("}"):
+        attributes = info[1:-1].strip()
+        candidates = FENCE_CLASS_RE.findall(attributes)
+        if not candidates:
+            items = re.split(r"[\s,]+", attributes)
+            candidates = []
+            for item in items:
+                if not item.startswith("#"):
+                    candidates.append(item.rstrip(","))
+        for candidate in candidates:
+            if candidate.lower() in SOURCE_FENCE_LANGUAGES | {"jq"}:
+                return candidate.lower()
+        return candidates[0].lower() if candidates else ""
+    return info.split(maxsplit=1)[0].lower()
+
+
+def yaml_syntax(line: str) -> str:
+    """Mask quoted values and comments before inspecting YAML control syntax."""
+    syntax: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for character in line:
+        if quote:
+            syntax.append(" ")
+            if character == quote and not escaped:
+                quote = None
+            escaped = character == "\\" and not escaped
+            if character != "\\":
+                escaped = False
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            syntax.append(" ")
+        elif character == "#" and (not syntax or syntax[-1].isspace()):
+            break
+        else:
+            syntax.append(character)
+    return "".join(syntax)
+
+
+def yaml_value_text(line: str) -> str:
+    """Remove a YAML comment while preserving quoted scalar content."""
+    value: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for character in line:
+        if character == "#" and quote is None and (not value or value[-1].isspace()):
+            break
+        value.append(character)
+        if quote:
+            if character == quote and not escaped:
+                quote = None
+            escaped = character == "\\" and not escaped
+            if character != "\\":
+                escaped = False
+        elif character in {"'", '"'}:
+            quote = character
+    return "".join(value)
+
+
+def yaml_anchor_value(line: str, start: int) -> str:
+    """Extract the scalar node immediately following a YAML anchor."""
+    tail = yaml_value_text(line[start:]).lstrip()
+    while tag := YAML_TAG_RE.match(tail):
+        tail = tail[tag.end() :]
+    if not tail:
+        return ""
+    quote = tail[0] if tail[0] in {"'", '"'} else None
+    if quote:
+        index = 1
+        while index < len(tail):
+            if quote == "'" and tail[index : index + 2] == "''":
+                index += 2
+                continue
+            if tail[index] == quote:
+                backslashes = 0
+                before = index - 1
+                while before >= 0 and tail[before] == "\\":
+                    backslashes += 1
+                    before -= 1
+                if quote == "'" or backslashes % 2 == 0:
+                    return normalized_value(tail[: index + 1])
+            index += 1
+        return normalized_value(tail)
+    flow_context = serialization_nesting(line[:start]) > 0
+    delimiter = re.search(r"[],}]", tail) if flow_context else None
+    return normalized_value(tail[: delimiter.start()] if delimiter else tail)
+
+
+def update_yaml_aliases(
+    line: str,
+    aliases: dict[str, bool],
+) -> tuple[tuple[int, str, bool], ...]:
+    """Apply scalar anchor declarations in source order within one YAML document."""
+    events: list[tuple[int, str, bool]] = []
+    syntax = yaml_syntax(line)
+    for anchor in YAML_ANCHOR_VALUE_RE.finditer(syntax):
+        value = yaml_anchor_value(line, anchor.end("name"))
+        referenced = re.fullmatch(r"\*([A-Za-z0-9_.-]+)", value)
+        if referenced:
+            safe = aliases.get(referenced.group(1), False)
+        else:
+            block_value = bool(re.fullmatch(r"[|>](?:[+-]?[1-9]?|[1-9][+-])", value))
+            safe = bool(value) and not block_value and placeholder_value(value)
+        name = anchor.group("name")
+        aliases[name] = safe
+        events.append((anchor.start(), name, safe))
+    return tuple(events)
+
+
+def safe_yaml_block_content(value: str) -> bool:
+    """Return whether a YAML block line is explicitly synthetic identity content."""
+    value = normalized_value(value)
+    safe_block_prose = bool(SAFE_BLOCK_PROSE_RE.fullmatch(value))
+    safe_label_prose = bool(PROSE_SAFE_LANGUAGE_RE.fullmatch(value))
+    safe_prose = safe_block_prose or safe_label_prose
+    return not value or safe_prose or placeholder_value(value)
+
+
+def scan_yaml_identity_blocks(path: str, text: str, findings: set[Finding]) -> None:
+    """Inspect scalar bodies owned by YAML identity fields."""
+    active_block: tuple[int, str] | None = None
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        line = ANSI_ESCAPE_RE.sub("", raw_line)
+        stripped = line.strip()
+        indentation = len(line) - len(line.lstrip())
+        if active_block and stripped:
+            block_indent, key = active_block
+            if indentation > block_indent:
+                value = normalized_value(stripped)
+                if not safe_yaml_block_content(value):
+                    add_finding(
+                        findings,
+                        path=path,
+                        line=line_number,
+                        category="customer-identifier",
+                        message=f"{key} contains a literal organization identifier",
+                    )
+                continue
+            active_block = None
+        for match in IDENTITY_FIELD_RE.finditer(line):
+            value = normalized_value(match.group("value"))
+            if re.fullmatch(r"[|>](?:[+-]?[1-9]?|[1-9][+-])", value):
+                active_block = (indentation, match.group("key"))
+                break
+
+
 def scan_text(path: str, text: str, findings: set[Finding]) -> None:
     """Apply structured and line-oriented detectors to one text blob."""
+    text = ANSI_ESCAPE_RE.sub("", text)
+    text = ZERO_WIDTH_CONTROL_RE.sub("", text)
+    visible = (char for char in text if not invisible_format_character(char))
+    text = "".join(visible)
     legal_path = is_legal_attribution_path(path)
-    for line_number, line in enumerate(text.splitlines(), 1):
+    suffix = PurePosixPath(path).suffix.lower()
+    yaml = suffix in {".yaml", ".yml"}
+    aliases: dict[str, bool] = {}
+    scan_yaml_identity_blocks(path, text, findings)
+    fence_marker: str | None = None
+    fence_language: str | None = None
+    fence_close_column: int | None = None
+    active_jq_quote: str | None = None
+    yaml_block_indent: int | None = None
+    yaml_block_anchor: str | None = None
+    yaml_block_safe = False
+    yaml_block_has_content = False
+    for line_number, raw_line in enumerate(text.splitlines(), 1):
+        line = ANSI_ESCAPE_RE.sub("", raw_line)
+        line_aliases = aliases.copy()
+        yaml_alias_events: tuple[tuple[int, str, bool], ...] = ()
+        if yaml:
+            syntax_line = yaml_syntax(line)
+            syntax = syntax_line.strip()
+            indentation = len(line) - len(line.lstrip())
+            inside_block = False
+            if yaml_block_indent is not None:
+                if not line.strip() or indentation > yaml_block_indent:
+                    inside_block = True
+                    if line.strip() and yaml_block_anchor:
+                        yaml_block_has_content = True
+                        yaml_block_safe &= safe_yaml_block_content(line.strip())
+                else:
+                    if yaml_block_anchor:
+                        resolved_safe = yaml_block_has_content and yaml_block_safe
+                        aliases[yaml_block_anchor] = resolved_safe
+                    yaml_block_indent = None
+                    yaml_block_anchor = None
+            if not inside_block:
+                if syntax in {"---", "..."}:
+                    aliases.clear()
+                    line_aliases = aliases.copy()
+                else:
+                    line_aliases = aliases.copy()
+                    yaml_alias_events = update_yaml_aliases(line, aliases)
+                    block = YAML_BLOCK_START_RE.search(syntax_line)
+                    if block:
+                        yaml_block_indent = indentation
+                        yaml_block_anchor = block.group("anchor")
+                        yaml_block_safe = True
+                        yaml_block_has_content = False
+        fence = FENCE_RE.match(line)
+        fence_indent = 0
+        if fence:
+            fence_indent = len(fence.group("leading")) + len(fence.group("indent"))
+        top_level_fence = fence and not fence.group("container")
+        if top_level_fence and fence_indent > MAX_COMMONMARK_INDENT:
+            fence = None
+        if fence and fence.group("indent"):
+            container = fence.group("container").rstrip()
+            if container and container[-1] in "-+*.)":
+                fence = None
+        invalid_backtick_info = False
+        if fence:
+            backtick_marker = fence.group("marker").startswith("`")
+            invalid_backtick_info = backtick_marker and "`" in fence.group("info")
+        if invalid_backtick_info:
+            fence = None
+        close = FENCE_CLOSE_RE.match(line) if fence_marker else None
+        closing_fence = bool(
+            close
+            and fence_marker
+            and fence_close_column is not None
+            and "\t" not in line[: close.start("marker")]
+            and close.start("marker") <= fence_close_column
+            and close.group("marker")[0] == fence_marker[0]
+            and len(close.group("marker")) >= len(fence_marker)
+        )
+        opening_fence = bool(fence and fence_marker is None)
+        if opening_fence and fence:
+            fence_marker = fence.group("marker")
+            fence_language = parse_fence_language(fence.group("info"))
+            if fence.group("container"):
+                fence_close_column = fence.start("marker") + 3
+            else:
+                fence_close_column = 3
+            active_jq_quote = None
+
+        fence_boundary = closing_fence or opening_fence
+        effective_language = None if fence_boundary else fence_language
+        suffix_is_source = suffix in SOURCE_CODE_SUFFIXES
+        fence_is_source = effective_language in SOURCE_FENCE_LANGUAGES
+        source_code = suffix_is_source or fence_is_source
+        if suffix == ".jq" or effective_language == "jq":
+            spans = ((0, len(line)),)
+            active_jq_quote = None
+        elif source_code:
+            spans = ()
+            active_jq_quote = None
+        else:
+            spans, active_jq_quote = jq_filter_spans(line, active_jq_quote)
+
         is_commit_message = path.startswith("<commit:")
         trailer_match = PROVENANCE_TRAILER_RE.match(line)
         provenance_trailer = bool(is_commit_message and trailer_match)
@@ -589,10 +1820,27 @@ def scan_text(path: str, text: str, findings: set[Finding]) -> None:
             line,
             legal_path or provenance_trailer,
             findings,
+            source_code=source_code,
+            jq_spans=spans,
         )
-        scan_structured_identity(path, line_number, line, findings)
+        scan_structured_identity(
+            path,
+            line_number,
+            line,
+            findings,
+            source_code=source_code,
+            jq_spans=spans,
+            yaml_aliases=line_aliases,
+            yaml_alias_events=yaml_alias_events,
+        )
         scan_query_parameters(path, line_number, line, findings)
         scan_public_ips(path, line_number, line, findings)
+
+        if closing_fence:
+            fence_marker = None
+            fence_language = None
+            fence_close_column = None
+            active_jq_quote = None
 
 
 def looks_binary(data: bytes) -> bool:
@@ -604,9 +1852,9 @@ def scan_binary(path: str, data: bytes, findings: set[Finding], *, media: bool) 
     """Inspect ASCII-compatible binary metadata without rendering the file."""
     # Keep only printable metadata runs. Treating every byte as Latin-1 lets
     # compression noise masquerade as contact syntax across arbitrary bytes.
-    text = "\n".join(
-        (match.group(0).decode("ascii") for match in PRINTABLE_ASCII_RE.finditer(data)),
-    )
+    printable_data = data if media else data.replace(b"\0", b"")
+    matches = PRINTABLE_ASCII_RE.finditer(printable_data)
+    text = "\n".join(match.group(0).decode("ascii") for match in matches)
     if not media:
         scan_text(path, text, findings)
         return
@@ -669,7 +1917,15 @@ def scan_blob(path: str, data: bytes, findings: set[Finding]) -> None:
     if looks_binary(data):
         scan_binary(path, data, findings, media=False)
         return
-    scan_text(path, data.decode("utf-8", "replace"), findings)
+    decoded = data.decode("utf-8", "surrogateescape")
+    text: list[str] = []
+    for character in decoded:
+        codepoint = ord(character)
+        if SURROGATE_ESCAPE_FIRST <= codepoint <= SURROGATE_ESCAPE_C1_LAST:
+            text.append(chr(codepoint - SURROGATE_ESCAPE_BASE))
+        elif not SURROGATE_ESCAPE_FIRST <= codepoint <= SURROGATE_ESCAPE_LAST:
+            text.append(character)
+    scan_text(path, "".join(text), findings)
 
 
 def scan(input_dir: Path) -> set[Finding]:

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -76,6 +76,33 @@ assert_violation() {
   fi
 }
 
+assert_customer_identifier() {
+  local label="$1" dir="$2"
+  shift 2
+  local rc
+  rc=$(run_scan "$dir" "$@" --format json)
+  if [ "$rc" -ne 1 ]; then
+    echo "[FAIL] $label — expected finding (1), got $rc"
+    sed 's/^/  /' "${WORK}/stdout" "${WORK}/stderr"
+    FAIL=1
+    return
+  fi
+  if python3 - "${WORK}/stdout" <<'PY'; then
+import json
+import sys
+
+findings = json.load(open(sys.argv[1], encoding="utf-8"))["findings"]
+if len(findings) != 1 or findings[0]["category"] != "customer-identifier":
+    raise SystemExit(1)
+PY
+    echo "[OK] $label -> one customer-identifier finding"
+  else
+    echo "[FAIL] $label — expected exactly one customer-identifier finding"
+    sed 's/^/  /' "${WORK}/stdout" "${WORK}/stderr"
+    FAIL=1
+  fi
+}
+
 assert_error() {
   local label="$1" dir="$2"
   shift 2
@@ -129,10 +156,21 @@ git -C "$repo" add fixture.mdx
 git -C "$repo" commit -qm expressions
 assert_clean "schematic variables and documentation expressions" "$repo" --scope head --mode enforce
 
+repo=$(new_repo quoted-prose-value)
+cat >"${repo}/fixture.mdx" <<'EOF'
+Status: "Namespace: write denied — create it before continuing"
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm quoted-prose
+assert_clean "identity-shaped text inside another quoted value is prose" "$repo" --scope head --mode enforce
+
 repo=$(new_repo documentation-prose-labels)
 cat >"${repo}/fixture.mdx" <<'EOF'
 <Note>
 Every customer: "Use the documented example tenant." Continue with the setup instructions.
+For every customer: use the documented example tenant.
+Each account: "Use the synthetic placeholder value."
+For every customer: use the customer's documented example tenant.
 </Note>
 EOF
 git -C "$repo" add fixture.mdx
@@ -157,6 +195,1536 @@ EOF
 git -C "$repo" add fixture.mdx
 git -C "$repo" commit -qm literals
 assert_violation "expression-shaped identity literals remain enforced" "$repo" --scope head --mode enforce
+
+repo=$(new_repo compact-json-later-field)
+cat >"${repo}/fixture.json" <<'EOF'
+{"other":1,"tenant":"real-customer"}
+EOF
+git -C "$repo" add fixture.json
+git -C "$repo" commit -qm compact-json
+assert_customer_identifier "identity fields after another compact JSON field" "$repo" --scope head --mode enforce
+
+repo=$(new_repo compact-json-nested-field)
+cat >"${repo}/fixture.json" <<'EOF'
+{"outer":{"namespace":"private-customer"}}
+EOF
+git -C "$repo" add fixture.json
+git -C "$repo" commit -qm nested-json
+assert_customer_identifier "identity fields nested in compact JSON" "$repo" --scope head --mode enforce
+
+repo=$(new_repo log-prefixed-identity)
+cat >"${repo}/fixture.mdx" <<'EOF'
+INFO tenant: private-customer
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm log-prefix
+assert_customer_identifier "identity fields after a log-level prefix" "$repo" --scope head --mode enforce
+
+repo=$(new_repo timestamp-prefixed-identity)
+cat >"${repo}/fixture.txt" <<'EOF'
+2026-08-01 customer_id: acct-481516
+EOF
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm timestamp-prefix
+assert_customer_identifier "identity fields after a timestamp prefix" "$repo" --scope head --mode enforce
+
+repo=$(new_repo blockquote-identity)
+cat >"${repo}/fixture.md" <<'EOF'
+> tenant: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm blockquote
+assert_customer_identifier "identity fields in blockquotes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo indented-list-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+items:
+  - tenant: private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm indented-list
+assert_customer_identifier "identity fields in indented list items" "$repo" --scope head --mode enforce
+
+repo=$(new_repo markdown-table-identity)
+cat >"${repo}/fixture.md" <<'EOF'
+| tenant: private-customer |
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm markdown-table
+assert_customer_identifier "identity fields in Markdown tables" "$repo" --scope head --mode enforce
+
+repo=$(new_repo decorated-log-identity)
+cat >"${repo}/fixture.txt" <<'EOF'
+2026-08-01T12:00:00Z INFO auth-service tenant: private-customer
+EOF
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm decorated-log
+assert_customer_identifier "identity fields after decorated log prefixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo dot-prefixed-yaml-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: .private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm dot-prefixed-yaml
+assert_customer_identifier "dot-prefixed YAML identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo numbered-list-identity)
+cat >"${repo}/fixture.md" <<'EOF'
+1. tenant: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm numbered-list
+assert_customer_identifier "identity fields in numbered list items" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quoted-dot-json-identity)
+cat >"${repo}/fixture.json" <<'EOF'
+{"tenant":".private-customer"}
+EOF
+git -C "$repo" add fixture.json
+git -C "$repo" commit -qm quoted-dot-json
+assert_customer_identifier "quoted dot-prefixed JSON identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quoted-delimited-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: "example-corp#private-customer"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm quoted-delimited-value
+assert_customer_identifier "safe quoted prefixes cannot hide identity suffixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quoted-comma-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: "example-corp,private-customer"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm quoted-comma-value
+assert_customer_identifier "quoted commas cannot truncate identity inspection" "$repo" --scope head --mode enforce
+
+repo=$(new_repo plain-hash-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: example-corp#private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm plain-hash-value
+assert_customer_identifier "plain YAML hashes without whitespace remain value content" "$repo" --scope head --mode enforce
+
+repo=$(new_repo plain-comma-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: example-corp,private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm plain-comma-value
+assert_customer_identifier "plain YAML commas remain block-scalar value content" "$repo" --scope head --mode enforce
+
+repo=$(new_repo placeholder-prefix-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: $TENANT-private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm placeholder-prefix
+assert_customer_identifier "placeholder prefixes cannot hide literal identity suffixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo angle-placeholder-prefix-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: <tenant>-private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm angle-placeholder-prefix
+assert_customer_identifier "angle placeholders cannot hide literal identity suffixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo template-placeholder-prefix-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: {{ tenant }}-private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm template-placeholder-prefix
+assert_customer_identifier "template placeholders cannot hide literal identity suffixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo whole-placeholder-identities)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: $TENANT
+customer: ${CUSTOMER}
+account: <account>
+project: {project}
+namespace: {{ namespace }}
+subscription: [% subscription %]
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm whole-placeholders
+assert_clean "whole identity placeholders remain synthetic" "$repo" --scope head --mode enforce
+
+repo=$(new_repo placeholder-comma-suffix)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: ${TENANT},private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm placeholder-comma-suffix
+assert_customer_identifier "YAML block commas cannot terminate placeholders" "$repo" --scope head --mode enforce
+
+repo=$(new_repo placeholder-hash-suffix)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: $TENANT#private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm placeholder-hash-suffix
+assert_customer_identifier "YAML hashes without whitespace cannot terminate placeholders" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-doubled-quote-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: 'example-corp''private-customer'
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm doubled-quote-value
+assert_customer_identifier "YAML doubled quotes cannot truncate identity inspection" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quantified-literal-identity)
+cat >"${repo}/fixture.mdx" <<'EOF'
+Every customer: "private-customer"
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm quantified-literal
+assert_customer_identifier "quantified literal identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo log-sentence-identity)
+cat >"${repo}/fixture.mdx" <<'EOF'
+INFO customer: "Use the documented example tenant."
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm log-sentence
+assert_customer_identifier "sentence-shaped identity values after log prefixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo article-sentence-identity)
+cat >"${repo}/fixture.mdx" <<'EOF'
+The customer: "Private Customer Inc."
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm article-sentence
+assert_customer_identifier "article-prefixed identity labels" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quantified-organization-name)
+cat >"${repo}/fixture.mdx" <<'EOF'
+Every customer: "Private Customer Inc." Continue with setup.
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm quantified-organization
+assert_customer_identifier "quantified prose cannot hide organization names" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quantified-organization-with-safe-continuation)
+cat >"${repo}/fixture.mdx" <<'EOF'
+Every customer: "Private Customer Inc." Continue with the documented example.
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm quantified-organization-continuation
+assert_customer_identifier "later safe prose cannot hide an organization name" "$repo" --scope head --mode enforce
+
+repo=$(new_repo safe-prose-before-organization)
+cat >"${repo}/fixture.mdx" <<'EOF'
+Every customer: Use the documented example tenant. Private Customer Inc.
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm safe-prose-before-organization
+assert_customer_identifier "safe prose cannot prefix a hidden organization name" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quoted-safe-prose-before-organization)
+cat >"${repo}/fixture.mdx" <<'EOF'
+Every customer: "Use the documented example tenant." Private Customer Inc.
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm quoted-safe-prose-before-organization
+assert_customer_identifier "quoted safe prose cannot hide trailing organization names" "$repo" --scope head --mode enforce
+
+repo=$(new_repo unrelated-jq-prefix)
+cat >"${repo}/fixture.mdx" <<'EOF'
+jq . input.json; tenant: .private-customer
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm unrelated-jq
+assert_customer_identifier "an earlier jq command cannot exempt a later field" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-expressions)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+/usr/bin/jq '{tenant: input.tenant, namespace: env.NAMESPACE}' input.json
+jq '{
+  namespace: .pool.namespace,
+  tenant: (.tenant // "default")
+}' input.json
+```
+```jq
+{tenant: input.tenant, namespace: env.NAMESPACE}
+```
+EOF
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: input.tenant, namespace: env.NAMESPACE}
+EOF
+git -C "$repo" add fixture.mdx filter.jq
+git -C "$repo" commit -qm jq-expressions
+assert_clean "jq filters are executable expressions" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-options-and-indentation)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+  jq '{tenant: .metadata.tenant}' input.json
+jq --arg label 'sample' '{namespace: .metadata.namespace}' input.json
+command jq '{tenant: input.tenant}' input.json
+command -- jq '{tenant: input.tenant}' input.json
+sudo jq '{tenant: input.tenant}' input.json
+sudo -n jq '{tenant: input.tenant}' input.json
+sudo -u user jq '{tenant: input.tenant}' input.json
+sudo -n -u user jq '{tenant: input.tenant}' input.json
+sudo -nE jq '{tenant: input.tenant}' input.json
+sudo --preserve-env jq '{tenant: input.tenant}' input.json
+sudo -H jq '{tenant: input.tenant}' input.json
+sudo -- jq '{tenant: input.tenant}' input.json
+sudo -n env -i jq '{tenant: input.tenant}' input.json
+env JQ_COLORS=off jq '{tenant: input.tenant}' input.json
+/usr/bin/env jq '{tenant: input.tenant}' input.json
+/usr/bin/env -i jq '{tenant: input.tenant}' input.json
+env -u JQ_COLORS jq '{tenant: input.tenant}' input.json
+env --unset=JQ_COLORS jq '{tenant: input.tenant}' input.json
+LC_ALL=C jq '{tenant: input.tenant}' input.json
+xargs jq '{tenant: input.tenant}'
+xargs -n1 jq '{tenant: input.tenant}'
+xargs -n 1 jq '{tenant: input.tenant}'
+xargs -P 2 jq '{tenant: input.tenant}'
+xargs -0 jq '{tenant: input.tenant}'
+xargs --null jq '{tenant: input.tenant}'
+xargs -I {} jq '{tenant: input.tenant}'
+xargs --max-args 1 jq '{tenant: input.tenant}'
+time jq '{tenant: input.tenant}' input.json
+/usr/bin/time jq '{tenant: input.tenant}' input.json
+env --unset JQ_COLORS jq '{tenant: input.tenant}' input.json
+env --ignore-environment jq '{tenant: input.tenant}' input.json
+sudo --user nobody jq '{tenant: input.tenant}' input.json
+sudo --preserve-env=PATH jq '{tenant: input.tenant}' input.json
+nice jq '{tenant: input.tenant}' input.json
+nice -n 10 jq '{tenant: input.tenant}' input.json
+/usr/bin/nice jq '{tenant: input.tenant}' input.json
+nice -10 jq '{tenant: input.tenant}' input.json
+nohup jq '{tenant: input.tenant}' input.json
+timeout 5 jq '{tenant: input.tenant}' input.json
+stdbuf -oL jq '{tenant: input.tenant}' input.json
+exec jq '{tenant: input.tenant}' input.json
+xargs -r jq '{tenant: input.tenant}'
+xargs -L 1 jq '{tenant: input.tenant}'
+xargs -d '\n' jq '{tenant: input.tenant}'
+xargs --replace jq '{tenant: input.tenant}'
+sudo -S jq '{tenant: input.tenant}' input.json
+sudo -k jq '{tenant: input.tenant}' input.json
+sudo -g staff jq '{tenant: input.tenant}' input.json
+jq --argfile data input.json '{tenant: .tenant}' input.json
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-options
+assert_clean "jq indentation and option arguments preserve filter context" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-numeric-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+jq -n '{account_id: 987654321}'
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-numeric
+assert_customer_identifier "numeric identity literals inside jq remain enforced" "$repo" --scope head --mode enforce
+
+repo=$(new_repo direct-jq-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: 987654321}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm direct-jq-numeric
+assert_customer_identifier "numeric identity literals in jq files remain enforced" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-quote-state-boundary)
+cat >"${repo}/fixture.mdx" <<'EOF'
+jq ".foo\\"; tenant: .private-customer
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-quote-boundary
+assert_customer_identifier "closed jq filters cannot exempt later fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-string-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+jq -n '{tenant: "real-customer"}'
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-literal
+assert_customer_identifier "quoted literals inside jq filters remain enforced" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-double-shell-string-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+jq "{tenant: \"real-customer\"}"
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-double-shell-literal
+assert_customer_identifier "escaped literals inside double-quoted jq filters remain enforced" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-interpolated-strings)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+jq '{tenant: "prefix-\(.suffix)"}' input.json
+jq "{namespace: \"prefix-\\(.suffix)\"}" input.json
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-interpolation
+assert_clean "jq interpolated strings are executable expressions" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-interpolation-inner-quotes)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "example-\("corp")"}
+{tenant: "\(")")"}
+{tenant: "example-\("corp" | .)"}
+{account_id: "\(987654321 | . == 0)"}
+{tenant: "\("example-" + "corp")"}
+{tenant: "\(["example", "corp"] | join("-"))"}
+{tenant: "example-\(123)"}
+{tenant: "example-\(123 | .)"}
+{tenant: "\("example-" | .)\(123 | .)"}
+{tenant: "example-\(false)-corp"}
+{tenant: "example-\(true)-corp"}
+{tenant: "example-\(null)-corp"}
+{account_id: "\(1.23456789012e11)"}
+{account_id: "\(123456789012e0)"}
+{tenant: "\("example-\("corp")")"}
+{tenant: "\("example-\(123)")"}
+{tenant: "\("example-\(false)-corp")"}
+{tenant: "\(("example-\("corp")") | (.))"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-interpolation-inner-quotes
+assert_clean "quotes inside jq interpolation do not terminate the outer string" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-constant-interpolation-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\("private-customer")"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-constant-interpolation-literal
+assert_customer_identifier "constant jq interpolation cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-computed-interpolation-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\("private-customer" | .)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-computed-interpolation-literal
+assert_customer_identifier "computed jq interpolation cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-computed-interpolation-number)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: "\(987654321)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-computed-interpolation-number
+assert_customer_identifier "numeric jq interpolation cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-piped-interpolation-number)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: "\(987654321 | .)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-piped-interpolation-number
+assert_customer_identifier "piped numeric jq interpolation cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-adjacent-placeholder-composition)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "example-corp\("example-corp" | .)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-adjacent-placeholder-composition
+assert_customer_identifier "adjacent jq placeholders cannot compose an identity" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-multiple-interpolation-composition)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\("example-corp" | .)\("example-corp" | .)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-multiple-interpolation-composition
+assert_customer_identifier "multiple jq interpolations compose before classification" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-grouped-interpolation-string)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\("private-customer" | ((.)))"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-grouped-interpolation-string
+assert_customer_identifier "redundant jq groups cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-grouped-interpolation-number)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: "\(987654321 | (((.))))"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-grouped-interpolation-number
+assert_customer_identifier "grouped jq no-op filters cannot hide numeric identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-grouped-noop-chain)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\(("private-customer" | (. | .)))"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-grouped-noop-chain
+assert_customer_identifier "grouped jq identity chains cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-adjacent-number-composition)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: "\(123456789012)\(123456789012)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-adjacent-number-composition
+assert_customer_identifier "adjacent numeric jq constants compose before classification" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-placeholder-number-composition)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "example-corp\(123456789012)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-placeholder-number-composition
+assert_customer_identifier "numeric jq constants cannot suffix placeholder identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-scientific-interpolation-canonicalization)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "example-\(1e6)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-scientific-interpolation-canonicalization
+assert_customer_identifier "jq numeric interpolation uses canonical stringification" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-nested-constant-interpolation)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\("private-\("customer")")"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-nested-constant-interpolation
+assert_customer_identifier "nested jq constants compose before classification" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-expression-literals)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: "private-customer-\(.suffix)"}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-interpolated-literal
+assert_customer_identifier "jq interpolation cannot hide literal identity fragments" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-fallback-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: input.tenant // "private-customer"}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-fallback-literal
+assert_customer_identifier "jq fallbacks cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-punctuated-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: "private-customer,division"}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-punctuated-literal
+assert_customer_identifier "jq punctuation cannot truncate literal inspection" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-nested-object-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: {name: "default", org: "private-customer"}.org}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-nested-object
+assert_customer_identifier "nested jq objects cannot hide output identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-array-output-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: ["private-customer"][0]}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-array-output
+assert_customer_identifier "jq array indexing cannot hide output identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-branch-array-output-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: (if true then ["private-customer"][0] else input.tenant end)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-branch-array-output
+assert_customer_identifier "jq branch arrays cannot hide output identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-reduce-array-output-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: (reduce ["private-customer"][] as $x (null; $x))}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-reduce-array-output
+assert_customer_identifier "jq reducer arrays cannot hide output identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-container-numeric-literals)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: [987654321][0]}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-container-numeric
+assert_customer_identifier "jq arrays cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-object-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: {id: 987654321}.id}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-object-numeric
+assert_customer_identifier "jq objects cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-branch-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: (if true then 987654321 else input.account_id end)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-branch-numeric
+assert_customer_identifier "jq branches cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-function-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: first(987654321)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-function-numeric
+assert_customer_identifier "jq output functions cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-arithmetic-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: 987654321 + 0}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-arithmetic-numeric
+assert_customer_identifier "jq constant arithmetic cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-pipe-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: (.account_id | 987654321)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-pipe-numeric
+assert_customer_identifier "jq pipes cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-positional-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: limit(1; 987654321)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-positional-numeric
+assert_customer_identifier "jq generator arguments retain numeric literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-until-output-string-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+null | {tenant: until(. != null; "private-customer")}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-until-output-string
+assert_customer_identifier "jq until update strings retain literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-until-output-number-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+null | {account_id: until(. != null; 987654321)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-until-output-number
+assert_customer_identifier "jq until update numbers retain literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-range-output-number-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: range(987654321; 987654322)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-range-output-number
+assert_customer_identifier "identifier-sized jq range bounds retain literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-signed-fallback-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: .account_id // -987654321}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-signed-fallback-numeric
+assert_customer_identifier "jq signed fallbacks retain numeric literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-scientific-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: 9.87654321e8}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-scientific-numeric
+assert_customer_identifier "jq scientific notation retains numeric literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-dynamic-arithmetic-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: (.account_id + 987654321)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-dynamic-arithmetic-numeric
+assert_customer_identifier "jq dynamic arithmetic retains identifier-sized literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-small-dynamic-arithmetic-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id: ((.account_id * 0) + 12345)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-small-dynamic-arithmetic-numeric
+assert_customer_identifier "jq cancelled arithmetic retains small numeric literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-compact-arithmetic-numeric-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{account_id:(.account_id+987654321)}
+{account_id:(.account_id-987654321)}
+{account_id:(((.account_id//0)*0)+12345)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-compact-arithmetic-numeric
+assert_violation "compact jq arithmetic operators cannot hide numeric identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-safe-object-index)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: {"private-customer": "example-corp"}["private-customer"]}
+{tenant: env["private-customer"]}
+{tenant: input["private-customer"]}
+{tenant: objects["private-customer"]}
+{tenant: payload["private-customer"]}
+{account_id: .ids[0] + 1}
+{account_id: range(0; 10)}
+{account_id: range(0; 1; 987654321)}
+{account_id: range(0; 10; first(100000))}
+{account_id: range(0; 10; limit(1; 100000))}
+{account_id: range(0; 10; [100000][0])}
+{account_id: select(.account_id == 987654321)}
+{account_id: .ids[987654321]}
+{account_id: indices(987654321)}
+{account_id: flatten(987654321)}
+{account_id: .account_id // 0}
+{account_id: .account_id // 123456789012}
+{account_id: .account_id + 0e999}
+{account_id: .account_id // 0e999}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-safe-object-index
+assert_clean "jq indexes and arithmetic constants remain expressions" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-even-backslash-string)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "example-corp\\"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-even-backslash
+assert_clean "jq even backslashes preserve closing-quote parity" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-escaped-interpolation-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\\(private-customer)"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-escaped-interpolation-literal
+assert_customer_identifier "escaped jq interpolation cannot hide literal identities" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-unicode-placeholder)
+cat >"${repo}/filter.jq" <<'EOF'
+{tenant: "\u0065xample-corp"}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-unicode-placeholder
+assert_clean "jq Unicode escapes resolve before placeholder comparison" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-expression-message-strings)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: input.tenant // error("tenant is required")}
+{tenant: select(.status == "active")}
+{tenant: getpath(["tenant"])}
+{tenant: has("tenant")}
+{tenant: .["tenant"]}
+{tenant: if .kind == "customer" then .tenant else empty end}
+{tenant: sub("private"; "example-corp")}
+{tenant: gsub("private"; "example-corp")}
+{tenant: if "customer" == .kind then .tenant else empty end}
+{tenant: startswith("customer")}
+{tenant: test("customer")}
+{tenant: match("customer")}
+{tenant: capture("(?<tenant>customer)").tenant}
+{tenant: delpaths([["customer"]])}
+{tenant: split("customer")}
+{tenant: ltrimstr("customer")}
+{tenant: rtrimstr("customer")}
+{tenant: inside("customer")}
+{tenant: rindex("customer")}
+{tenant: bsearch("customer")}
+{tenant: setpath(["customer"]; input.tenant)}
+{tenant: strptime("%Y-customer-%m")}
+{tenant: scan("customer")}
+{tenant: sort_by(.kind == "customer")}
+{tenant: unique_by(.kind == "customer")}
+{tenant: group_by(.kind == "customer")}
+{tenant: min_by(.kind == "customer")}
+{tenant: max_by(.kind == "customer")}
+{tenant: any("customer")}
+{tenant: all("customer")}
+{tenant: isempty("customer")}
+{tenant: IN("customer")}
+{tenant: combinations(2)}
+{tenant: splits("private-customer")}
+{tenant: "private-customer" | in({"private-customer": true})}
+{tenant: if "private-customer" then "example-corp" else . end}
+{tenant: until("private-customer"; .)}
+{tenant: paths("private-customer")}
+{tenant: sub("private"; "example-corp"; "g")}
+{tenant: gsub("private"; "example-corp"; "g")}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-message-strings
+assert_clean "jq function arguments are not output identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-transform-replacement-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: sub("public"; "private-customer")}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-transform-replacement
+assert_customer_identifier "jq transform replacements retain literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-nested-transform-replacement-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+"x" | {tenant: sub("x"; if limit(1; true) then "private-customer" else "example-corp" end)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-nested-transform-replacement
+assert_customer_identifier "nested jq separators cannot hide sub replacement literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-nested-gsub-replacement-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+"x" | {tenant: gsub("x"; if limit(1; true) then "private-customer" else "example-corp" end)}
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-nested-gsub-replacement
+assert_customer_identifier "nested jq separators cannot hide gsub replacement literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-setpath-value-literal)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```jq
+{tenant: setpath(["customer"]; "private-customer")}
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-setpath-value
+assert_customer_identifier "jq setpath output values retain literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-comment-in-shell-filter)
+cat >"${repo}/fixture.mdx" <<'EOF'
+```bash
+jq '{
+  # tenant: private-customer
+}' input.json
+```
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm jq-filter-comment
+assert_customer_identifier "shell-quoted jq comments cannot hide identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo compact-identity-delimiters)
+cat >"${repo}/fixture.txt" <<'EOF'
+[INFO]tenant=private-customer
+EOF
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm compact-delimiter
+assert_customer_identifier "compact log delimiters cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo compact-markdown-identity)
+cat >"${repo}/fixture.md" <<'EOF'
+|tenant: private-customer|
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm compact-table
+assert_customer_identifier "compact Markdown tables cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo marked-up-identity-key)
+cat >"${repo}/fixture.md" <<'EOF'
+`tenant`: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm marked-key
+assert_customer_identifier "Markdown key markup cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo whole-inline-identity-field)
+cat >"${repo}/fixture.md" <<'EOF'
+`tenant: private-customer`
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm whole-inline-field
+assert_customer_identifier "inline code cannot hide whole identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo whole-inline-identity-expression)
+cat >"${repo}/fixture.md" <<'EOF'
+Use `tenant: input.tenant` in this example.
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm whole-inline-expression
+assert_clean "inline identity expressions are executable examples" "$repo" --scope head --mode enforce
+
+repo=$(new_repo nested-markup-identity-key)
+cat >"${repo}/fixture.md" <<'EOF'
+***tenant***: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm nested-markup-key
+assert_customer_identifier "nested Markdown key markup cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo mixed-markup-identity-key)
+cat >"${repo}/fixture.md" <<'EOF'
+**`tenant`**: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm mixed-markup-key
+assert_customer_identifier "mixed Markdown key markup cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo emphasized-identity-key)
+cat >"${repo}/fixture.md" <<'EOF'
+*tenant*: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm emphasized-key
+assert_customer_identifier "Markdown emphasis around keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo struck-identity-key)
+cat >"${repo}/fixture.md" <<'EOF'
+~~tenant~~: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm struck-key
+assert_customer_identifier "Markdown strike markup cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-identity-key)
+printf '\033[32mtenant=private-customer\033[0m\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-key
+assert_customer_identifier "ANSI decoration cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-inside-identity-key)
+printf 'ten\033[31mant=private-customer\033[0m\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-inside-key
+assert_customer_identifier "ANSI escapes inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-csi-inside-identity-key)
+printf 'ten\033[0Kant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-csi-inside-key
+assert_customer_identifier "ANSI CSI controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-osc-inside-identity-key)
+printf 'ten\033]8;;https://example.com\007\033]8;;\007ant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-osc-inside-key
+assert_customer_identifier "ANSI OSC controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-c1-inside-identity-key)
+printf 'ten\302\2330Kant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-c1-inside-key
+assert_customer_identifier "ANSI C1 CSI controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-c1-osc-inside-identity-key)
+printf 'ten\302\2358;;https://example.com\302\234\302\2358;;\302\234ant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-c1-osc-inside-key
+assert_customer_identifier "ANSI C1 OSC controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-raw-controls-inside-identity-key)
+printf 'te\2330Kn\2358;;https://example.com\234\220payload\234\033(Bant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-raw-controls-inside-key
+assert_customer_identifier "raw ANSI controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo ansi-control-strings-inside-identity-key)
+printf 'te\302\230payload\302\234n\302\236payload\302\234\302\237payload\302\234ant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm ansi-control-strings-inside-key
+assert_customer_identifier "ANSI control strings inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo consecutive-osc-controls-inside-identity-key)
+printf 'te\033]0;one\033\\n\033]0;two\033\\ant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm consecutive-osc-controls-inside-key
+assert_customer_identifier "consecutive OSC controls cannot consume key text" "$repo" --scope head --mode enforce
+
+repo=$(new_repo terminal-controls-inside-identity-key)
+printf 'te\007n\010a\177nt=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm terminal-controls-inside-key
+assert_customer_identifier "terminal controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo unicode-format-controls-inside-identity-key)
+printf 'te\342\200\213n\342\200\214a\342\201\240n\302\255t=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm unicode-format-controls-inside-key
+assert_customer_identifier "Unicode format controls inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo unicode-default-ignorable-inside-identity-key)
+printf 'te\357\270\217n\315\217a\341\240\213nt=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm unicode-default-ignorable-inside-key
+assert_customer_identifier "Unicode default-ignorable marks cannot hide identity fields" "$repo" --scope head --mode enforce
+
+for codepoint in 0xE0000 0xE0080 0xE01F0 0xE0FFF; do
+  repo=$(new_repo "unicode-plane-14-${codepoint}")
+  python3 - "$codepoint" "${repo}/fixture.txt" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[2]).write_text(
+    f"ten{chr(int(sys.argv[1], 0))}ant=private-customer\n",
+    encoding="utf-8",
+)
+PY
+  git -C "$repo" add fixture.txt
+  git -C "$repo" commit -qm "unicode-plane-14-${codepoint}"
+  assert_customer_identifier "Plane-14 default-ignorable ${codepoint} cannot hide identity fields" "$repo" --scope head --mode enforce
+done
+
+repo=$(new_repo unicode-filler-controls-inside-identity-key)
+printf 'te\341\236\264n\341\205\237a\343\205\244n\357\276\240t=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm unicode-filler-controls-inside-key
+assert_customer_identifier "Unicode invisible fillers cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo nul-inside-identity-key)
+printf 'ten\000ant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm nul-inside-key
+assert_customer_identifier "NUL bytes inside keys cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo multiline-ansi-string-inside-identity-key)
+printf 'ten\033Ppayload\nmore\033\\ant=private-customer\n' >"${repo}/fixture.txt"
+git -C "$repo" add fixture.txt
+git -C "$repo" commit -qm multiline-ansi-string-inside-key
+assert_customer_identifier "multiline ANSI control strings cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo html-identity-field)
+cat >"${repo}/fixture.mdx" <<'EOF'
+<td>tenant: private-customer</td>
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm html-field
+assert_customer_identifier "HTML delimiters cannot hide identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo non-field-identity-suffixes)
+cat >"${repo}/fixture.mdx" <<'EOF'
+multi-tenant: enabled
+non-customer: behavior is documented.
+https://example.com/customer: read the guide.
+EOF
+git -C "$repo" add fixture.mdx
+git -C "$repo" commit -qm non-fields
+assert_clean "hyphenated words and URL paths are not identity fields" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-anchor-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: &customer private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm anchored-value
+assert_customer_identifier "YAML anchors cannot hide literal identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-alias-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared private-customer
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm aliased-value
+assert_customer_identifier "YAML aliases cannot hide literal identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-alias-document-scope)
+cat >"${repo}/fixture.yaml" <<'EOF'
+---
+actual: &shared private-customer
+tenant: *shared
+---
+actual: &shared example-corp
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm alias-document-scope
+assert_customer_identifier "YAML aliases resolve in declaration and document order" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-alias-fake-redefinition)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared private-customer
+tenant: *shared
+# &shared example-corp
+note: "use &shared example-corp"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm alias-fake-redefinition
+assert_customer_identifier "comments and strings cannot redefine YAML anchors" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-indirect-alias-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &default private-customer
+copy: &shared *default
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm indirect-alias
+assert_customer_identifier "indirect YAML aliases cannot hide literal values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-safe-alias-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared example-corp
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm safe-alias
+assert_clean "YAML aliases to synthetic values remain clean" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-safe-flow-alias)
+cat >"${repo}/fixture.yaml" <<'EOF'
+values: [&shared example-corp]
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm safe-flow-alias
+assert_clean "YAML flow anchors resolve only their scalar node" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-safe-flow-map-alias)
+cat >"${repo}/fixture.yaml" <<'EOF'
+{actual: &shared example-corp, tenant: *shared}
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm safe-flow-map-alias
+assert_clean "YAML flow mappings resolve aliases on the same line" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-flow-anchor-order)
+cat >"${repo}/fixture.yaml" <<'EOF'
+{first: &shared example-corp, use: *shared, later: &shared private-customer}
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm flow-anchor-order
+assert_customer_identifier "multiple YAML flow anchors apply in event order" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-flow-alias-use-order)
+cat >"${repo}/fixture.yaml" <<'EOF'
+{first: &shared private-customer, tenant: *shared, later: &shared example-corp}
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm flow-alias-use-order
+assert_customer_identifier "YAML aliases use anchor state at their position" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-anchored-doubled-quote)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared 'example-corp''private-customer'
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm anchored-doubled-quote
+assert_customer_identifier "YAML anchored doubled quotes retain complete values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-anchor-comma-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared example-corp,private-customer
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm anchor-comma-value
+assert_customer_identifier "YAML anchor commas remain block scalar content" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-anchor-hash-identity)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared example-corp#private-customer
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm anchor-hash-value
+assert_customer_identifier "YAML anchor hashes without whitespace remain scalar content" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-anchor-tag-order)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared !!str example-corp
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm anchor-tag-order
+assert_clean "YAML tags after anchors preserve scalar safety" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-anchor-nonspecific-tag)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared ! example-corp
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm anchor-nonspecific-tag
+assert_clean "YAML non-specific tags after anchors preserve scalar safety" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-direct-tags)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: !!str example-corp
+tenant: &shared !!str example-corp
+tenant: !!str "*shared"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm direct-tags
+assert_clean "YAML tags on identity values preserve scalar safety" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-tag-handles)
+cat >"${repo}/fixture.yaml" <<'EOF'
+%TAG !e! tag:example.com,2020:
+---
+actual: &shared !e!str example-corp
+tenant: *shared
+other: &encoded !foo%20bar example-corp
+customer: *encoded
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm tag-handles
+assert_clean "YAML tag handles preserve anchored scalar safety" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-local-tag-uri-characters)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: !foo@bar example-corp
+customer: !foo;bar example-corp
+account: !foo&bar example-corp
+project: !foo=bar example-corp
+namespace: !foo?bar example-corp
+actual: &shared !foo$~,'(bar) example-corp
+tenant: *shared
+tagged: !foo#bar &local_fragment example-corp
+tenant: *local_fragment
+verbatim: !<tag:example#fragment> &verbatim_fragment example-corp
+tenant: *verbatim_fragment
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm local-tag-uri-characters
+assert_clean "YAML local-tag URI characters preserve scalar safety" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-local-tag-uri-unsafe-value)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: !foo@bar private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm local-tag-uri-unsafe-value
+assert_customer_identifier "YAML local tags cannot hide identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-quoted-alias-literal)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared private-customer
+tenant: "*shared"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm quoted-alias-literal
+assert_clean "quoted YAML alias syntax remains literal content" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-nested-flow-context)
+cat >"${repo}/fixture.yaml" <<'EOF'
+{metadata: {}, tenant: example-corp, other: default}
+{metadata: {}, full_name: Dana R., other: default}
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm nested-flow-context
+assert_clean "nested YAML flow collections preserve field delimiters" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-anchor-state)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared private-customer
+note: |
+  &shared example-corp
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-anchor-state
+assert_customer_identifier "YAML block text cannot redefine anchors" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-safe-block-alias)
+cat >"${repo}/fixture.yaml" <<'EOF'
+actual: &shared |
+  example-corp
+tenant: *shared
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm safe-block-alias
+assert_clean "YAML aliases resolve safe anchored block scalars" "$repo" --scope head --mode enforce
+
+repo=$(new_repo emphasized-identity-value)
+cat >"${repo}/fixture.md" <<'EOF'
+tenant: **private-customer**
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm emphasized-value
+assert_customer_identifier "Markdown emphasis cannot hide literal identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-scalar)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: |
+  documented example text
+namespace: >-
+  documented example text
+account: |2-
+    documented example text
+project: |
+  Use the documented example tenant.
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-scalar
+assert_clean "YAML block-scalar indicators are syntax" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-scalar-literal)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: |
+  private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-scalar-literal
+assert_customer_identifier "YAML block scalars cannot hide literal identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-scalar-organization)
+cat >"${repo}/fixture.yaml" <<'EOF'
+customer_name: |
+  Private Customer Inc.
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-scalar-organization
+assert_customer_identifier "YAML block scalars inspect multiword organization values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-scalar-comment)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: |
+  private-customer # division
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-scalar-comment
+assert_customer_identifier "YAML block scalar comments cannot hide identity values" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-scalar-safe-prefix)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: |
+  example-corp # private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-scalar-safe-prefix
+assert_customer_identifier "safe block prefixes cannot hide identity suffixes" "$repo" --scope head --mode enforce
+
+repo=$(new_repo yaml-block-scalar-hash-content)
+cat >"${repo}/fixture.yaml" <<'EOF'
+tenant: |
+  # private-customer
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm block-scalar-hash-content
+assert_customer_identifier "hash-prefixed block content remains identity data" "$repo" --scope head --mode enforce
+
+repo=$(new_repo markdown-yaml-block-scalar-literal)
+cat >"${repo}/fixture.md" <<'EOF'
+```yaml
+tenant: |
+  private-customer
+```
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm markdown-block-scalar
+assert_customer_identifier "Markdown YAML blocks inspect identity scalar bodies" "$repo" --scope head --mode enforce
+
+repo=$(new_repo fenced-source-expressions)
+cat >"${repo}/fixture.md" <<'EOF'
+```javascript
+const context = { tenant: input.tenant };
+```
+```go
+context := Config{Namespace: input.Namespace}
+```
+```hcl
+tenant = var.tenant
+```
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm fenced-expressions
+assert_clean "fenced source expressions are not identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo attributed-fenced-source-expression)
+cat >"${repo}/fixture.md" <<'EOF'
+```{.javascript}
+const context = { tenant: input.tenant };
+```
+```{js}
+const context = { tenant: input.tenant };
+```
+```{#example .javascript}
+const context = { tenant: input.tenant };
+```
+```{.js,#example}
+const context = { tenant: input.tenant };
+```
+```{python, echo=FALSE}
+context = {"tenant": input.tenant}
+```
+```{python,echo=FALSE}
+context = {"tenant": input.tenant}
+```
+```javascript
+```not-a-closing-fence
+const context = { tenant: input.tenant };
+```
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm attributed-fence
+assert_clean "attributed source fences preserve expression context" "$repo" --scope head --mode enforce
+
+repo=$(new_repo blockquoted-source-fences)
+cat >"${repo}/fixture.md" <<'EOF'
+> ```javascript
+> const context = { tenant: input.tenant };
+> ```
+> ```jq
+> {tenant: .tenant}
+> ```
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm blockquoted-fences
+assert_clean "blockquoted source fences preserve expression context" "$repo" --scope head --mode enforce
+
+repo=$(new_repo list-item-source-fences)
+cat >"${repo}/fixture.md" <<'EOF'
+- ```javascript
+  const context = { tenant: input.tenant };
+  ```
+- - ```javascript
+    const context = { tenant: input.tenant };
+    ```
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm list-item-fences
+assert_clean "list-item source fences preserve expression context" "$repo" --scope head --mode enforce
+
+repo=$(new_repo indented-invalid-source-fence)
+cat >"${repo}/fixture.md" <<'EOF'
+    ```javascript
+tenant: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm indented-invalid-source-fence
+assert_customer_identifier "four-space Markdown fences cannot create source context" "$repo" --scope head --mode enforce
+
+repo=$(new_repo long-ordered-invalid-source-fence)
+cat >"${repo}/fixture.md" <<'EOF'
+1234567890. ```javascript
+account: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm long-ordered-invalid-source-fence
+assert_customer_identifier "ten-digit list markers cannot create source fences" "$repo" --scope head --mode enforce
+
+repo=$(new_repo backtick-info-invalid-source-fence)
+cat >"${repo}/fixture.md" <<'EOF'
+```javascript `invalid
+customer: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm backtick-info-invalid-source-fence
+assert_customer_identifier "backticks invalidate backtick-fence info strings" "$repo" --scope head --mode enforce
+
+repo=$(new_repo indented-invalid-source-fence-closer)
+cat >"${repo}/fixture.md" <<'EOF'
+```javascript
+    ```
+const context = { tenant: input.tenant };
+```
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm indented-invalid-source-fence-closer
+assert_clean "four-space fence-like lines do not close top-level source fences" "$repo" --scope head --mode enforce
+
+repo=$(new_repo tab-invalid-source-fence-closer)
+printf '```javascript\n\t```\nconst context = { tenant: input.tenant };\n```\n' >"${repo}/fixture.md"
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm tab-invalid-source-fence-closer
+assert_clean "tab-indented fence-like lines do not close source fences" "$repo" --scope head --mode enforce
+
+repo=$(new_repo list-padding-invalid-source-fence)
+cat >"${repo}/fixture.md" <<'EOF'
+-     ```javascript
+tenant: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm list-padding-invalid-source-fence
+assert_customer_identifier "excess list padding cannot create source fences" "$repo" --scope head --mode enforce
+
+repo=$(new_repo blockquote-padding-invalid-source-fence)
+cat >"${repo}/fixture.md" <<'EOF'
+>     ```javascript
+tenant: private-customer
+EOF
+git -C "$repo" add fixture.md
+git -C "$repo" commit -qm blockquote-padding-invalid-source-fence
+assert_customer_identifier "excess blockquote padding cannot create source fences" "$repo" --scope head --mode enforce
+
+repo=$(new_repo source-file-expressions)
+cat >"${repo}/fixture.tf" <<'EOF'
+locals {
+  tenant = var.tenant
+}
+EOF
+git -C "$repo" add fixture.tf
+git -C "$repo" commit -qm source-expression
+assert_clean "Terraform expressions are not identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo source-attribute-literal)
+cat >"${repo}/fixture.tf" <<'EOF'
+config.tenant = "private-customer"
+EOF
+git -C "$repo" add fixture.tf
+git -C "$repo" commit -qm source-attribute-literal
+assert_customer_identifier "source attribute assignments retain literal enforcement" "$repo" --scope head --mode enforce
+
+repo=$(new_repo source-comment-literal)
+cat >"${repo}/fixture.ts" <<'EOF'
+// tenant: private-customer
+EOF
+git -C "$repo" add fixture.ts
+git -C "$repo" commit -qm comment-literal
+assert_customer_identifier "source comments cannot hide identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo source-comment-expression)
+cat >"${repo}/fixture.ts" <<'EOF'
+// tenant: input.tenant
+EOF
+git -C "$repo" add fixture.ts
+git -C "$repo" commit -qm comment-expression
+assert_clean "source comments can document identity expressions" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-comment-literal)
+cat >"${repo}/filter.jq" <<'EOF'
+# tenant: private-customer
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-comment-literal
+assert_customer_identifier "jq comments cannot hide identity literals" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-comment-expression)
+cat >"${repo}/filter.jq" <<'EOF'
+# tenant: input.tenant
+EOF
+git -C "$repo" add filter.jq
+git -C "$repo" commit -qm jq-comment-expression
+assert_clean "jq comments can document identity expressions" "$repo" --scope head --mode enforce
 
 repo=$(new_repo public-ip-contexts)
 cat >"${repo}/fixture.txt" <<'EOF'
@@ -215,6 +1783,22 @@ printf 'full_name: Jane Doe\n' >"${repo}/fixture.yaml"
 git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm name
 assert_violation "literal structured person name" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quoted-person-name)
+cat >"${repo}/fixture.yaml" <<'EOF'
+full_name: "Dana R., Private Customer"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm quoted-person-name
+assert_violation "quoted punctuation cannot truncate person-name inspection" "$repo" --scope head --mode enforce
+
+repo=$(new_repo quoted-personal-record)
+cat >"${repo}/fixture.yaml" <<'EOF'
+street_address: "default,private-location"
+EOF
+git -C "$repo" add fixture.yaml
+git -C "$repo" commit -qm quoted-personal-record
+assert_violation "quoted punctuation cannot truncate personal-record inspection" "$repo" --scope head --mode enforce
 
 repo=$(new_repo numeric-person-fields)
 printf 'first_name: 101\nlast_name: "202"\n' >"${repo}/fixture.yaml"


### PR DESCRIPTION
## Summary

- enforce identity fields across compact serialization, log/timestamp prefixes, Markdown structure, YAML anchors/tags, jq literals, and invisible-control variants
- classify jq string/number constants by output role, including positional functions, nested no-op interpolation, arithmetic, and canonical numeric stringification
- preserve safe prose, source expressions, placeholders, YAML aliases, jq control arguments, and documentation-reserved values with hermetic regressions
- keep the managed scanner byte-stable under Ruff 88/100/120 column configurations

## Measured verification

- `bash tests/test-check-pii.sh`
- every `tests/test-*.sh`
- `pre-commit run --all-files`
- Ruff 0.16.0 lint and format checks at 88, 100, and 120 columns
- staged PII enforcement
- `gitleaks detect --redact --no-banner`
- independent implementation and adversarial replay on the final artifact

Translation generation was not run: fleet translation generation is intentionally suspended until production release, and the suspension guards passed.

Parser-sized follow-up classes remain explicitly measured in #932, #933, #939, and #940; no discovered defect was left silent.

Closes #926
