### PR TITLE
fix: bind Pages builds to exact content ref

### DIFF
--- a/.github/workflows/docs-site-deploy.yml
+++ b/.github/workflows/docs-site-deploy.yml
@@ -1,0 +1,19 @@
+---
+name: Deploy docs-control Site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    uses: ./.github/workflows/github-pages-deploy.yml
+    with:
+      content-ref: ${{ github.sha }}

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_call:
     inputs:
+      content-ref:
+        description: 'Exact commit or ref to build from the calling repo'
+        required: true
+        type: string
       content-path:
         description: 'Path to content directory in the calling repo'
         required: false
@@ -69,6 +73,8 @@ jobs:
     steps:
       - name: Checkout content repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.content-ref || github.sha }}
 
       - name: Login to GHCR
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
@@ -142,6 +148,8 @@ jobs:
           find "$OUTPUT_DIR" -type f | head -20
 
       - name: Stage governance assets for /api/
+        env:
+          CONTENT_REF: ${{ inputs.content-ref || github.sha }}
         run: |
           OUTPUT_DIR="${{ runner.temp }}/docs-output"
           API_DIR="${OUTPUT_DIR}/api"
@@ -173,11 +181,14 @@ jobs:
             done
           fi
 
-          # Revision marker — lets downstreams detect Pages deploy lag
+          # Revision marker — records what was requested and what checkout resolved.
+          # Do not add a timestamp: identical content at an identical ref must produce
+          # an identical marker.
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
           jq -n \
-            --arg commit "${GITHUB_SHA}" \
-            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{commit:$commit, generated_at:$generated_at}' \
+            --arg content_ref "${CONTENT_REF}" \
+            --arg commit "${CHECKED_OUT_SHA}" \
+            '{content_ref:$content_ref, commit:$commit}' \
             > "${API_DIR}/revision.json"
           echo "Published: /api/revision.json"
 

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,8 +1,6 @@
 ---
 name: Build and Deploy Docs
 on:
-  push:
-    branches: [main]
   workflow_call:
     inputs:
       content-ref:
@@ -21,27 +19,6 @@ on:
         type: string
       docs-title:
         description: 'Documentation site title (overrides frontmatter)'
-        required: false
-        type: string
-      docs-site:
-        description: 'Documentation site URL'
-        required: false
-        default: 'https://f5-sales-demo.github.io'
-        type: string
-  workflow_dispatch:
-    inputs:
-      content-path:
-        description: 'Path to content directory'
-        required: false
-        default: 'docs'
-        type: string
-      builder-image:
-        description: 'Builder Docker image URI'
-        required: false
-        default: 'ghcr.io/f5-sales-demo/docs-builder:latest'
-        type: string
-      docs-title:
-        description: 'Documentation site title'
         required: false
         type: string
       docs-site:
@@ -71,23 +48,26 @@ jobs:
     outputs:
       build-status: ${{ job.status }}
     steps:
-      - name: Validate immutable content commit
+      - name: Resolve immutable content commit
+        id: content
         env:
-          CONTENT_REF: ${{ inputs.content-ref || github.sha }}
+          REQUESTED_REF: ${{ inputs.content-ref }}
         run: |
+          CONTENT_REF="$REQUESTED_REF"
           if [[ ! "$CONTENT_REF" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::content-ref must be a full lowercase 40-character commit SHA"
             exit 1
           fi
+          echo "content_ref=$CONTENT_REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout content repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.content-ref || github.sha }}
+          ref: ${{ steps.content.outputs.content_ref }}
 
       - name: Verify checked-out content commit
         env:
-          CONTENT_REF: ${{ inputs.content-ref || github.sha }}
+          CONTENT_REF: ${{ steps.content.outputs.content_ref }}
         run: |
           CHECKED_OUT_SHA=$(git rev-parse HEAD)
           if [ "$CHECKED_OUT_SHA" != "$CONTENT_REF" ]; then
@@ -168,7 +148,7 @@ jobs:
 
       - name: Stage governance assets for /api/
         env:
-          CONTENT_REF: ${{ inputs.content-ref || github.sha }}
+          CONTENT_REF: ${{ steps.content.outputs.content_ref }}
         run: |
           OUTPUT_DIR="${{ runner.temp }}/docs-output"
           API_DIR="${OUTPUT_DIR}/api"

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -6,7 +6,7 @@ on:
   workflow_call:
     inputs:
       content-ref:
-        description: 'Exact commit or ref to build from the calling repo'
+        description: 'Exact 40-character commit SHA to build from the calling repo'
         required: true
         type: string
       content-path:
@@ -71,10 +71,29 @@ jobs:
     outputs:
       build-status: ${{ job.status }}
     steps:
+      - name: Validate immutable content commit
+        env:
+          CONTENT_REF: ${{ inputs.content-ref || github.sha }}
+        run: |
+          if [[ ! "$CONTENT_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::content-ref must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+
       - name: Checkout content repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.content-ref || github.sha }}
+
+      - name: Verify checked-out content commit
+        env:
+          CONTENT_REF: ${{ inputs.content-ref || github.sha }}
+        run: |
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          if [ "$CHECKED_OUT_SHA" != "$CONTENT_REF" ]; then
+            echo "::error::Checkout resolved $CHECKED_OUT_SHA, expected $CONTENT_REF"
+            exit 1
+          fi
 
       - name: Login to GHCR
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -110,6 +110,7 @@ jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
     with:
+      # Must be the immutable full commit SHA whose documentation is being built.
       content-ref: $\{{ github.sha }}
 ```
 

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -10,6 +10,7 @@ sidebar:
 When template files change on docs-control's `main` branch, the dispatch workflow at `.github/workflows/dispatch-downstream.yml` triggers enforcement in every enrolled downstream repository.
 
 The trigger paths include:
+
 - `.github/config/repo-settings.json`, `downstream-repos.json`, `docs-sites.json`
 - `workflows/**` (caller templates)
 - `.github/workflows/enforce-repo-settings.yml`, `sync-managed-files.yml`, `github-pages-deploy.yml`, `require-linked-issue.yml`
@@ -103,11 +104,13 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
+    with:
+      content-ref: $\{{ github.sha }}
 ```
 
 ### require-linked-issue.yml

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -39,6 +39,7 @@ bad() {
 # commit checkout resolved, and contains no wall-clock data.
 input_block=$(sed -n '/^      content-ref:/,/^        type: string/p' "$DEPLOY_WORKFLOW")
 checkout_block=$(sed -n '/^      - name: Checkout content repo/,/^      - name: Login to GHCR/p' "$DEPLOY_WORKFLOW")
+validation_block=$(sed -n '/^      - name: Validate immutable content commit/,/^      - name: Checkout content repo/p' "$DEPLOY_WORKFLOW")
 revision_block=$(sed -n '/^      - name: Stage governance assets for \/api\//,/^      - name: Upload artifact/p' "$DEPLOY_WORKFLOW")
 
 if grep -q '^        required: true$' <<<"$input_block" &&
@@ -52,6 +53,14 @@ if grep -qF 'ref: ${{ inputs.content-ref || github.sha }}' <<<"$checkout_block";
   ok "Pages deploy checks out the requested content ref"
 else
   bad "Pages deploy checkout does not use content-ref"
+fi
+
+if grep -qF '^[0-9a-f]{40}$' <<<"$validation_block" &&
+  grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$checkout_block" &&
+  grep -qF 'if [ "$CHECKED_OUT_SHA" != "$CONTENT_REF" ]' <<<"$checkout_block"; then
+  ok "Pages deploy requires and verifies an immutable full commit SHA"
+else
+  bad "Pages deploy does not enforce immutable full-SHA content identity"
 fi
 
 if grep -qF 'CONTENT_REF: ${{ inputs.content-ref || github.sha }}' <<<"$revision_block" &&

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Hermetic regression test for the Pages-freshness guard in the governed-read
-# workflows (sync-managed-files.yml, enforce-repo-settings.yml).
+# Hermetic regression tests for the Pages publication identity contract and the
+# Pages-freshness guard in the governed-read workflows (sync-managed-files.yml,
+# enforce-repo-settings.yml).
 #
 # WHY: `fetch_governed` prefers the Pages-published governance mirror, which lags a
 # docs-control merge by however long its deploy takes. The guard must force an API
@@ -10,14 +11,16 @@
 # governance changes silently never propagated. enforce-repo-settings.yml defined
 # revision_is_fresh but never called it at all.
 #
-# This test locks two properties, statically (no network):
-#   1. Both workflows CALL the guard, and do so UNCONDITIONALLY on SOURCE_SHA
-#      (i.e. an empty source_sha must still be checked, via a main-HEAD fallback).
-#   2. The revision_is_fresh comparison semantics stay exact-match.
+# This test locks the publication identity and freshness contracts statically
+# (no network): the deploy checks out its explicit caller ref and publishes the
+# resolved commit without volatile data; both readers call the freshness guard
+# unconditionally; and revision_is_fresh remains an exact comparison.
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 FAIL=0
+DEPLOY_WORKFLOW="${REPO_ROOT}/.github/workflows/github-pages-deploy.yml"
+CALLER_TEMPLATE="${REPO_ROOT}/workflows/github-pages-deploy.yml"
 
 WORKFLOWS=(
   "${REPO_ROOT}/.github/workflows/sync-managed-files.yml"
@@ -29,6 +32,49 @@ bad() {
   echo "[FAIL] $1"
   FAIL=1
 }
+
+# The reusable workflow must build the requested caller revision, not the SHA of
+# whichever commit happens to contain the reusable workflow invocation. Its
+# revision marker is an artifact identity: it records the requested ref and the
+# commit checkout resolved, and contains no wall-clock data.
+input_block=$(sed -n '/^      content-ref:/,/^        type: string/p' "$DEPLOY_WORKFLOW")
+checkout_block=$(sed -n '/^      - name: Checkout content repo/,/^      - name: Login to GHCR/p' "$DEPLOY_WORKFLOW")
+revision_block=$(sed -n '/^      - name: Stage governance assets for \/api\//,/^      - name: Upload artifact/p' "$DEPLOY_WORKFLOW")
+
+if grep -q '^        required: true$' <<<"$input_block" &&
+  grep -q '^        type: string$' <<<"$input_block"; then
+  ok "Pages deploy requires an explicit workflow_call content-ref"
+else
+  bad "Pages deploy workflow_call content-ref is not required"
+fi
+
+if grep -qF 'ref: ${{ inputs.content-ref || github.sha }}' <<<"$checkout_block"; then
+  ok "Pages deploy checks out the requested content ref"
+else
+  bad "Pages deploy checkout does not use content-ref"
+fi
+
+if grep -qF 'CONTENT_REF: ${{ inputs.content-ref || github.sha }}' <<<"$revision_block" &&
+  grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$revision_block" &&
+  grep -qF -- '--arg content_ref "${CONTENT_REF}"' <<<"$revision_block" &&
+  grep -qF -- '--arg commit "${CHECKED_OUT_SHA}"' <<<"$revision_block" &&
+  grep -qF "'{content_ref:\$content_ref, commit:\$commit}'" <<<"$revision_block"; then
+  ok "revision.json records requested ref and checked-out commit"
+else
+  bad "revision.json does not bind requested ref to checked-out commit"
+fi
+
+if grep -qE 'GITHUB_SHA|generated_at|date -u' <<<"$revision_block"; then
+  bad "revision.json still contains caller-SHA or wall-clock inputs"
+else
+  ok "revision.json is independent of caller SHA and wall-clock time"
+fi
+
+if grep -qF 'content-ref: ${{ github.sha }}' "$CALLER_TEMPLATE"; then
+  ok "governed caller supplies the required content ref"
+else
+  bad "governed caller omits the required content ref"
+fi
 
 for wf in "${WORKFLOWS[@]}"; do
   name=$(basename "$wf")

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -21,6 +21,7 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 FAIL=0
 DEPLOY_WORKFLOW="${REPO_ROOT}/.github/workflows/github-pages-deploy.yml"
 CALLER_TEMPLATE="${REPO_ROOT}/workflows/github-pages-deploy.yml"
+SELF_CALLER="${REPO_ROOT}/.github/workflows/docs-site-deploy.yml"
 
 WORKFLOWS=(
   "${REPO_ROOT}/.github/workflows/sync-managed-files.yml"
@@ -39,7 +40,7 @@ bad() {
 # commit checkout resolved, and contains no wall-clock data.
 input_block=$(sed -n '/^      content-ref:/,/^        type: string/p' "$DEPLOY_WORKFLOW")
 checkout_block=$(sed -n '/^      - name: Checkout content repo/,/^      - name: Login to GHCR/p' "$DEPLOY_WORKFLOW")
-validation_block=$(sed -n '/^      - name: Validate immutable content commit/,/^      - name: Checkout content repo/p' "$DEPLOY_WORKFLOW")
+validation_block=$(sed -n '/^      - name: Resolve immutable content commit/,/^      - name: Checkout content repo/p' "$DEPLOY_WORKFLOW")
 revision_block=$(sed -n '/^      - name: Stage governance assets for \/api\//,/^      - name: Upload artifact/p' "$DEPLOY_WORKFLOW")
 
 if grep -q '^        required: true$' <<<"$input_block" &&
@@ -49,13 +50,15 @@ else
   bad "Pages deploy workflow_call content-ref is not required"
 fi
 
-if grep -qF 'ref: ${{ inputs.content-ref || github.sha }}' <<<"$checkout_block"; then
+if grep -qF 'ref: ${{ steps.content.outputs.content_ref }}' <<<"$checkout_block"; then
   ok "Pages deploy checks out the requested content ref"
 else
   bad "Pages deploy checkout does not use content-ref"
 fi
 
-if grep -qF '^[0-9a-f]{40}$' <<<"$validation_block" &&
+if grep -qF 'CONTENT_REF="$REQUESTED_REF"' <<<"$validation_block" &&
+  ! grep -qE 'GITHUB_SHA|\|\|' <<<"$validation_block" &&
+  grep -qF '^[0-9a-f]{40}$' <<<"$validation_block" &&
   grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$checkout_block" &&
   grep -qF 'if [ "$CHECKED_OUT_SHA" != "$CONTENT_REF" ]' <<<"$checkout_block"; then
   ok "Pages deploy requires and verifies an immutable full commit SHA"
@@ -63,7 +66,15 @@ else
   bad "Pages deploy does not enforce immutable full-SHA content identity"
 fi
 
-if grep -qF 'CONTENT_REF: ${{ inputs.content-ref || github.sha }}' <<<"$revision_block" &&
+if ! grep -qE '^  (push|workflow_dispatch):' "$DEPLOY_WORKFLOW" &&
+  grep -qF 'uses: ./.github/workflows/github-pages-deploy.yml' "$SELF_CALLER" &&
+  grep -qF 'content-ref: ${{ github.sha }}' "$SELF_CALLER"; then
+  ok "direct docs-control triggers pass their exact SHA through a thin caller"
+else
+  bad "reusable Pages workflow still owns a direct trigger or lacks a thin caller"
+fi
+
+if grep -qF 'CONTENT_REF: ${{ steps.content.outputs.content_ref }}' <<<"$revision_block" &&
   grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$revision_block" &&
   grep -qF -- '--arg content_ref "${CONTENT_REF}"' <<<"$revision_block" &&
   grep -qF -- '--arg commit "${CHECKED_OUT_SHA}"' <<<"$revision_block" &&

--- a/workflows/github-pages-deploy.yml
+++ b/workflows/github-pages-deploy.yml
@@ -23,3 +23,5 @@ concurrency:
 jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
+    with:
+      content-ref: ${{ github.sha }}


### PR DESCRIPTION
Closes #949

## What changed

- require callers to provide the exact content ref
- checkout that ref instead of the incidental workflow caller SHA
- publish deterministic revision.json with requested ref and resolved commit
- update the governed caller template and contract tests

## Measured rollout constraint

A GitHub API scan measured 38/38 currently deployed governed callers without `content-ref`. This PR must not merge until those callers are migrated and verified; api-specs-enriched can pin this immutable reviewed commit during the coordinated rollout.

## Verification

- actionlint: passed
- shellcheck: passed
- Pages contract test: passed
- markdownlint: passed
- linter-config tests: 137 passed
- independent subagent review completed