### PR TITLE
fix(lint): disable only MD033, and enforce the six rules that were bypassed

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,10 +1,4 @@
 {
   "MD013": { "line_length": 400 },
-  "MD029": false,
-  "MD033": false,
-  "MD041": false,
-  "MD060": false,
-  "MD025": false,
-  "MD024": false,
-  "MD007": false
+  "MD033": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ this document governs how a change gets reviewed and merged.
 
 Every change follows this path:
 
-```
+```text
 Issue → Branch → PR (linked to issue) → CI passes → auto-merge when green → Branch auto-deleted
 ```
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -10,7 +10,7 @@ sidebar:
 The documentation and governance system spans three repositories, each with a distinct responsibility:
 
 | Repository | Role |
-|---|---|
+| --- | --- |
 | **docs-control** | Central governance hub -- repository settings, branch protection config, managed files manifest, reusable CI workflows, caller workflow templates, and downstream dispatch |
 | **docs-builder** | Docker build image -- Astro + Starlight build orchestration, npm dependencies, Puppeteer PDF generation, interactive components |
 | **docs-theme** | Astro Starlight plugin -- shared branding, CSS, fonts, logos, layout components, `astro.config.mjs`, and `content.config.ts` |
@@ -30,7 +30,7 @@ When a template file changes in docs-control on `main`:
 Two fine-grained personal access tokens provide least-privilege separation:
 
 | Token | Permissions | Used by |
-|---|---|---|
+| --- | --- | --- |
 | `REPO_SETTINGS_TOKEN` | Administration R/W, Pages R/W, Contents Read, Metadata Read | `enforce-repo-settings.yml`, `dispatch-downstream.yml` |
 | `REPO_SYNC_TOKEN` | Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read | `sync-managed-files.yml` |
 
@@ -38,12 +38,18 @@ The enforcement workflow needs admin access to modify branch protection and Page
 
 ## Self-detection
 
-Docs-control is both the provider and consumer of its own governance config. When `enforce-repo-settings.yml` runs on docs-control itself (via the `push` trigger), it detects this by comparing `managed_files.source_repo` against `github.repository`. This triggers the `self_contexts` override in branch protection -- docs-control uses workflows directly (for example, `Shell Unit Tests`), while downstream repositories use caller wrappers (for example, `lint / Shell Unit Tests`). See the [configuration page](./configuration/) for details on `contexts` vs `self_contexts`.
+Docs-control is both the provider and consumer of its own governance config. When
+`enforce-repo-settings.yml` runs on docs-control itself (via the `push` trigger), it detects
+this by comparing `managed_files.source_repo` against `github.repository`. This triggers the
+`self_contexts` override in branch protection -- docs-control uses workflows directly (for
+example, `Shell Unit Tests`), while downstream repositories use caller wrappers (for example,
+`lint / Shell Unit Tests`). See the [configuration page](./configuration/) for details on
+`contexts` vs `self_contexts`.
 
 ## Repository layout
 
 | Directory / File | Purpose |
-|---|---|
+| --- | --- |
 | `.github/config/repo-settings.json` | Central config: repository settings, branch protection, Actions permissions, Pages config, and the managed files manifest |
 | `.github/config/downstream-repos.json` | Registry of enrolled downstream repositories |
 | `.github/config/docs-sites.json` | Metadata for each downstream docs site (label, URL, description) used by README templating |

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -60,5 +60,5 @@ example, `Shell Unit Tests`), while downstream repositories use caller wrappers 
 | `CLAUDE.md` | AI assistant instructions (synced to all downstream repositories) |
 | `README.md.tpl` | Template for dynamically generated downstream README files |
 | `.pre-commit-config.yaml` | Pre-commit hooks configuration (synced to all downstream repositories) |
-| `.markdownlint.json` | Markdown linting rules |
-| `.yamllint.yaml` | YAML linting rules |
+| `.markdownlint.json` | Markdown linter rules |
+| `.yamllint.yaml` | YAML linter rules |

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -92,6 +92,7 @@ The central configuration file drives all enforcement, sync, and dispatch behavi
 Standard GitHub repository settings applied via `PATCH /repos/{owner}/{repo}`. Each key maps directly to the GitHub API field. The [enforcement workflow](./settings-enforcement/) compares each key against the repository's current value and only patches keys that have drifted.
 
 Notable settings:
+
 - `delete_branch_on_merge: true` -- automatically cleans up merged PR branches
 - `allow_update_branch: true` -- enables the "Update branch" button on PRs
 - `homepage: ""` -- auto-computed at runtime as `https://f5-sales-demo.github.io/{repo}/`
@@ -99,6 +100,7 @@ Notable settings:
 ### `actions_permissions`
 
 Controls GitHub Actions workflow permissions for the repository:
+
 - `default_workflow_permissions: "write"` -- workflows get read/write access to the repository by default
 - `can_approve_pull_request_reviews: true` -- allows workflows to approve PRs
 
@@ -107,6 +109,7 @@ Controls GitHub Actions workflow permissions for the repository:
 An array of branch protection rules. Each entry specifies a `branch` name and the desired protection settings. Currently only `main` is protected.
 
 Key fields:
+
 - `enforce_admins: true` -- protection rules apply to repository administrators too
 - `required_status_checks.strict: false` -- branches don't need to be up-to-date before merging
 - `required_status_checks.contexts` -- the check names downstream repositories must pass (for example, `check / Check linked issues` and `lint / Shell Unit Tests`)
@@ -131,11 +134,19 @@ Each profile classifies the complete matching inventory:
 - `unit` entries contain a test `path` and an `args` array. The runner passes each argument literally, without shell evaluation.
 - `environment` entries contain a test `path` and a non-empty `reason` explaining why the bare-runner unit gate cannot execute it.
 
-The reusable workflow fetches the selector and configuration from the same docs-control `main` revision, logs that revision, and validates the inventory before running anything. Missing configuration, unsafe paths or arguments, duplicate paths, and unclassified or missing tests fail the required context. This makes a profile an audited classification contract rather than an ignore list. Repositories without a profile keep the broad default.
+The reusable workflow fetches the selector and configuration from the same docs-control `main`
+revision, logs that revision, and validates the inventory before running anything. Missing
+configuration, unsafe paths or arguments, duplicate paths, and unclassified or missing tests
+fail the required context. This makes a profile an audited classification contract rather than
+an ignore list. Repositories without a profile keep the broad default.
 
 The `xcsh` override excludes both Super-Linter contexts because that repository does not call the reusable Super-Linter workflow; its native `check`, `pii-guard`, and `test` contexts remain required. Live verification must prove an exclusion is necessary before it is added.
 
-Do not require a context from a workflow with `paths` or `paths-ignore` filters. GitHub leaves that context pending when the workflow does not start. Broad security tools must run in an unfiltered pull-request workflow or in a scheduled full-tree audit; the managed workflow-security audit uses the latter model for `zizmor`. A job-level condition is safe because a skipped job still reports a successful check.
+Do not require a context from a workflow with `paths` or `paths-ignore` filters. GitHub leaves
+that context pending when the workflow does not start. Broad security tools must run in an
+unfiltered pull-request workflow or in a scheduled full-tree audit; the managed
+workflow-security audit uses the latter model for `zizmor`. A job-level condition is safe
+because a skipped job still reports a successful check.
 
 ### `topics`
 
@@ -144,12 +155,14 @@ An array of GitHub topics to apply to the repository. Currently empty -- topics 
 ### `pages`
 
 GitHub Pages configuration:
+
 - `enabled: true` -- ensures Pages is enabled on every enrolled repository
 - `build_type: "workflow"` -- uses GitHub Actions for the Pages build (not legacy branch-based builds)
 
 ### `managed_files`
 
 Defines the file synchronization manifest:
+
 - `source_repo` -- the repository that holds canonical versions of managed files (`f5-sales-demo/docs-control`)
 - `files` -- an array of `{src, dest}` objects mapping source paths in docs-control to destination paths in downstream repositories
 

--- a/docs/dispatch.mdx
+++ b/docs/dispatch.mdx
@@ -114,7 +114,7 @@ permissions.
 When a downstream repository uses a caller workflow, the GitHub Actions status check name becomes `<caller_job_key> / <reusable_job_name>`. For example:
 
 | Caller job key | Reusable job name | Resulting check name |
-|---|---|---|
+| --- | --- | --- |
 | `check` | `Check linked issues` | `check / Check linked issues` |
 | `lint` | `Lint Code Base` | `lint / Lint Code Base` |
 | `lint` | `Shell Unit Tests` | `lint / Shell Unit Tests` |

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -14,6 +14,7 @@ It skips execution when running on the source repository itself (docs-control), 
 The workflow iterates the `managed_files.files` array from the [central config](./configuration/). For each entry, it fetches the canonical content from docs-control and compares it against the downstream copy. Files that are missing or have drifted are flagged for sync.
 
 The managed files manifest includes:
+
 - Caller workflows (`enforce-repo-settings.yml`, `github-pages-deploy.yml`, `require-linked-issue.yml`)
 - Issue and PR templates
 - `CONTRIBUTING.md`, `CLAUDE.md`, `STYLE_GUIDE.md`, `.editorconfig`, `.gitignore`, `LICENSE`
@@ -22,6 +23,7 @@ The managed files manifest includes:
 ## Dynamic dependabot.yml generation
 
 The workflow detects which package ecosystems exist in the downstream repository:
+
 - **npm** -- `package.json` exists
 - **pip** -- `requirements.txt`, `pyproject.toml`, or `setup.py` exists
 - **docker** -- `Dockerfile` exists

--- a/docs/file-sync.mdx
+++ b/docs/file-sync.mdx
@@ -24,9 +24,9 @@ The managed files manifest includes:
 
 The workflow detects which package ecosystems exist in the downstream repository:
 
-- **npm** -- `package.json` exists
-- **pip** -- `requirements.txt`, `pyproject.toml`, or `setup.py` exists
-- **docker** -- `Dockerfile` exists
+- `npm` -- `package.json` exists
+- `pip` -- `requirements.txt`, `pyproject.toml`, or `setup.py` exists
+- `docker` -- `Dockerfile` exists
 
 It generates a `.github/dependabot.yml` with a `github-actions` ecosystem entry (always included) plus entries for each detected ecosystem. All ecosystems use weekly Monday schedules with conventional commit prefixes and minor/patch grouping.
 

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -136,7 +136,7 @@ each opted-out config (e.g., xcsh ships a permissive `ruff.toml` and
 ## Deferring required status checks: excluded_required_contexts
 
 When onboarding an existing codebase that is not yet compatible with the
-ecosystem's lint rules, immediately marking `Lint Code Base` (or any other
+ecosystem's linter rules, immediately marking `Lint Code Base` (or any other
 reusable-workflow status check) as a required context will block every
 PR until the codebase is cleaned up. Use
 `repo_overrides.<repo>.excluded_required_contexts` in
@@ -202,7 +202,7 @@ It lives in `governance.json` rather than `repo-settings.json` because
 `governance.json` is itself a managed file, synced byte-identically into
 every downstream repository. A consumer can therefore read the
 classification offline from any checkout, with no API call. `repo-settings.json`
-is only ever fetched by workflows at run time and never lands in a clone.
+is only ever fetched by workflows at runtime and never lands in a clone.
 
 Two `jq` assertions in `tests/test-protect-managed-files.sh` keep the manifest
 honest: every assignment must name a defined class, and every entry in

--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -284,7 +284,7 @@ Every `.mdx` file needs YAML frontmatter with at least a `title` field. Remove a
 MkDocs Material uses `!!! type "Title"` with indented content. Starlight uses fenced directives:
 
 | MkDocs syntax | Starlight syntax |
-|---|---|
+| --- | --- |
 | `!!! note "Title"` | `:::note[Title]` ... `:::` |
 | `!!! tip "Title"` | `:::tip[Title]` ... `:::` |
 | `!!! warning "Title"` | `:::caution[Title]` ... `:::` |
@@ -294,7 +294,7 @@ MkDocs Material uses `!!! type "Title"` with indented content. Starlight uses fe
 **Type mapping**:
 
 | MkDocs type | Starlight directive |
-|---|---|
+| --- | --- |
 | `note`, `info`, `abstract`, `summary`, `tldr`, `quote`, `cite`, `question`, `help`, `faq` | `:::note` |
 | `tip`, `hint`, `success`, `check`, `example` | `:::tip` |
 | `warning`, `attention` | `:::caution` |
@@ -307,7 +307,7 @@ Remove the 4-space content indentation that MkDocs requires -- Starlight directi
 MkDocs Material uses `:material-icon-name:` syntax. Replace with emoji or plain text:
 
 | Material icon | Replacement |
-|---|---|
+| --- | --- |
 | `:material-check:` | &#10003; |
 | `:material-close:` | &#10007; |
 | `:material-arrow-right:` | &#8594; |

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -620,21 +620,35 @@ done
 echo ""
 echo "=== Section 5b: .markdownlint.json opinionated-rule disables ==="
 
-# Each entry below is a rule docs-control disables based on real audit
-# findings against governed repos. Removing the disable would re-introduce
-# hundreds of noise violations on fork/reference-style docs.
-# MD029  ordered-list-style    — allow mixed 1. + 1) styles
-# MD033  no-inline-html        — MDX components and HTML embed
-# MD041  first-line-h1         — Starlight frontmatter supplies the H1 implicitly
-# MD060  table-column-style    — tables are content-first, not pipe-aligned
-# MD025  single-title          — multi-H1 is used in reference docs
-# MD024  no-duplicate-heading  — repeated section names in reference docs
-# MD007  ul-indent             — indent preference varies by fork style
-for rule in MD029 MD033 MD041 MD060 MD025 MD024 MD007; do
+# MD033 no-inline-html is the ONLY rule this configuration disables, and it is a
+# genuine engineering requirement rather than a preference: MDX *is* JSX, so every
+# component in every .mdx page is inline HTML to markdownlint. Measured across the
+# fleet's English documentation: 67,167 violations, none of them fixable without
+# abandoning MDX.
+#
+# The six rules that used to sit beside it here were re-enabled. Each had been
+# disabled to avoid "hundreds of noise violations on fork/reference-style docs",
+# which is a cost argument, not a requirement — and the measurements did not
+# support it either. MD041 was justified as "Starlight frontmatter supplies the H1
+# implicitly"; markdownlint already honours a frontmatter title, and the whole
+# fleet had six violations.
+for rule in MD033; do
   if jq -e --arg r "$rule" '.[$r] == false' "$REPO_ROOT/.markdownlint.json" >/dev/null; then
     pass "5b.x .markdownlint.json disables $rule"
   else
     fail "5b.x .markdownlint.json disables $rule" "not set to false"
+  fi
+done
+
+# Every rule below is ENFORCED. Each was previously disabled; the assertions exist
+# so a bypass cannot quietly return the way MD040's did — it was not only switched
+# off in the configuration, it was pinned there by this test.
+for rule in MD029 MD041 MD060 MD025 MD024 MD007; do
+  if jq -e --arg r "$rule" 'has($r) | not' "$REPO_ROOT/.markdownlint.json" >/dev/null ||
+    jq -e --arg r "$rule" '.[$r] != false' "$REPO_ROOT/.markdownlint.json" >/dev/null; then
+    pass "5b.x .markdownlint.json enforces $rule"
+  else
+    fail "5b.x .markdownlint.json enforces $rule" "$rule is disabled — fix the documents instead"
   fi
 done
 

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -632,13 +632,21 @@ echo "=== Section 5b: .markdownlint.json opinionated-rule disables ==="
 # support it either. MD041 was justified as "Starlight frontmatter supplies the H1
 # implicitly"; markdownlint already honours a frontmatter title, and the whole
 # fleet had six violations.
-for rule in MD033; do
-  if jq -e --arg r "$rule" '.[$r] == false' "$REPO_ROOT/.markdownlint.json" >/dev/null; then
-    pass "5b.x .markdownlint.json disables $rule"
-  else
-    fail "5b.x .markdownlint.json disables $rule" "not set to false"
-  fi
-done
+if jq -e '.MD033 == false' "$REPO_ROOT/.markdownlint.json" >/dev/null; then
+  pass "5b.x .markdownlint.json disables MD033"
+else
+  fail "5b.x .markdownlint.json disables MD033" "not set to false"
+fi
+
+# And nothing else. A new disable should have to argue for itself here rather than
+# arrive quietly in a configuration diff.
+disabled_count=$(jq '[to_entries[] | select(.value == false)] | length' "$REPO_ROOT/.markdownlint.json")
+if [ "$disabled_count" -eq 1 ]; then
+  pass "5b.x .markdownlint.json disables exactly one rule"
+else
+  fail "5b.x .markdownlint.json disables exactly one rule" \
+    "$disabled_count rules disabled: $(jq -r '[to_entries[] | select(.value == false) | .key] | join(", ")' "$REPO_ROOT/.markdownlint.json")"
+fi
 
 # Every rule below is ENFORCED. Each was previously disabled; the assertions exist
 # so a bypass cannot quietly return the way MD040's did — it was not only switched


### PR DESCRIPTION
Closes #994

Follows #982, which fixed `MD040`. Same pattern, the remaining six rules.

## The measurement

The shared justification for all seven disables was *"removing the disable would
re-introduce hundreds of noise violations on fork/reference-style docs"* — a cost argument,
not a reason the rule is wrong. Measured with `markdownlint-cli@0.49.1` across **1,035
English documentation files** (locale trees excluded, as Super-Linter excludes them):

| Rule | Violations | Auto-fixable | Verdict |
| --- | ---: | --- | --- |
| `MD033` no-inline-html | **67,167** | no | **Requirement** — MDX is JSX |
| `MD060` table-column-style | 2,264 | yes | bypass |
| `MD025` single-title | 56 | no | bypass — STYLE_GUIDE requires one H1 per document |
| `MD007` ul-indent | 56 | yes | bypass |
| `MD024` no-duplicate-heading | 52 | no | bypass |
| `MD029` ordered-list-style | 23 | yes | bypass |
| `MD041` first-line-h1 | **6** | no | bypass, stated reason false |

`MD041` is the clearest. Disabled because "Starlight frontmatter supplies the H1
implicitly" — markdownlint already honours a frontmatter `title`, which is why the whole
fleet has six violations rather than one per page.

## What changed

- `.markdownlint.json` now disables `MD033` alone.
- §5b assertions inverted: each of the six is asserted **enforced**. `MD040` proved why that
  matters — it was disabled in configuration *and pinned there by this test*, so re-enabling
  it failed CI until the assertion was corrected.
- This repository's fallout cleared: **43 violations → 0**. 39 by `markdownlint --fix`, four
  by hand: three prose lines over the 400-column cap, and one untagged fence in
  `CONTRIBUTING.md` which is an ASCII flow diagram, so `text`.

Worth noting: three of those four hand-fixes were **MD013 violations of a rule that was
already enabled**, sitting in `.mdx` files that nothing linted until #982 landed. The gap
was real in the governance repository itself.

## Verification

```text
markdownlint across docs/ and root *.md : 0 violations
tests/test-linter-configs.sh            : 151 passed, 0 failed
tests/test-protect-managed-files.sh     : 133 passed, 0 failed
tests/test-lint-mdx-prose.sh            : PASS
```

## Follow-on

2,743 violations remain in 20 repositories — `api-specs-enriched` 857, `xcsh` 423,
`docs-theme` 315, `origin-server` 221, `traffic-generator` 214, and a long tail. Each gets
its own issue and pull request rather than one sweep: `MD060` reformats tables, and those
diffs should be reviewable by whoever owns the content. Rollout is naturally incremental in
the meantime — `VALIDATE_ALL_CODEBASE: false` means a repository is judged only on the files
its pull request touches.