### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-02T19:29:57Z",
-  "source_commit": "8152baf7b466bbf8a570743a55f6b6890f0aed7e",
+  "generated_at": "2026-08-02T19:49:33Z",
+  "source_commit": "2a26e426aeb1f6ea0354f112fbbc3246aa784060",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -131,8 +131,8 @@
     ".markdownlint.json": {
       "src": ".markdownlint.json",
       "dest": ".markdownlint.json",
-      "sha": "3a30d7451c8f12b3994bfdad580a083b03303e38",
-      "size": 56
+      "sha": "fa8f3a5d30a2cbc8adaaf8657dad39c2acd75d18",
+      "size": 73
     },
     ".github/workflows/dependabot-auto-merge.yml": {
       "src": "workflows/dependabot-auto-merge.yml",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.