### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,35 +1,35 @@
 {
-  "generated_at": "2026-08-02T17:59:53Z",
-  "source_commit": "42ed6dbb4e7926e3aec16be9bc3ff87065fc2b12",
+  "generated_at": "2026-08-02T18:06:29Z",
+  "source_commit": "25408ac367033d693872f937b8b106e0c12ce19c",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
       "dest": ".github/workflows/github-pages-deploy.yml",
-      "sha": "f36f5f95dd9c03f9997d270c028dd4fbe30a03f3",
+      "sha": "82bad9393ab4056efc8c620a605538da1c5dd103",
       "size": 808
     },
     ".github/workflows/enforce-repo-settings.yml": {
       "src": "workflows/enforce-repo-settings.yml",
       "dest": ".github/workflows/enforce-repo-settings.yml",
-      "sha": "3becddb9bdb7a55d45b45b13cbb2515c49e28455",
+      "sha": "fbf9f1c70ca7056566916e4bcd20f49c593c756d",
       "size": 9685
     },
     ".github/workflows/require-linked-issue.yml": {
       "src": "workflows/require-linked-issue.yml",
       "dest": ".github/workflows/require-linked-issue.yml",
-      "sha": "a07a9fd35f8f023de52689db7ab271a13d981414",
+      "sha": "8f59b24df5ef0f1ef0343480139a83651a8fde9c",
       "size": 1087
     },
     ".github/workflows/super-linter.yml": {
       "src": "workflows/super-linter.yml",
       "dest": ".github/workflows/super-linter.yml",
-      "sha": "2f89b8ebe6a1b9f3f9fd75bae29e0556691edab1",
+      "sha": "ce989392458972d4d3401094be94057996be4618",
       "size": 800
     },
     ".github/workflows/translation-audit.yml": {
       "src": "workflows/translation-audit.yml",
       "dest": ".github/workflows/translation-audit.yml",
-      "sha": "66c81c3fd57c1e1da2968141cc890388ec15a8a9",
+      "sha": "8febcf094d40210e0a1bb214beb0f75efaad7465",
       "size": 1796
     },
     ".github/PULL_REQUEST_TEMPLATE.md": {
@@ -137,13 +137,13 @@
     ".github/workflows/dependabot-auto-merge.yml": {
       "src": "workflows/dependabot-auto-merge.yml",
       "dest": ".github/workflows/dependabot-auto-merge.yml",
-      "sha": "b2ecc94adebe776788e7d67c1f524f99aa34816f",
+      "sha": "0faa1cd3a61823ba9db89b2d652c77759b290590",
       "size": 840
     },
     ".github/workflows/auto-merge.yml": {
       "src": "workflows/auto-merge.yml",
       "dest": ".github/workflows/auto-merge.yml",
-      "sha": "f2e26b3b65d4dbad8125be308f56a353d672d4ff",
+      "sha": "d1650142f14afdc8736bda95f58a8d2fb92092a6",
       "size": 1381
     },
     "biome.json": {
@@ -305,7 +305,7 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "a8283a2fa7adc3e4396e7a7f86793d735bb18833",
+      "sha": "3738506f4e95477edb24ca8fbb0fa1c71fed4100",
       "size": 6756
     },
     ".github/workflows/workflow-security-audit.yml": {


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.