### PR TITLE
fix(governance): narrow translated and fixture lint scopes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,9 @@ repos:
         entry: markdownlint-cli2
         language: system
         types: [markdown]
+        # Parser fixtures intentionally contain noncanonical Markdown so the
+        # renderer's full syntax support remains covered.
+        exclude: ^packages/chat-ui/test/markdown/fixtures/
 
   # ===========================================================================
   # Shell formatting — pinned to Super-Linter's SHELL_SHFMT v3.13.1.
@@ -189,7 +192,7 @@ repos:
         # traversal; when pre-commit passes explicit file paths it is bypassed.
         # Filter translation docs and source catalogs here so their
         # foreign-language words never reach codespell. See issues #579 and #934.
-        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|src/i18n/.*translations)
+        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations)
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -138,14 +138,15 @@ for word in doesnt forin invokable takin defaul ser anc checkin sevice; do
 done
 
 # pre-commit passes explicit paths, bypassing .codespellrc's skip list. Its
-# hook-level regex must filter both translated docs and translated source
-# catalogs while leaving English docs and i18n implementation code checked.
+# hook-level regex must filter translated docs, root translated READMEs, and
+# translated source catalogs while leaving English docs and i18n
+# implementation code checked.
 CODESPELL_EXCLUDE=$(awk '
   /- id: codespell$/ { in_codespell = 1; next }
   in_codespell && /exclude:/ { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }
 ' "$REPO_ROOT/.pre-commit-config.yaml")
 
-for path in docs/fr/guide.md src/i18n/mega-menu-translations.ts; do
+for path in docs/fr/guide.md README.de.md README.zh-tw.md src/i18n/mega-menu-translations.ts; do
   if [[ "$path" =~ $CODESPELL_EXCLUDE ]]; then
     pass "5.x codespell pre-commit excludes '$path'"
   else
@@ -153,11 +154,35 @@ for path in docs/fr/guide.md src/i18n/mega-menu-translations.ts; do
   fi
 done
 
-for path in docs/en/guide.md src/i18n/translator.ts; do
+for path in README.md docs/en/guide.md src/i18n/translator.ts; do
   if [[ "$path" =~ $CODESPELL_EXCLUDE ]]; then
     fail "5.x codespell pre-commit checks '$path'" "unexpectedly matched by hook exclude regex"
   else
     pass "5.x codespell pre-commit checks '$path'"
+  fi
+done
+
+# Markdown parser fixtures intentionally exercise syntax that the published
+# documentation style rejects. Linting or autofixing them destroys parser
+# coverage, so the hook must exclude only that behavior-sensitive fixture tree.
+MARKDOWNLINT_EXCLUDE=$(awk '
+  /- id: markdownlint$/ { in_markdownlint = 1; next }
+  in_markdownlint && /exclude:/ { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }
+' "$REPO_ROOT/.pre-commit-config.yaml")
+
+for path in packages/chat-ui/test/markdown/fixtures/emphasis.md packages/chat-ui/test/markdown/fixtures/headings.md; do
+  if [[ "$path" =~ $MARKDOWNLINT_EXCLUDE ]]; then
+    pass "5.x markdownlint preserves '$path'"
+  else
+    fail "5.x markdownlint preserves '$path'" "not matched by hook exclude regex"
+  fi
+done
+
+for path in README.md packages/chat-ui/src/markdown.ts; do
+  if [[ "$path" =~ $MARKDOWNLINT_EXCLUDE ]]; then
+    fail "5.x markdownlint checks '$path'" "unexpectedly matched by hook exclude regex"
+  else
+    pass "5.x markdownlint checks '$path'"
   fi
 done
 


### PR DESCRIPTION
Closes #957

## Outcome

The managed local hooks now preserve behavior-sensitive Markdown parser fixtures and exclude supported root translated READMEs from English spelling checks. Ordinary Markdown, English documentation, and source files remain covered.

## Verification

- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin bash tests/test-linter-configs.sh` — 147 passed, 0 failed
- `PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin pre-commit run --all-files` — passed
- `gitleaks protect --staged --redact` — no leaks
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean

## Notes

HEAD audit still reports only the previously reviewed generic `docs/images/hero.svg` media-review notice; this change adds no media or identity data.