### PR TITLE
fix: pin reusable workflow build inputs

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -13,7 +13,7 @@ on:
       builder-image:
         description: 'Builder Docker image URI'
         required: false
-        default: 'ghcr.io/f5-sales-demo/docs-builder:latest'
+        default: 'ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163'
         type: string
       docs-title:
         description: 'Documentation site title (overrides frontmatter)'
@@ -34,7 +34,7 @@ on:
       builder-image:
         description: 'Builder Docker image URI'
         required: false
-        default: 'ghcr.io/f5-sales-demo/docs-builder:latest'
+        default: 'ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163'
         type: string
       docs-title:
         description: 'Documentation site title'
@@ -46,11 +46,7 @@ on:
         default: 'https://f5-sales-demo.github.io'
         type: string
 
-permissions:
-  contents: read
-  packages: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages-${{ github.repository }}
@@ -61,9 +57,11 @@ concurrency:
 
 jobs:
   build:
+    name: Build Documentation
     runs-on: ubuntu-latest
     permissions:
-      packages: read
+      contents: read # checkout the documentation source
+      packages: read # authenticate the pinned builder image pull from GHCR
     outputs:
       build-status: ${{ job.status }}
     steps:
@@ -123,7 +121,7 @@ jobs:
             -e DOCS_SITE="${{ inputs.docs-site || format('https://{0}.github.io', github.repository_owner) }}" \
             -e GITHUB_REPOSITORY="${{ github.repository }}" \
             ${{ inputs.docs-title && format('-e DOCS_TITLE="{0}"', inputs.docs-title) || '' }} \
-            ${{ inputs.builder-image || format('ghcr.io/{0}/docs-builder:latest', github.repository_owner) }}
+            ${{ inputs.builder-image || 'ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163' }}
 
           echo "✅ Build completed successfully"
           ls -lah ${{ runner.temp }}/docs-output/
@@ -191,12 +189,13 @@ jobs:
           retention-days: 1
 
   deploy:
+    name: Deploy Documentation
     needs: build
     runs-on: ubuntu-latest
     if: success()
     permissions:
-      pages: write
-      id-token: write
+      pages: write # publish the verified Pages artifact
+      id-token: write # authenticate the Pages deployment
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -7,6 +7,15 @@ on:
     types: [opened, synchronize, reopened]
   workflow_call:
 
+permissions: {}
+
+concurrency:
+  # A called workflow inherits github.workflow from its caller. Keep this
+  # group distinct from caller-level groups or cancel-in-progress can cancel
+  # the caller itself instead of only superseding an older lint invocation.
+  group: reusable-super-linter-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint Code Base
@@ -15,9 +24,9 @@ jobs:
     # and PR annotations. The shell-unit-tests job below gets contents:read only.
     permissions:
       contents: read
-      packages: read
-      statuses: write
-      pull-requests: write
+      packages: read # pull the pinned Super-Linter container image
+      statuses: write # publish the lint status context
+      pull-requests: write # annotate pull requests with lint findings
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -190,16 +199,16 @@ jobs:
           echo "Enforcing ${script} from canonical governance @ ${canonical_sha}"
           git -C "$gov_dir" show "${canonical_sha}:${script}" | bash -s
 
-      # Biome runs OUTSIDE the Super-Linter container so we can track Biome
-      # `latest` instead of being gated on Super-Linter's container release
-      # cadence. Authority boundary: setup-biome owns JS/TS/JSON/JSX; the
+      # Biome runs OUTSIDE the Super-Linter container so its exact version is
+      # independent of the Super-Linter container release cadence. Authority
+      # boundary: setup-biome owns JS/TS/JSON/JSX; the
       # Super-Linter step below runs everything else with VALIDATE_BIOME_*
       # disabled. Step order matters: if Biome fails, Super-Linter is skipped
       # (default fail-fast, no `if: always()`) so developers get a focused log.
       - name: Setup Biome
         uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51  # v2.7.1 — Dependabot-managed
         with:
-          version: latest
+          version: 2.5.6
 
       - name: Run Biome
         run: |
@@ -223,8 +232,8 @@ jobs:
           PYTEST_ADDOPTS: --cache-dir=/tmp/pytest_cache
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Disable Biome in Super-Linter — handled by the biomejs/setup-biome
-          # step above, which runs Biome `latest` instead of the container's
-          # bundled version. Authority boundary: setup-biome owns JS/TS/JSON/JSX;
+          # step above, which runs the pinned Biome version instead of the
+          # container's bundled version. Authority boundary: setup-biome owns JS/TS/JSON/JSX;
           # Super-Linter retains everything else.
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -957,6 +957,41 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 14: reusable workflow tool and image inputs are immutable
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 14: reusable workflow immutable inputs ==="
+
+SUPER_LINTER_WORKFLOW="$REPO_ROOT/.github/workflows/super-linter.yml"
+PAGES_WORKFLOW="$REPO_ROOT/.github/workflows/github-pages-deploy.yml"
+EXPECTED_BUILDER='ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163'
+
+if [ "$(grep -Ec "^[[:space:]]*version:[[:space:]]*(['\"]?2\\.5\\.6['\"]?)[[:space:]]*$" "$SUPER_LINTER_WORKFLOW")" = "1" ] &&
+  ! grep -Eq "^[[:space:]]*version:[[:space:]]*(['\"]?latest['\"]?)([[:space:]]|$)" "$SUPER_LINTER_WORKFLOW"; then
+  pass "14.1 Super-Linter installs exactly Biome 2.5.6"
+else
+  fail "14.1 Super-Linter installs exactly Biome 2.5.6" \
+    "the formatter pin is absent, duplicated, or mutable"
+fi
+
+if grep -Fq 'group: reusable-super-linter-${{ github.workflow }}-' "$SUPER_LINTER_WORKFLOW"; then
+  pass "14.2 reusable lint concurrency cannot collide with its caller"
+else
+  fail "14.2 reusable lint concurrency cannot collide with its caller" \
+    "the group needs a reusable-workflow-specific prefix"
+fi
+
+# Two workflow_call defaults and the runtime fallback must resolve to identical
+# bytes. A caller can still opt into a different immutable digest explicitly.
+if [ "$(grep -cF "$EXPECTED_BUILDER" "$PAGES_WORKFLOW")" = "3" ] &&
+  ! grep -Fq 'docs-builder:latest' "$PAGES_WORKFLOW"; then
+  pass "14.3 every default documentation builder input uses the measured digest"
+else
+  fail "14.3 every default documentation builder input uses the measured digest" \
+    "expected three identical digest pins and no latest tag"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # Summary
 # ════════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
## Summary
- pin fleet Biome formatting to exact version 2.5.6
- pin all default documentation builds to the measured docs-builder image digest
- scope reusable workflow permissions and prevent concurrency-group collisions
- add regression assertions against mutable inputs

## Verification
- governance contracts: 140 passed, 0 failed
- managed-file protection: 122 passed, 0 failed
- consumer shell contracts: 25 passed, 0 failed
- actionlint: passed
- Zizmor: no findings
- pre-commit hooks: passed; translation regeneration skipped
- live GHCR latest manifest resolves to the pinned digest

Closes #954
Closes #955