### PR TITLE
chore(governance): activate downstream rollout

### DIFF
--- a/.github/config/governance-rollout.json
+++ b/.github/config/governance-rollout.json
@@ -1,3 +1,3 @@
 {
-  "state": "quiesced"
+  "state": "active"
 }

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 WF="${REPO_ROOT}/.github/workflows/dispatch-downstream.yml"
 CONFIG="${REPO_ROOT}/.github/config/downstream-repos.json"
+ROLLOUT="${REPO_ROOT}/.github/config/governance-rollout.json"
 
 FAIL=0
 check() {
@@ -39,6 +40,8 @@ check "aggregates FAIL_COUNT" "grep -q 'FAIL_COUNT' '$WF'"
 # Config still drives the fan-out.
 check "consumes downstream-repos.json" "grep -q 'downstream-repos.json' '$WF'"
 check "config is JSON array" "jq -e 'type == \"array\" and length > 0' '$CONFIG' > /dev/null"
+check "production governance rollout is active" \
+  "jq -e '.state == \"active\"' '$ROLLOUT' > /dev/null"
 
 # Trigger: dispatch must run when the regenerated manifest LANDS on main (the
 # auto-merging sync/manifest PR merges), not when the manifest build completes.


### PR DESCRIPTION
## Summary

- activate the governed downstream rollout after exact-caller bootstrap completed
- pin the production rollout state with a structural test

## Evidence

- dispatch run 30764355407 reported every downstream protected `main` contains the exact managed caller
- the new assertion failed while rollout was `quiesced`, then passed after activation
- `test-dispatch-matrix.sh`, `test-dispatch-preflight.sh`, `test-bootstrap-downstream-callers.sh`, and `test-source-receipt-ordering.sh` pass
- shellcheck and shfmt pass across every tracked shell script

Closes #1007