### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,35 +1,35 @@
 {
-  "generated_at": "2026-08-02T12:02:32Z",
-  "source_commit": "63203adc32c7d16fef4d6e0dc690f7b49930559a",
+  "generated_at": "2026-08-02T14:09:47Z",
+  "source_commit": "e98268f5e4b91cdb262add7e832b42c3aec913f1",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
       "dest": ".github/workflows/github-pages-deploy.yml",
-      "sha": "9b9128d78260a1c0ad05c2fe7899f2cf0f307ac4",
+      "sha": "8002cde7b73054632ade3064c60da605fc912cfc",
       "size": 808
     },
     ".github/workflows/enforce-repo-settings.yml": {
       "src": "workflows/enforce-repo-settings.yml",
       "dest": ".github/workflows/enforce-repo-settings.yml",
-      "sha": "5dfe3d3bc4a4ab3a7a4abf4ac38593ce0c9b419b",
+      "sha": "162ba2acce7dee70a288c5f154082dd3560e813b",
       "size": 1054
     },
     ".github/workflows/require-linked-issue.yml": {
       "src": "workflows/require-linked-issue.yml",
       "dest": ".github/workflows/require-linked-issue.yml",
-      "sha": "ca68f33df6c8c94208192ad4ca7593118ab82ebe",
+      "sha": "ef85626aba84a26c7837ebba655add59a23ab141",
       "size": 1087
     },
     ".github/workflows/super-linter.yml": {
       "src": "workflows/super-linter.yml",
       "dest": ".github/workflows/super-linter.yml",
-      "sha": "a7cf1511ecb521940383ff99f5f1be4340d7da53",
+      "sha": "baafef062f05566c13204d74ee34fe304b24225a",
       "size": 800
     },
     ".github/workflows/translation-audit.yml": {
       "src": "workflows/translation-audit.yml",
       "dest": ".github/workflows/translation-audit.yml",
-      "sha": "f0ea009df4a42afcbcf2a3cd1133776da579ffe7",
+      "sha": "e6f0da498054a95dcd7490ff76e504da92c90a71",
       "size": 1796
     },
     ".github/PULL_REQUEST_TEMPLATE.md": {
@@ -119,13 +119,13 @@
     ".github/workflows/dependabot-auto-merge.yml": {
       "src": "workflows/dependabot-auto-merge.yml",
       "dest": ".github/workflows/dependabot-auto-merge.yml",
-      "sha": "15913c4cb0d4de9d9a700ad888e5d6550b1bb9e5",
+      "sha": "68fe071a099dbe2ee92e22013d14e966e5e6c8a1",
       "size": 840
     },
     ".github/workflows/auto-merge.yml": {
       "src": "workflows/auto-merge.yml",
       "dest": ".github/workflows/auto-merge.yml",
-      "sha": "75b2e77279f137be4bde3d116adf17d7cd5fee94",
+      "sha": "37133b08a5a2f070a4c18985d35420f5c6b13baa",
       "size": 1381
     },
     "biome.json": {
@@ -239,8 +239,8 @@
     "scripts/check_pii.py": {
       "src": "scripts/check_pii.py",
       "dest": "scripts/check_pii.py",
-      "sha": "3356dffee37045a5cf92eb6f3e275dad7c098d40",
-      "size": 71356
+      "sha": "10b1f003d10dddb4e318217c5e307bce37895c40",
+      "size": 71395
     },
     "scripts/check-pii.sh": {
       "src": "scripts/check-pii.sh",
@@ -287,7 +287,7 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "0053915fb63fcaec4ec49e468b34127616099f0b",
+      "sha": "b1c5bafbee455b8448562b36e0cca08837b6a813",
       "size": 6756
     },
     ".github/workflows/workflow-security-audit.yml": {


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.