### PR TITLE
fix: harden managed workflow permissions

### DIFF
--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -10,6 +10,7 @@ sidebar:
 When template files change on docs-control's `main` branch, the dispatch workflow at `.github/workflows/dispatch-downstream.yml` triggers enforcement in every enrolled downstream repository.
 
 The trigger paths include:
+
 - `.github/config/repo-settings.json`, `downstream-repos.json`, `docs-sites.json`
 - `workflows/**` (caller templates)
 - `.github/workflows/enforce-repo-settings.yml`, `sync-managed-files.yml`, `github-pages-deploy.yml`, `require-linked-issue.yml`
@@ -95,19 +96,20 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
+    permissions:
+      contents: read
+      packages: read
+      pages: write
+      id-token: write
 ```
 
 ### require-linked-issue.yml
@@ -121,9 +123,7 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  issues: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: $\{{ github.workflow }}-$\{{ github.event.pull_request.number }}
@@ -132,7 +132,9 @@ concurrency:
 jobs:
   check:
     uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
-    secrets: inherit
+    permissions:
+      issues: read
+      pull-requests: write
 ```
 
 ## Check name format

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -7,9 +7,7 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   call:
@@ -20,6 +18,9 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
     uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@main
+    permissions:
+      contents: write # fallback GITHUB_TOKEN must be able to complete the merge
+      pull-requests: write # enable auto-merge and update the pull request
     # Least privilege: pass ONLY the secret the reusable needs, not every
     # repository secret (`secrets: inherit`). REPO_SYNC_TOKEN is the PAT that lets
     # an auto-merge trigger downstream workflows; the reusable falls back to

--- a/workflows/code-review.yml
+++ b/workflows/code-review.yml
@@ -16,6 +16,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   review:
     # Real agentic review for HUMAN, same-repo PRs. Skipped for genuine automated
@@ -70,8 +72,8 @@ jobs:
         (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
     uses: f5-sales-demo/docs-control/.github/workflows/claude-review.yml@main
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read # inspect the same-repository pull request
+      pull-requests: write # publish the reusable review result
     secrets:
       F5_GATEWAY_TOKEN: ${{ secrets.F5_GATEWAY_TOKEN }}
       REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
@@ -87,6 +89,7 @@ jobs:
   # none did. Both jobs share the gate so the pair stays consistent: whichever way
   # the variable is set, either both run or neither does.
   review-status-automated:
+    name: Mark Automated Review Exemption
     if: >-
       vars.REVIEWER_ENABLED == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -103,7 +106,7 @@ jobs:
        (startsWith(github.head_ref, 'dependabot/') && github.actor == 'dependabot[bot]'))
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
+      statuses: write # post the required review context for trusted automation
     steps:
       - name: Post passing review/claude-review status for automated PR
         env:

--- a/workflows/dependabot-auto-merge.yml
+++ b/workflows/dependabot-auto-merge.yml
@@ -8,9 +8,7 @@ on:
   # workflow — no PR-code checkout or exec.
   pull_request_target:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   call:
@@ -18,3 +16,6 @@ jobs:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@main
+    permissions:
+      contents: write # merge the validated Dependabot update
+      pull-requests: write # approve and enable auto-merge

--- a/workflows/github-pages-deploy.yml
+++ b/workflows/github-pages-deploy.yml
@@ -7,11 +7,7 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -23,3 +19,8 @@ concurrency:
 jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
+    permissions:
+      contents: read # read documentation sources
+      packages: read # pull the fleet documentation builder image
+      pages: write # publish the built Pages artifact
+      id-token: write # authenticate the Pages deployment

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -9,9 +9,7 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
-permissions:
-  issues: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -23,3 +21,6 @@ jobs:
     # GITHUB_TOKEN (always available to a called workflow), so passing repository
     # secrets would hand over more than it needs.
     uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
+    permissions:
+      issues: read # verify that the referenced tracking issue exists
+      pull-requests: write # publish the required check result and comment

--- a/workflows/semgrep.yml
+++ b/workflows/semgrep.yml
@@ -8,19 +8,16 @@ name: Semgrep
 # managed_files entry with "only_repos" in .github/config/repo-settings.json.
 # Content/demo repos are excluded deliberately: they would produce noise, not signal.
 #
-# ADVISORY BY DESIGN: the scan never fails the build (`|| true`); findings surface in
-# the repository Security tab (Code Scanning) via the SARIF upload. Promote to a
-# required check per repo only AFTER its finding volume has been triaged — gating on
-# an untriaged SAST feed would block every merge on pre-existing findings.
+# Findings are advisory and surface in the repository Security tab through SARIF.
+# Scanner execution errors still fail the job; an unavailable or broken scan must
+# never be reported as success.
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
 
-permissions:
-  contents: read
-  security-events: write # required to upload SARIF to Code Scanning
+permissions: {}
 
 concurrency:
   group: semgrep-${{ github.ref }}
@@ -30,6 +27,9 @@ jobs:
   semgrep:
     name: Semgrep SAST
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the source to scan
+      security-events: write # upload SARIF to Code Scanning
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -39,7 +39,7 @@ jobs:
           # Registry rulesets: p/default (curated, cross-language) plus language
           # packs. A pack for a language a repo does not use simply yields no
           # findings, so one template serves every code-bearing repo.
-          # `|| true` keeps the job green regardless of findings (advisory).
+          # Findings remain advisory because --error is intentionally absent.
           # Excluded rules (categorically inapplicable — exclude at config level
           # rather than dismissing the same alert in every repo forever):
           #   python3x-compatibility-* : flags Python 3.6+ APIs as "too new". Every
@@ -51,7 +51,7 @@ jobs:
             --config p/golang \
             --exclude-rule python.lang.compatibility.python36.python36-compatibility-Popen1 \
             --exclude-rule python.lang.compatibility.python36.python36-compatibility-Popen2 \
-            --sarif --output semgrep.sarif || true
+            --sarif --output semgrep.sarif
 
       - name: Upload SARIF to Code Scanning
         if: always() && hashFiles('semgrep.sarif') != ''

--- a/workflows/super-linter.yml
+++ b/workflows/super-linter.yml
@@ -6,11 +6,7 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: read
-  packages: read
-  statuses: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -21,3 +17,8 @@ jobs:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main
+    permissions:
+      contents: read # checkout repository content in the reusable workflow
+      packages: read # pull lint tooling from GitHub Packages
+      statuses: write # publish the lint status context
+      pull-requests: write # annotate pull requests with lint results


### PR DESCRIPTION
## Summary
- scope managed caller permissions to the exact reusable-call jobs
- fail Semgrep execution errors while keeping findings advisory
- update dispatch documentation to match the hardened templates

## Verification
- actionlint passed
- Zizmor pedantic reported zero findings on changed workflows
- managed consumer templates matched byte-for-byte
- Markdownlint and focused governance regressions passed

Closes #951