### PR TITLE
fix: unblock managed MDX rollout

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -7,7 +7,7 @@
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
     "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-    "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "console": [".ruff.toml", ".mypy.ini", ".isort.cfg"],
     "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
   },
   "protected_files": [

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -84,7 +84,8 @@
           { "path": "tests/test-check-repo-hygiene.sh", "args": [] },
           { "path": "tests/test-fetch-governed.sh", "args": [] },
           { "path": "tests/test-hook-neutralization.sh", "args": ["--unit-only"] },
-          { "path": "tests/test-inlined-helpers-match.sh", "args": [] }
+          { "path": "tests/test-inlined-helpers-match.sh", "args": [] },
+          { "path": "tests/test-lint-mdx-prose.sh", "args": [] }
         ],
         "environment": [
           {
@@ -124,7 +125,7 @@
       "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
       "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
       "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-      "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+      "console": [".ruff.toml", ".mypy.ini", ".isort.cfg"],
       "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
     },
     "files": [

--- a/tests/test-consumer-shell-tests.sh
+++ b/tests/test-consumer-shell-tests.sh
@@ -187,7 +187,8 @@ if jq -e '
     "tests/test-check-repo-hygiene.sh",
     "tests/test-fetch-governed.sh",
     "tests/test-hook-neutralization.sh",
-    "tests/test-inlined-helpers-match.sh"
+    "tests/test-inlined-helpers-match.sh",
+    "tests/test-lint-mdx-prose.sh"
   ] and
   ($p.unit[] | select(.path == "tests/test-hook-neutralization.sh") | .args) == ["--unit-only"] and
   ($p.environment | map(.path)) == [

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -736,6 +736,14 @@ for cfg in .ruff.toml .python-lint .mypy.ini; do
   fi
 done
 
+if jq -e '.managed_files.skip_files.console | index(".python-lint") == null' \
+  "$REPO_SETTINGS" >/dev/null; then
+  pass "7.x console receives .python-lint for the managed PII scanner"
+else
+  fail "7.x console receives .python-lint for the managed PII scanner" \
+    ".python-lint is skipped, so Pylint defaults reject scripts/check_pii.py"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5c: .checkov.yaml skips the install-test harness dockerfiles
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- classify the managed MDX prose test in devcontainer's fail-closed consumer inventory
- distribute the canonical Pylint configuration to console so the managed PII scanner is judged by its owning configuration
- add regression coverage for both downstream blockers

Closes #1018

## Testing

- observed both new assertions fail before the manifest fixes
- all `tests/test-*.sh` suites
- shellcheck and shfmt over every tracked shell script
- `git diff --check`
