### PR TITLE
fix(lint): explicitly enable MD060

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "MD013": { "line_length": 400 },
-  "MD033": false
+  "MD033": false,
+  "MD060": true
 }

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -648,10 +648,20 @@ else
     "$disabled_count rules disabled: $(jq -r '[to_entries[] | select(.value == false) | .key] | join(", ")' "$REPO_ROOT/.markdownlint.json")"
 fi
 
+# MD060 is disabled by default in the markdownlint version used by CI. Unlike the
+# other rules in this group, omitting it does not enable it, so require an explicit
+# true value. This catches the regression where removing `"MD060": false` made the
+# configuration look enabled while markdownlint continued to skip the rule.
+if jq -e '.MD060 == true' "$REPO_ROOT/.markdownlint.json" >/dev/null; then
+  pass "5b.x .markdownlint.json explicitly enables MD060"
+else
+  fail "5b.x .markdownlint.json explicitly enables MD060" "MD060 must be set to true"
+fi
+
 # Every rule below is ENFORCED. Each was previously disabled; the assertions exist
 # so a bypass cannot quietly return the way MD040's did — it was not only switched
 # off in the configuration, it was pinned there by this test.
-for rule in MD029 MD041 MD060 MD025 MD024 MD007; do
+for rule in MD029 MD041 MD025 MD024 MD007; do
   if jq -e --arg r "$rule" 'has($r) | not' "$REPO_ROOT/.markdownlint.json" >/dev/null ||
     jq -e --arg r "$rule" '.[$r] != false' "$REPO_ROOT/.markdownlint.json" >/dev/null; then
     pass "5b.x .markdownlint.json enforces $rule"


### PR DESCRIPTION
Closes #1004.

## Summary

- explicitly enable MD060, which markdownlint leaves disabled by default
- require the managed configuration to set MD060 to true
- preserve MD033 as the only disabled rule

## Verification

- observed the new assertion fail against the previous configuration: 151 passed, 1 failed
- tests/test-linter-configs.sh: 152 passed, 0 failed
- tests/test-protect-managed-files.sh: passed
- tests/test-lint-mdx-prose.sh: passed
- shellcheck and shfmt across every shell script: passed
- git diff --check: passed