### PR TITLE
fix(governance): stream managed tree payloads

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -222,6 +222,49 @@ jobs:
             return 1
           }
 
+          # --- Helper: file-backed Git tree payloads ---------------------------
+          normalize_tree_content() {
+            local source_file="$1"
+            local normalized_file="$2"
+
+            # Command substitution strips every trailing newline from fetched
+            # content, while generated files already carry one. Normalize both
+            # sources to exactly one without ever placing the content in argv.
+            perl -0pe 's/\n*\z/\n/' "$source_file" >"$normalized_file"
+          }
+
+          append_tree_item() {
+            local tree_items_file="$1"
+            local dest_file="$2"
+            local content_file="$3"
+            local next_items_file
+            next_items_file=$(mktemp "${tree_items_file}.next.XXXXXX")
+
+            # Both the existing tree and managed content are unbounded payloads.
+            # Read them from files so exec never encounters ARG_MAX or Linux's
+            # smaller per-argument MAX_ARG_STRLEN limit.
+            if ! jq \
+              --arg path "$dest_file" \
+              --rawfile content "$content_file" \
+              '. + [{"path": $path, "mode": "100644", "type": "blob", "content": $content}]' \
+              "$tree_items_file" >"$next_items_file"; then
+              rm -f "$next_items_file"
+              return 1
+            fi
+            mv "$next_items_file" "$tree_items_file"
+          }
+
+          write_tree_request() {
+            local base_tree="$1"
+            local tree_items_file="$2"
+            local tree_json_file="$3"
+
+            jq -n \
+              --arg base "$base_tree" \
+              --slurpfile tree "$tree_items_file" \
+              '{"base_tree": $base, "tree": $tree[0]}' >"$tree_json_file"
+          }
+
           # --- Helper: atomic commit via Git Trees API -------------------------
           commit_tree() {
             local branch="$1"
@@ -257,50 +300,49 @@ jobs:
             base_tree=$(retry 3 gh api "repos/${repo_slug}/git/commits/${ref_sha}" --jq '.tree.sha')
             require_sha "base_tree for ${branch}" "$base_tree" || return 1
 
-            local tree_items="[]"
+            local payload_dir tree_items_file
+            payload_dir=$(mktemp -d)
+            tree_items_file="${payload_dir}/tree-items.json"
+            printf '[]\n' >"$tree_items_file"
+
+            local item_index=0
             for dest_file in $(printf '%b' "$DRIFT_FILES" | sed '/^$/d'); do
-              local content=""
+              local source_file=""
+              local normalized_file
               local key
               key=$(echo "$dest_file" | tr '/' '__')
 
               if [ "$dest_file" = ".github/dependabot.yml" ] && [ "$DEPENDABOT_DRIFT" = true ]; then
-                content="$GENERATED_DEPENDABOT"
+                source_file="/tmp/generated_dependabot.yml"
               elif [ "$dest_file" = "README.md" ] && [ "$README_DRIFT" = true ]; then
-                content="$GENERATED_README"
+                source_file="/tmp/generated_readme.md"
               elif [ -f "/tmp/drift_content/${key}" ]; then
-                content=$(cat "/tmp/drift_content/${key}")
+                source_file="/tmp/drift_content/${key}"
               else
                 echo "[WARN] No cached content for ${dest_file} -- skipping"
                 continue
               fi
 
-              # Restore exactly one trailing newline. The content above is
-              # captured via bash $(...) / $(cat ...), which strips trailing
-              # newlines. biome, yamllint and editorconfig-checker all require
-              # a final newline, so the stripped blob fails Lint Code Base in
-              # every downstream sync PR; the missing newline also makes the
-              # committed blob's SHA never match the source, causing perpetual
-              # drift. Normalizing to a single trailing newline fixes both.
-              content="${content%$'\n'}"$'\n'
-
-              tree_items=$(echo "$tree_items" | jq \
-                --arg path "$dest_file" \
-                --arg content "$content" \
-                '. + [{"path": $path, "mode": "100644", "type": "blob", "content": $content}]')
+              item_index=$((item_index + 1))
+              normalized_file="${payload_dir}/content-${item_index}"
+              normalize_tree_content "$source_file" "$normalized_file"
+              append_tree_item "$tree_items_file" "$dest_file" "$normalized_file"
             done
 
             local item_count
-            item_count=$(echo "$tree_items" | jq 'length')
+            item_count=$(jq 'length' "$tree_items_file")
             if [ "$item_count" -eq 0 ]; then
               echo "[SKIP] No files to commit"
+              rm -r "$payload_dir"
               return 0
             fi
 
-            local tree_json
-            tree_json=$(jq -n --arg base "$base_tree" --argjson tree "$tree_items" \
-              '{"base_tree": $base, "tree": $tree}')
+            local tree_json_file
+            tree_json_file="${payload_dir}/tree.json"
+            write_tree_request "$base_tree" "$tree_items_file" "$tree_json_file"
             local new_tree_sha
-            new_tree_sha=$(echo "$tree_json" | retry 3 gh api "repos/${repo_slug}/git/trees" --method POST --input - --jq '.sha')
+            new_tree_sha=$(retry 3 gh api "repos/${repo_slug}/git/trees" \
+              --method POST --input "$tree_json_file" --jq '.sha')
             require_sha "new_tree_sha for ${branch}" "$new_tree_sha" || return 1
 
             local commit_json
@@ -314,6 +356,7 @@ jobs:
               '{"sha": $sha, "force": $force}')
             retry_json 3 "$ref_update" "repos/${repo_slug}/git/refs/heads/${branch}" --method PATCH >/dev/null
 
+            rm -r "$payload_dir"
             echo "[OK] Atomic commit ${new_commit_sha:0:8} (${item_count} files)"
           }
 
@@ -501,7 +544,6 @@ jobs:
               DEPBOT="${DEPBOT}\n"
               # Write generated dependabot.yml to temp file (preserves trailing newline)
               printf '%b' "$DEPBOT" > /tmp/generated_dependabot.yml
-              GENERATED_DEPENDABOT=$(cat /tmp/generated_dependabot.yml)
 
               # Compare with current dependabot.yml in target repo (local disk,
               # no API call -- file was checked out by actions/checkout@v6).
@@ -617,8 +659,6 @@ jobs:
                 # existing case and any optional placeholder added later.
                 cat -s /tmp/generated_readme.md > /tmp/generated_readme.squeezed
                 mv /tmp/generated_readme.squeezed /tmp/generated_readme.md
-
-                GENERATED_README=$(cat /tmp/generated_readme.md)
 
                 # Compare with current README.md in target repo (local disk, no API).
                 if [ -f README.md ]; then

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -108,6 +108,86 @@ else
 fi
 
 echo ""
+echo "=== Section 4: tree payloads are file-backed ==="
+
+# File content and the cumulative tree can each exceed the runner's argument
+# limits. Extract the actual payload helpers from the workflow so the stress
+# test exercises production code instead of a test-only reimplementation.
+awk '
+  /^          # --- Helper: file-backed Git tree payloads/ { found=1 }
+  found && /^          # --- Helper: atomic commit via Git Trees API/ { exit }
+  found { sub(/^          /, ""); print }
+' "$SYNC" >"$WORK/tree_payload_helpers.sh"
+
+if [ -s "$WORK/tree_payload_helpers.sh" ]; then
+  pass "4.1 located the file-backed tree payload helpers"
+else
+  fail "4.1 located the file-backed tree payload helpers" \
+    "the workflow does not expose the production payload helpers"
+fi
+
+if grep -qE -- '--arg +content|--argjson +tree' "$SYNC"; then
+  fail "4.2 managed content and cumulative trees never enter argv" \
+    "commit_tree still passes a potentially unbounded payload through --arg or --argjson"
+else
+  pass "4.2 managed content and cumulative trees never enter argv"
+fi
+
+if grep -q -- '--rawfile content' "$SYNC" && grep -q -- '--slurpfile tree' "$SYNC"; then
+  pass "4.3 jq reads managed content and cumulative trees from files"
+else
+  fail "4.3 jq reads managed content and cumulative trees from files" \
+    "expected both --rawfile content and --slurpfile tree"
+fi
+
+if [ -s "$WORK/tree_payload_helpers.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$WORK/tree_payload_helpers.sh"
+
+  TREE_ITEMS="$WORK/tree-items.json"
+  printf '[]\n' >"$TREE_ITEMS"
+  LARGE_BYTES=262144
+  LARGE_FILE_COUNT=10
+  for index in $(seq 1 "$LARGE_FILE_COUNT"); do
+    RAW_CONTENT="$WORK/raw-${index}.txt"
+    NORMALIZED_CONTENT="$WORK/normalized-${index}.txt"
+    # Each 256 KiB file exceeds Linux's usual per-argument MAX_ARG_STRLEN, and
+    # the combined request exceeds its usual 2 MiB ARG_MAX. This succeeds only
+    # when neither payload becomes an exec argument.
+    dd if=/dev/zero bs="$LARGE_BYTES" count=1 2>/dev/null | tr '\0' X >"$RAW_CONTENT"
+    if [ "$index" -eq 2 ]; then
+      printf '\n\n' >>"$RAW_CONTENT"
+    fi
+    normalize_tree_content "$RAW_CONTENT" "$NORMALIZED_CONTENT"
+    append_tree_item "$TREE_ITEMS" "fixtures/large-${index}.txt" "$NORMALIZED_CONTENT"
+  done
+
+  TREE_REQUEST="$WORK/tree-request.json"
+  BASE_TREE="0123456789abcdef0123456789abcdef01234567"
+  write_tree_request "$BASE_TREE" "$TREE_ITEMS" "$TREE_REQUEST"
+
+  if jq -e \
+    --arg base_tree "$BASE_TREE" \
+    --argjson expected_count "$LARGE_FILE_COUNT" \
+    --argjson expected_length "$((LARGE_BYTES + 1))" \
+    '.base_tree == $base_tree and
+     (.tree | length) == $expected_count and
+     all(.tree[]; .mode == "100644" and .type == "blob") and
+     all(.tree[]; (.content | length) == $expected_length) and
+     all(.tree[]; .content | endswith("\n")) and
+     (.tree[1].path == "fixtures/large-2.txt")' \
+    "$TREE_REQUEST" >/dev/null; then
+    pass "4.4 production helpers assemble multiple oversized entries exactly"
+  else
+    fail "4.4 production helpers assemble multiple oversized entries exactly" \
+      "large entries, paths, or trailing-newline normalization were corrupted"
+  fi
+else
+  fail "4.4 production helpers assemble multiple oversized entries exactly" \
+    "payload helpers were unavailable for the stress test"
+fi
+
+echo ""
 echo "════════════════════════════════════════════"
 echo "  Results: $PASS passed, $FAIL failed ($TESTS_RUN total)"
 echo "════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Make managed-file Git Trees API assembly independent of process argument limits. Managed content, cumulative tree items, and the final request now remain file-backed from normalization through the API call.

## Related issue

Closes #963

## Changes

- normalize canonical and generated content to one trailing newline without shell payload copies
- assemble tree entries with `jq --rawfile` and the final request with `jq --slurpfile`
- post the request with `gh api --input <file>`
- retain the atomic single-ref-update rebase path for existing sync pull requests
- exercise ten 256 KiB entries, exceeding both Linux `MAX_ARG_STRLEN` per entry and the usual 2 MiB `ARG_MAX` in aggregate

## Verification evidence

- Red phase: `bash tests/test-sync-managed-files.sh` — 7 passed, 4 failed before implementation.
- Green phase: `bash tests/test-sync-managed-files.sh` — 11 passed, 0 failed.
- `uv run --python 3.13 --with pyyaml bash tests/test-linter-configs.sh` — 150 passed, 0 failed.
- All 24 `tests/test-*.sh` scripts passed.
- `pre-commit run --all-files` — passed.
- `actionlint .github/workflows/sync-managed-files.yml` — passed.
- `shellcheck tests/test-sync-managed-files.sh` — passed.
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean.
- Staged PII audit reported only the existing media-review requirement for `docs/images/hero.svg`; source, metadata, and visual inspection were clean.
- `gitleaks git --staged --redact .` — no leaks found.\n- CI: https:\/\/github.com\/f5-sales-demo\/docs-control\/actions\/runs\/30727070107 — passed.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions