### PR TITLE
fix: bind governance rollout to exact source receipts

### DIFF
--- a/.agents/skills/demo-components/agents/openai.yaml
+++ b/.agents/skills/demo-components/agents/openai.yaml
@@ -1,3 +1,4 @@
+---
 interface:
   display_name: "Demo Components"
   short_description: "Discover and deploy F5 demo infrastructure"

--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -6,9 +6,16 @@
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
-    "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
     "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-    "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+    "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+    "apt-repo": ["README.md"],
+    "code-review": ["README.md"],
+    "demo-resource-template": ["README.md"],
+    "marketplace-claude-code": ["README.md"],
+    "starlight-llms-txt": ["README.md"],
+    "starlight-mega-menu": ["README.md"],
+    "traffic-generator": ["README.md"]
   },
   "protected_files": [
     ".github/workflows/github-pages-deploy.yml",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -123,9 +123,16 @@
       "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
       "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
-      "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+      "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
       "console": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
-      "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"]
+      "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
+      "apt-repo": ["README.md"],
+      "code-review": ["README.md"],
+      "demo-resource-template": ["README.md"],
+      "marketplace-claude-code": ["README.md"],
+      "starlight-llms-txt": ["README.md"],
+      "starlight-mega-menu": ["README.md"],
+      "traffic-generator": ["README.md"]
     },
     "files": [
       {

--- a/.github/workflows/build-managed-files-manifest.yml
+++ b/.github/workflows/build-managed-files-manifest.yml
@@ -73,18 +73,49 @@ jobs:
 
       - name: Build manifest
         env:
+          GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           SOURCE_COMMIT: ${{ github.sha }}
           CONFIG_PATH: .github/config/repo-settings.json
           MANIFEST_PATH: .github/config/managed-files-manifest.json
         run: |
           set -euo pipefail
 
+          PROTECTED_MAIN_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          if ! printf '%s\n%s\n%s\n' \
+            "$SOURCE_COMMIT" "$CHECKED_OUT_SHA" "$PROTECTED_MAIN_SHA" |
+            awk '/^[0-9a-f]{40}$/ { valid++ } END { exit valid != 3 }'; then
+            echo "[ERROR] Manifest source identities are invalid" >&2
+            exit 1
+          fi
+          if [ "$SOURCE_COMMIT" != "$PROTECTED_MAIN_SHA" ] ||
+            [ "$CHECKED_OUT_SHA" != "$PROTECTED_MAIN_SHA" ]; then
+            echo "[ERROR] Manifest generation requires the exact current protected main" >&2
+            exit 1
+          fi
+
           if [ ! -f "$CONFIG_PATH" ]; then
             echo "[ERROR] $CONFIG_PATH not found" >&2
             exit 1
           fi
-
-          GENERATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if ! jq -e '
+            .managed_files.files | type == "array" and length > 0 and
+            all(.[];
+              (.src | type == "string" and length > 0) and
+              (.dest | type == "string" and length > 0))
+          ' "$CONFIG_PATH" >/dev/null; then
+            echo "[ERROR] managed_files.files must be a non-empty src/dest array" >&2
+            exit 1
+          fi
+          DUPLICATE_DESTS=$(jq -r '
+            [.managed_files.files[].dest] | sort | group_by(.) |
+            .[] | select(length > 1) | .[0]
+          ' "$CONFIG_PATH")
+          if [ -n "$DUPLICATE_DESTS" ]; then
+            echo "[ERROR] Duplicate managed-file destinations:" >&2
+            printf '%s\n' "$DUPLICATE_DESTS" | sed 's/^/  - /' >&2
+            exit 1
+          fi
 
           ENTRIES=$(jq -c '.managed_files.files[]' "$CONFIG_PATH")
           if [ -z "$ENTRIES" ]; then
@@ -94,6 +125,7 @@ jobs:
 
           FILES_JSON="{}"
           MISSING=""
+          INVALID_MODES=""
           while IFS= read -r entry; do
             src=$(echo "$entry" | jq -r '.src')
             dest=$(echo "$entry" | jq -r '.dest')
@@ -103,12 +135,18 @@ jobs:
             fi
             sha=$(git hash-object "$src")
             size=$(wc -c <"$src" | tr -d ' ')
+            mode=$(git ls-files -s -- "$src" | awk 'NR == 1 { print $1 }')
+            if ! printf '%s' "$mode" | grep -qE '^100(644|755)$'; then
+              INVALID_MODES="${INVALID_MODES}${src}:${mode:-missing}\n"
+              continue
+            fi
             FILES_JSON=$(echo "$FILES_JSON" | jq \
               --arg dest "$dest" \
               --arg src "$src" \
               --arg sha "$sha" \
+              --arg mode "$mode" \
               --argjson size "$size" \
-              '.[$dest] = {src: $src, dest: $dest, sha: $sha, size: $size}')
+              '.[$dest] = {src: $src, dest: $dest, sha: $sha, size: $size, mode: $mode}')
           done <<<"$ENTRIES"
 
           if [ -n "$MISSING" ]; then
@@ -116,12 +154,16 @@ jobs:
             printf '%b' "$MISSING" | sed 's/^/  - /' >&2
             exit 1
           fi
+          if [ -n "$INVALID_MODES" ]; then
+            echo "[ERROR] Managed-file sources have invalid Git modes:" >&2
+            printf '%b' "$INVALID_MODES" | sed 's/^/  - /' >&2
+            exit 1
+          fi
 
           jq -n \
-            --arg generated_at "$GENERATED_AT" \
             --arg source_commit "$SOURCE_COMMIT" \
             --argjson files "$FILES_JSON" \
-            '{generated_at: $generated_at, source_commit: $source_commit, files: $files}' \
+            '{source_commit: $source_commit, files: $files}' \
             >"$MANIFEST_PATH"
 
           echo "[OK] Wrote manifest with $(echo "$FILES_JSON" | jq 'length') entries"
@@ -131,22 +173,140 @@ jobs:
         # direct push of the manifest is rejected. Instead route the manifest
         # through an auto-merging PR on a sync/* branch (excluded from the
         # require-linked-issue gate). The PR is only opened/updated when the
-        # `files` map actually changes — generated_at/source_commit churn is
-        # ignored — so there is no per-run PR spam. The manifest is excluded
-        # from biome, so the PR's Lint Code Base passes. Falls back to today's
-        # per-file sync behavior if anything here is skipped.
+        # `files` map actually changes — source_commit churn is ignored — so
+        # there is no per-run PR spam. The manifest is excluded
+        # from biome, so the PR's Lint Code Base passes. Downstream sync fails
+        # closed until this exact manifest evidence lands.
         env:
           # PAT (not GITHUB_TOKEN) so the PR triggers CI and auto-merge can proceed.
           GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
+          SOURCE_COMMIT: ${{ github.sha }}
           MANIFEST_PATH: .github/config/managed-files-manifest.json
           BRANCH: sync/manifest
         run: |
           set -euo pipefail
 
-          # Compare only the files map (ignore volatile generated_at/source_commit).
-          NEW_FILES=$(jq -S '.files' "$MANIFEST_PATH")
-          CURRENT_FILES=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${MANIFEST_PATH}?ref=main" \
-            --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | jq -S '.files' 2>/dev/null || echo '{}')
+          PROTECTED_MAIN_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          if ! printf '%s\n%s\n%s\n' \
+            "$SOURCE_COMMIT" "$CHECKED_OUT_SHA" "$PROTECTED_MAIN_SHA" |
+            awk '/^[0-9a-f]{40}$/ { valid++ } END { exit valid != 3 }'; then
+            echo "[ERROR] Manifest publication identities are invalid" >&2
+            exit 1
+          fi
+          if [ "$SOURCE_COMMIT" != "$PROTECTED_MAIN_SHA" ] ||
+            [ "$CHECKED_OUT_SHA" != "$PROTECTED_MAIN_SHA" ]; then
+            echo "[ERROR] Manifest publication requires the exact current protected main" >&2
+            exit 1
+          fi
+
+          read_manifest_prs() {
+            local destination="$1"
+            if ! gh api "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+              --paginate --slurp >"$destination"; then
+              echo "[ERROR] Could not inventory open manifest PRs" >&2
+              return 1
+            fi
+            if ! jq -e --arg branch "$BRANCH" '
+              type == "array" and all(.[]; type == "array") and
+              all(.[][] | select(.head.ref == $branch);
+                (.number | type == "number" and floor == . and . >= 1) and
+                (.head.ref | type == "string") and
+                (.head.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.head.repo.full_name | type == "string") and
+                (.base.ref | type == "string"))
+            ' "$destination" >/dev/null; then
+              echo "[ERROR] Open manifest PR inventory is invalid" >&2
+              return 1
+            fi
+          }
+
+          select_owned_manifest_pr() {
+            local inventory="$1" count row pr_num pr_repo pr_base pr_head
+            count=$(jq --arg branch "$BRANCH" '
+              [.[][] | select(.head.ref == $branch)] | length
+            ' "$inventory")
+            case "$count" in
+              0) return 0 ;;
+              1)
+                row=$(jq -r --arg branch "$BRANCH" '
+                  .[][] | select(.head.ref == $branch) |
+                  [.number, .head.repo.full_name, .base.ref, .head.sha] | @tsv
+                ' "$inventory")
+                IFS=$'\t' read -r pr_num pr_repo pr_base pr_head <<<"$row"
+                if [ "$pr_repo" != "$GITHUB_REPOSITORY" ] || [ "$pr_base" != "main" ]; then
+                  echo "[ERROR] Open manifest PR is not owned by protected ${GITHUB_REPOSITORY} main" >&2
+                  return 1
+                fi
+                printf '%s\t%s\n' "$pr_num" "$pr_head"
+                ;;
+              *)
+                echo "[ERROR] Multiple open manifest PRs claim ${BRANCH}" >&2
+                return 1
+                ;;
+            esac
+          }
+
+          assert_manifest_pr_head() {
+            local pr_num="$1" expected_sha="$2" response
+            if ! printf '%s' "$pr_num" | grep -qE '^[1-9][0-9]*$' ||
+              ! printf '%s' "$expected_sha" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] Invalid manifest PR receipt" >&2
+              return 1
+            fi
+            response=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_num}")
+            if ! echo "$response" | jq -e \
+              --arg repo "${GITHUB_REPOSITORY}" \
+              --arg branch "$BRANCH" \
+              --arg sha "$expected_sha" '
+                .state == "open" and
+                .head.repo.full_name == $repo and
+                .head.ref == $branch and
+                .head.sha == $sha and
+                .base.ref == "main"
+              ' >/dev/null; then
+              echo "[ERROR] Manifest PR ownership or exact head changed before auto-merge" >&2
+              return 1
+            fi
+          }
+
+          assert_manifest_pr_diff() {
+            local expected_head="$1" response
+            if ! printf '%s' "$expected_head" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] Invalid manifest diff receipt" >&2
+              return 1
+            fi
+            response=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${PROTECTED_MAIN_SHA}...${expected_head}")
+            if ! printf '%s' "$response" | jq -e \
+              --arg expected_head "$expected_head" \
+              --arg manifest_path "$MANIFEST_PATH" '
+                .status == "ahead" and
+                .ahead_by == 1 and
+                .total_commits == 1 and
+                (.commits | length) == 1 and
+                .commits[0].sha == $expected_head and
+                (.files | length) == 1 and
+                .files[0].filename == $manifest_path
+              ' >/dev/null; then
+              echo "[ERROR] Manifest PR is not one exact manifest-only commit on protected main" >&2
+              return 1
+            fi
+          }
+
+          # Compare only the files map (ignore source_commit churn).
+          NEW_FILES=$(jq -eS '.files | select(type == "object")' "$MANIFEST_PATH")
+          CURRENT_MANIFEST=$(mktemp)
+          if ! git show "HEAD:${MANIFEST_PATH}" >"$CURRENT_MANIFEST"; then
+            echo "[ERROR] Current checkout lacks a committed manifest receipt" >&2
+            exit 1
+          fi
+          if ! CURRENT_FILES=$(jq -eS '.files | select(type == "object")' "$CURRENT_MANIFEST"); then
+            echo "[ERROR] Current committed manifest is invalid" >&2
+            rm -f "$CURRENT_MANIFEST"
+            exit 1
+          fi
+          rm -f "$CURRENT_MANIFEST"
 
           if [ "$NEW_FILES" = "$CURRENT_FILES" ]; then
             echo "[OK] Managed-file set unchanged - no manifest PR needed"
@@ -154,17 +314,124 @@ jobs:
           fi
           echo "[INFO] Managed-file set changed - opening/updating manifest PR"
 
+          # Inventory ownership and the exact remote ref before any mutation.
+          MANIFEST_PR_INVENTORY=$(mktemp)
+          read_manifest_prs "$MANIFEST_PR_INVENTORY"
+          MANIFEST_PR_ROW=$(select_owned_manifest_pr "$MANIFEST_PR_INVENTORY")
+          rm -f "$MANIFEST_PR_INVENTORY"
+          PR_NUM=""
+          INVENTORIED_HEAD=""
+          if [ -n "$MANIFEST_PR_ROW" ]; then
+            IFS=$'\t' read -r PR_NUM INVENTORIED_HEAD <<<"$MANIFEST_PR_ROW"
+          fi
+
+          set +e
+          REMOTE_BRANCH_ROW=$(git ls-remote --exit-code --heads origin "refs/heads/$BRANCH")
+          REMOTE_BRANCH_RC=$?
+          set -e
+          case "$REMOTE_BRANCH_RC" in
+            0)
+              REMOTE_BRANCH_SHA=$(printf '%s' "$REMOTE_BRANCH_ROW" |
+                awk -v ref="refs/heads/$BRANCH" '
+                  $2 == ref && $1 ~ /^[0-9a-f]{40}$/ { print $1; valid++ }
+                  END { exit valid != 1 }
+                ')
+              if [ -z "$PR_NUM" ] || [ "$REMOTE_BRANCH_SHA" != "$INVENTORIED_HEAD" ]; then
+                echo "[ERROR] Remote manifest branch is not owned by the inventoried PR" >&2
+                exit 1
+              fi
+              ;;
+            2)
+              REMOTE_BRANCH_SHA=""
+              if [ -n "$PR_NUM" ]; then
+                echo "[ERROR] Inventoried manifest PR has no exact remote branch" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "[ERROR] Could not prove the remote manifest branch state" >&2
+              exit 1
+              ;;
+          esac
+
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git switch -C "$BRANCH"
+          git switch --create "$BRANCH"
           git add "$MANIFEST_PATH"
-          git commit -m "chore(governance): regenerate managed-files-manifest.json"
-          git push --force origin "$BRANCH"
-
-          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')" ]; then
-            gh pr create --base main --head "$BRANCH" \
-              --title "chore(governance): regenerate managed-files-manifest.json" \
-              --body "Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches."
+          if [ "$(git diff --cached --name-only)" != "$MANIFEST_PATH" ]; then
+            echo "[ERROR] Manifest commit stages paths outside ${MANIFEST_PATH}" >&2
+            exit 1
           fi
-          gh pr merge "$BRANCH" --squash --auto --delete-branch || true
+          git commit -m "chore(governance): regenerate managed-files-manifest.json"
+
+          EXPECTED_HEAD=$(git rev-parse HEAD)
+          if ! printf '%s' "$EXPECTED_HEAD" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "[ERROR] Local manifest branch head is invalid" >&2
+            exit 1
+          fi
+          CURRENT_MAIN_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')
+          if [ "$CURRENT_MAIN_SHA" != "$PROTECTED_MAIN_SHA" ]; then
+            echo "[ERROR] Protected main changed before manifest publication" >&2
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_BRANCH_SHA" ]; then
+            git push \
+              "--force-with-lease=refs/heads/$BRANCH:$REMOTE_BRANCH_SHA" \
+              origin "HEAD:refs/heads/$BRANCH"
+          else
+            git push \
+              "--force-with-lease=refs/heads/$BRANCH:" \
+              origin "HEAD:refs/heads/$BRANCH"
+          fi
+
+          # Re-inventory after the lease-protected push. A concurrent PR or
+          # head change must be proved before it can be selected.
+          MANIFEST_PR_INVENTORY=$(mktemp)
+          read_manifest_prs "$MANIFEST_PR_INVENTORY"
+          MANIFEST_PR_ROW=$(select_owned_manifest_pr "$MANIFEST_PR_INVENTORY")
+          if [ -z "$MANIFEST_PR_ROW" ]; then
+            if [ -n "$PR_NUM" ]; then
+              echo "[ERROR] Inventoried manifest PR disappeared after the exact push" >&2
+              rm -f "$MANIFEST_PR_INVENTORY"
+              exit 1
+            fi
+            rm -f "$MANIFEST_PR_INVENTORY"
+            PR_URL=$(gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base main --head "$BRANCH" \
+              --title "chore(governance): regenerate managed-files-manifest.json" \
+              --body "Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.")
+            PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
+            if ! printf '%s' "$PR_NUM" | grep -qE '^[1-9][0-9]*$'; then
+              echo "[ERROR] Manifest PR creation returned an invalid URL" >&2
+              exit 1
+            fi
+            MANIFEST_PR_INVENTORY=$(mktemp)
+            read_manifest_prs "$MANIFEST_PR_INVENTORY"
+            MANIFEST_PR_ROW=$(select_owned_manifest_pr "$MANIFEST_PR_INVENTORY")
+          else
+            IFS=$'\t' read -r ACTUAL_PR_NUM ACTUAL_HEAD <<<"$MANIFEST_PR_ROW"
+            if [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] ||
+              { [ -n "$PR_NUM" ] && [ "$ACTUAL_PR_NUM" != "$PR_NUM" ]; }; then
+              echo "[ERROR] Manifest PR ownership or head changed after the exact push" >&2
+              rm -f "$MANIFEST_PR_INVENTORY"
+              exit 1
+            fi
+            PR_NUM="$ACTUAL_PR_NUM"
+          fi
+          rm -f "$MANIFEST_PR_INVENTORY"
+
+          if [ -z "$MANIFEST_PR_ROW" ]; then
+            echo "[ERROR] Manifest PR was not present after creation" >&2
+            exit 1
+          fi
+          IFS=$'\t' read -r FINAL_PR_NUM FINAL_HEAD <<<"$MANIFEST_PR_ROW"
+          if [ "$FINAL_PR_NUM" != "$PR_NUM" ] || [ "$FINAL_HEAD" != "$EXPECTED_HEAD" ]; then
+            echo "[ERROR] Manifest PR does not own the exact pushed head" >&2
+            exit 1
+          fi
+          assert_manifest_pr_head "$PR_NUM" "$EXPECTED_HEAD"
+          assert_manifest_pr_diff "$EXPECTED_HEAD"
+          gh pr merge "$PR_NUM" --repo "$GITHUB_REPOSITORY" \
+            --squash --auto --delete-branch --match-head-commit "$EXPECTED_HEAD"
           echo "[OK] Manifest PR open with auto-merge enabled"

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -21,6 +21,7 @@ on:
       - '.github/config/governed-workflow-pin.json'
       - '.github/config/governance-rollout.json'
       - '.github/workflows/dispatch-downstream.yml'
+      - 'workflows/enforce-repo-settings.yml'
       - 'README.md.tpl'
   schedule:
     - cron: '17 */6 * * *'
@@ -31,7 +32,9 @@ permissions:
 
 concurrency:
   group: dispatch-downstream
-  cancel-in-progress: true
+  # Bootstrap mutates downstream PR state. Queue newer receipts so an in-flight
+  # exact transition can defer monotonically instead of being killed mid-write.
+  cancel-in-progress: false
 
 jobs:
   dispatch:

--- a/.github/workflows/docs-site-deploy.yml
+++ b/.github/workflows/docs-site-deploy.yml
@@ -1,0 +1,19 @@
+---
+name: Deploy docs-control Site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    uses: ./.github/workflows/github-pages-deploy.yml
+    with:
+      content-ref: ${{ github.sha }}

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -9,17 +9,15 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: 'Commit SHA of the docs-control push that triggered this run. Used for Pages staleness check.'
-        required: false
+        description: 'Exact docs-control commit receipt for every governed read.'
+        required: true
         type: string
-        default: ''
   workflow_call:
     inputs:
       source_sha:
-        description: 'Commit SHA of the docs-control push that triggered this run. Used for Pages staleness check.'
-        required: false
+        description: 'Exact docs-control commit receipt for every governed read.'
+        required: true
         type: string
-        default: ''
     secrets:
       repo-settings-token:
         description: 'PAT with admin permissions for repository settings'
@@ -46,6 +44,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.repo-settings-token || secrets.REPO_SETTINGS_TOKEN }}
           SOURCE_SHA: ${{ inputs.source_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -113,6 +113,137 @@ jobs:
             retry "$max" bash -c 'printf "%s" "$0" | gh api "$@" --input -' "$json" "$@"
           }
 
+          api_value_or_404() {
+            local endpoint="$1" jq_filter="$2"
+            local out_file err_file rc value
+            out_file=$(mktemp)
+            err_file=$(mktemp)
+            set +e
+            gh api "$endpoint" --jq "$jq_filter" >"$out_file" 2>"$err_file"
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              value=$(cat "$out_file")
+              rm -f "$out_file" "$err_file"
+              if [ -z "$value" ]; then
+                echo "[ERROR] GitHub API returned an empty value for ${endpoint}" >&2
+                return 1
+              fi
+              printf '%s' "$value"
+              return 0
+            fi
+            if grep -qE '\(HTTP 404\)$' "$err_file"; then
+              rm -f "$out_file" "$err_file"
+              return 44
+            fi
+            echo "[ERROR] GitHub API read failed closed for ${endpoint}" >&2
+            sed -E 's/(Request-Id:).*/\1 [redacted]/I' "$err_file" >&2
+            rm -f "$out_file" "$err_file"
+            return 1
+          }
+
+          normalize_desired_protection() {
+            jq -ce '
+              def names($key):
+                map(if type == "string" then . else error("invalid " + $key) end) | sort;
+              {
+                enforce_admins: .enforce_admins,
+                required_status_checks:
+                  (if .required_status_checks == null then null else {
+                    strict: .required_status_checks.strict,
+                    contexts: (.required_status_checks.contexts | sort)
+                  } end),
+                required_pull_request_reviews:
+                  (if .required_pull_request_reviews == null then null else {
+                    dismiss_stale_reviews:
+                      (.required_pull_request_reviews.dismiss_stale_reviews // false),
+                    require_code_owner_reviews:
+                      (.required_pull_request_reviews.require_code_owner_reviews // false),
+                    required_approving_review_count:
+                      (.required_pull_request_reviews.required_approving_review_count // 0),
+                    require_last_push_approval:
+                      (.required_pull_request_reviews.require_last_push_approval // false),
+                    dismissal_restrictions: {
+                      users: ((.required_pull_request_reviews.dismissal_restrictions.users // []) | names("users")),
+                      teams: ((.required_pull_request_reviews.dismissal_restrictions.teams // []) | names("teams"))
+                    },
+                    bypass_pull_request_allowances: {
+                      users: ((.required_pull_request_reviews.bypass_pull_request_allowances.users // []) | names("users")),
+                      teams: ((.required_pull_request_reviews.bypass_pull_request_allowances.teams // []) | names("teams")),
+                      apps: ((.required_pull_request_reviews.bypass_pull_request_allowances.apps // []) | names("apps"))
+                    }
+                  } end),
+                restrictions:
+                  (if .restrictions == null then null else {
+                    users: ((.restrictions.users // []) | names("users")),
+                    teams: ((.restrictions.teams // []) | names("teams")),
+                    apps: ((.restrictions.apps // []) | names("apps"))
+                  } end),
+                required_linear_history: .required_linear_history,
+                allow_force_pushes: .allow_force_pushes,
+                allow_deletions: .allow_deletions,
+                block_creations: .block_creations,
+                required_conversation_resolution: .required_conversation_resolution,
+                lock_branch: .lock_branch,
+                allow_fork_syncing: .allow_fork_syncing
+              }
+            '
+          }
+
+          normalize_current_protection() {
+            jq -ce '
+              def identities($key):
+                map(
+                  if type == "string" then .
+                  elif $key == "users" then .login
+                  else .slug
+                  end
+                ) | sort;
+              {
+                enforce_admins: .enforce_admins.enabled,
+                required_status_checks:
+                  (if .required_status_checks == null then null else {
+                    strict: .required_status_checks.strict,
+                    contexts: (.required_status_checks.contexts | sort)
+                  } end),
+                required_pull_request_reviews:
+                  (if .required_pull_request_reviews == null then null else {
+                    dismiss_stale_reviews:
+                      (.required_pull_request_reviews.dismiss_stale_reviews // false),
+                    require_code_owner_reviews:
+                      (.required_pull_request_reviews.require_code_owner_reviews // false),
+                    required_approving_review_count:
+                      (.required_pull_request_reviews.required_approving_review_count // 0),
+                    require_last_push_approval:
+                      (.required_pull_request_reviews.require_last_push_approval // false),
+                    dismissal_restrictions: {
+                      users: ((.required_pull_request_reviews.dismissal_restrictions.users // []) | identities("users")),
+                      teams: ((.required_pull_request_reviews.dismissal_restrictions.teams // []) | identities("teams"))
+                    },
+                    bypass_pull_request_allowances: {
+                      users: ((.required_pull_request_reviews.bypass_pull_request_allowances.users // []) | identities("users")),
+                      teams: ((.required_pull_request_reviews.bypass_pull_request_allowances.teams // []) | identities("teams")),
+                      apps: ((.required_pull_request_reviews.bypass_pull_request_allowances.apps // []) | identities("apps"))
+                    }
+                  } end),
+                restrictions:
+                  (if .restrictions == null then null else {
+                    users: ((.restrictions.users // []) | identities("users")),
+                    teams: ((.restrictions.teams // []) | identities("teams")),
+                    apps: ((.restrictions.apps // []) | identities("apps"))
+                  } end),
+                required_linear_history: (.required_linear_history.enabled // false),
+                allow_force_pushes: (.allow_force_pushes.enabled // false),
+                allow_deletions: (.allow_deletions.enabled // false),
+                block_creations: (.block_creations.enabled // false),
+                required_conversation_resolution:
+                  (.required_conversation_resolution.enabled // false),
+                lock_branch: (.lock_branch.enabled // false),
+                allow_fork_syncing: (.allow_fork_syncing.enabled // false)
+              }
+            '
+          }
+
           # Probe an endpoint for its HTTP status line.
           #
           # This deliberately does NOT use retry(): reading a status code requires
@@ -164,69 +295,97 @@ jobs:
             return 1
           }
 
-          # --- Pages-first fetch helper (canonical: tests/fixtures/fetch-governed.sh) ---
-          PAGES_BASE="https://${GITHUB_REPOSITORY_OWNER}.github.io/docs-control"
-
+          # --- Exact-receipt fetch helper (canonical: tests/fixtures/fetch-governed.sh) ---
           fetch_governed() {
-            local key="$1" fallback="$2" body err_file
-            local url="${PAGES_BASE}/api/${key}"
+            local key="$1" fallback="$2" api_file decoded_file err_file
+            local receipt_sha receipt_size decoded_sha decoded_size
 
-            body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
-            if [ -n "$body" ]; then
-              printf '%s' "$body"
-              return 0
+            if ! printf '%s' "${expected_source_sha:-}" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
+              return 1
+            fi
+            if [[ "$fallback" == *[?#]* ]]; then
+              echo "[ERROR] Governed API path already contains a query or fragment for ${key}" >&2
+              return 1
             fi
 
-            echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
+            api_file=$(mktemp)
+            decoded_file=$(mktemp)
             err_file=$(mktemp)
-            if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+            if ! retry 3 gh api "${fallback}?ref=${expected_source_sha}" >"$api_file" 2>"$err_file"; then
               echo "[ERROR] gh api failed for ${key}:" >&2
               cat "$err_file" >&2
-              rm -f "$err_file"
+              rm -f "$api_file" "$decoded_file" "$err_file"
               return 1
             fi
-            rm -f "$err_file"
-            if [ -z "$body" ]; then
-              echo "[ERROR] gh api returned empty body for ${key}" >&2
+            if ! jq -e '
+              .type == "file" and .encoding == "base64" and
+              (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.size | type == "number" and floor == . and . >= 0) and
+              (.content | type == "string") and
+              (.size == 0 or (.content | length > 0))
+            ' "$api_file" >/dev/null 2>&1; then
+              echo "[ERROR] gh api returned an invalid content envelope for ${key}" >&2
+              rm -f "$api_file" "$decoded_file" "$err_file"
               return 1
             fi
-
-            printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
+            if ! jq -r '.content' "$api_file" | tr -d '\n' | base64 -d >"$decoded_file"; then
+              echo "[ERROR] gh api returned invalid base64 content for ${key}" >&2
+              rm -f "$api_file" "$decoded_file" "$err_file"
+              return 1
+            fi
+            receipt_sha=$(jq -r '.sha' "$api_file")
+            receipt_size=$(jq -r '.size' "$api_file")
+            decoded_sha=$(git hash-object "$decoded_file")
+            decoded_size=$(wc -c <"$decoded_file" | tr -d ' ')
+            if [ "$decoded_sha" != "$receipt_sha" ] || [ "$decoded_size" != "$receipt_size" ]; then
+              echo "[ERROR] Decoded bytes do not match the content receipt for ${key}" >&2
+              rm -f "$api_file" "$decoded_file" "$err_file"
+              return 1
+            fi
+            cat "$decoded_file"
+            rm -f "$api_file" "$decoded_file" "$err_file"
           }
 
-          revision_is_fresh() {
-            local source_sha="${1:-}" rev pages_sha
-            [ -z "$source_sha" ] && return 1
-
-            rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
-              "${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
-            [ -z "$rev" ] && return 1
-
-            pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
-            [ "$pages_sha" = "$source_sha" ]
-          }
-
-          # Gate governed reads on Pages freshness. `fetch_governed` prefers the
-          # Pages-published governance mirror, which lags a docs-control merge by
-          # however long its deploy takes; reading a stale mirror means enforcing
-          # OUTDATED settings (and previously `revision_is_fresh` was defined here
-          # but never called, so this workflow had no staleness guard at all).
-          # Prefer the dispatching push's sha; otherwise use docs-control main HEAD.
           expected_source_sha="${SOURCE_SHA:-}"
-          if [ -z "$expected_source_sha" ]; then
-            expected_source_sha=$(retry 3 gh api \
-              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha' 2>/dev/null || echo "")
+          if [ -z "$expected_source_sha" ] && [ "$EVENT_NAME" != "workflow_call" ]; then
+            expected_source_sha="$EVENT_SHA"
           fi
 
-          if [ -z "$expected_source_sha" ]; then
-            echo "[WARN] Could not determine docs-control main HEAD — using API for governed reads" >&2
-            PAGES_BASE="https://invalid.pages.local"
-          elif ! revision_is_fresh "$expected_source_sha"; then
-            echo "[WARN] Pages revision lags source ${expected_source_sha:0:8} — this run will fall back to API for governed reads" >&2
-            PAGES_BASE="https://invalid.pages.local"
-          else
-            echo "[OK] Pages governance mirror is fresh at ${expected_source_sha:0:8}"
+          if ! printf '%s' "$expected_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
+            exit 1
           fi
+          if ! current_source_sha=$(retry 3 gh api \
+            "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha'); then
+            echo "[ERROR] Could not resolve protected docs-control main" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$current_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "[ERROR] Protected docs-control main returned an invalid commit" >&2
+            exit 1
+          fi
+          if [ "$expected_source_sha" != "$current_source_sha" ]; then
+            if ! source_status=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/compare/${expected_source_sha}...${current_source_sha}" \
+              --jq '.status'); then
+              echo "[ERROR] Could not prove the source receipt is on protected docs-control main" >&2
+              exit 1
+            fi
+            if [ "$source_status" = "ahead" ]; then
+              echo "[DEFER] Historical protected-main receipt; enqueueing current main"
+              if ! gh workflow run enforce-repo-settings.yml \
+                --repo "$GITHUB_REPOSITORY" \
+                -f source_sha="$current_source_sha"; then
+                echo "[ERROR] Could not enqueue the current protected-main receipt" >&2
+                exit 1
+              fi
+              exit 0
+            fi
+            echo "[ERROR] Source receipt is not an approved protected-main commit" >&2
+            exit 1
+          fi
+          echo "[OK] Governed reads bound to source ${expected_source_sha:0:8}"
 
           OWNER="${GITHUB_REPOSITORY_OWNER}"
           REPO="${GITHUB_REPOSITORY#*/}"
@@ -411,69 +570,34 @@ jobs:
               fi
             fi
 
-            HTTP_CODE=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
-              --include 2>/dev/null | head -1 | awk '{print $2}') || true
-            CURRENT_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
+            set +e
+            CURRENT_PROTECTION=$(api_value_or_404 \
+              "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" '.')
+            PROTECTION_READ_RC=$?
+            set -e
+            case "$PROTECTION_READ_RC" in
+              0)
+                if ! echo "$CURRENT_PROTECTION" | jq -e 'type == "object"' >/dev/null; then
+                  echo "[ERROR] Branch-protection API returned an invalid response" >&2
+                  exit 1
+                fi
+                ;;
+              44) CURRENT_PROTECTION="" ;;
+              *) exit 1 ;;
+            esac
 
             PROTECTION_DRIFT=false
 
-            if [ "$HTTP_CODE" = "404" ] || [ -z "$CURRENT_PROTECTION" ]; then
+            if [ "$PROTECTION_READ_RC" = 44 ]; then
               echo "[WARN] No branch protection found -- will create"
               PROTECTION_DRIFT=true
             else
-              desired_enforce=$(echo "$DESIRED_PAYLOAD" | jq '.enforce_admins')
-              current_enforce=$(echo "$CURRENT_PROTECTION" | jq '.enforce_admins.enabled')
-              if [ "$desired_enforce" != "$current_enforce" ]; then
-                echo "[WARN] Drift in enforce_admins: current=$current_enforce desired=$desired_enforce"
+              DESIRED_PROTECTION_STATE=$(echo "$DESIRED_PAYLOAD" | normalize_desired_protection)
+              CURRENT_PROTECTION_STATE=$(echo "$CURRENT_PROTECTION" | normalize_current_protection)
+              if [ "$DESIRED_PROTECTION_STATE" != "$CURRENT_PROTECTION_STATE" ]; then
+                echo "[WARN] Branch protection does not match desired state"
                 PROTECTION_DRIFT=true
               fi
-
-              desired_checks=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_status_checks')
-              current_checks_raw=$(echo "$CURRENT_PROTECTION" | jq -c '.required_status_checks')
-              if [ "$current_checks_raw" != "null" ]; then
-                current_checks=$(echo "$current_checks_raw" | jq -c '{strict: .strict, contexts: (.contexts | sort)}')
-              else
-                current_checks="null"
-              fi
-              if [ "$desired_checks" != "null" ]; then
-                desired_checks_norm=$(echo "$desired_checks" | jq -c '{strict: .strict, contexts: (.contexts | sort)}')
-              else
-                desired_checks_norm="null"
-              fi
-              if [ "$desired_checks_norm" != "$current_checks" ]; then
-                echo "[WARN] Drift in required_status_checks"
-                PROTECTION_DRIFT=true
-              fi
-
-              desired_reviews=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_pull_request_reviews')
-              if [ "$desired_reviews" != "null" ]; then
-                for review_key in required_approving_review_count dismiss_stale_reviews require_code_owner_reviews require_last_push_approval; do
-                  desired_val=$(echo "$desired_reviews" | jq ".$review_key")
-                  current_val=$(echo "$CURRENT_PROTECTION" | jq ".required_pull_request_reviews.$review_key // false")
-                  if [ "$desired_val" != "$current_val" ]; then
-                    echo "[WARN] Drift in $review_key: current=$current_val desired=$desired_val"
-                    PROTECTION_DRIFT=true
-                  fi
-                done
-              fi
-
-              desired_restrictions=$(echo "$DESIRED_PAYLOAD" | jq -c '.restrictions')
-              if [ "$desired_restrictions" = "null" ]; then
-                current_restrictions=$(echo "$CURRENT_PROTECTION" | jq -c '.restrictions')
-                if [ "$current_restrictions" != "null" ]; then
-                  echo "[WARN] Drift in restrictions"
-                  PROTECTION_DRIFT=true
-                fi
-              fi
-
-              for flag in required_linear_history allow_force_pushes allow_deletions block_creations required_conversation_resolution lock_branch allow_fork_syncing; do
-                desired_flag=$(echo "$DESIRED_PAYLOAD" | jq ".$flag")
-                current_flag=$(echo "$CURRENT_PROTECTION" | jq ".$flag.enabled // false")
-                if [ "$desired_flag" != "$current_flag" ]; then
-                  echo "[WARN] Drift in $flag: current=$current_flag desired=$desired_flag"
-                  PROTECTION_DRIFT=true
-                fi
-              done
             fi
 
             if [ "$PROTECTION_DRIFT" = true ]; then
@@ -484,16 +608,7 @@ jobs:
                 '{
                   enforce_admins: $desired.enforce_admins,
                   required_status_checks: $desired.required_status_checks,
-                  required_pull_request_reviews: (
-                    if $desired.required_pull_request_reviews == null then null
-                    else {
-                      required_approving_review_count: $desired.required_pull_request_reviews.required_approving_review_count,
-                      dismiss_stale_reviews: $desired.required_pull_request_reviews.dismiss_stale_reviews,
-                      require_code_owner_reviews: $desired.required_pull_request_reviews.require_code_owner_reviews,
-                      require_last_push_approval: $desired.required_pull_request_reviews.require_last_push_approval
-                    }
-                    end
-                  ),
+                  required_pull_request_reviews: $desired.required_pull_request_reviews,
                   restrictions: $desired.restrictions,
                   required_linear_history: $desired.required_linear_history,
                   allow_force_pushes: $desired.allow_force_pushes,
@@ -545,11 +660,17 @@ jobs:
               echo "[WARN] Pages status unknown -- skipping Pages phase rather than guessing between create and update"
             elif [ "$PAGES_HTTP_CODE" = "404" ]; then
               echo "[INFO] Enabling GitHub Pages with ${DESIRED_BUILD_TYPE} source..."
-              retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1 || true
+              retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1
               echo "[OK] Pages enabled with build_type=${DESIRED_BUILD_TYPE}"
             else
-              PAGES_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
-              CURRENT_BUILD_TYPE=$(echo "$PAGES_RESPONSE" | jq -r '.build_type // empty')
+              PAGES_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages")
+              if ! echo "$PAGES_RESPONSE" | jq -e '
+                type == "object" and (.build_type | type == "string" and length > 0)
+              ' >/dev/null; then
+                echo "[ERROR] Pages API returned an invalid response" >&2
+                exit 1
+              fi
+              CURRENT_BUILD_TYPE=$(echo "$PAGES_RESPONSE" | jq -r '.build_type')
               if [ "$CURRENT_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
                 echo "[WARN] Drift in pages.build_type: current=$CURRENT_BUILD_TYPE desired=$DESIRED_BUILD_TYPE"
                 echo "[INFO] Updating Pages build_type to ${DESIRED_BUILD_TYPE}..."
@@ -594,8 +715,31 @@ jobs:
               echo "[INFO] Expected secrets for ${REPO}: $(echo "$EXPECTED_SECRETS" | tr '\n' ', ' | sed 's/,$//')"
 
               # List current secrets
-              CURRENT_SECRETS=$(retry 3 gh api "repos/${OWNER}/${REPO}/actions/secrets" \
-                --jq '.secrets[].name' 2>/dev/null | sort) || true
+              SECRETS_RECEIPT=$(mktemp)
+              if ! retry 3 gh api \
+                "repos/${OWNER}/${REPO}/actions/secrets?per_page=100" \
+                --paginate --slurp >"$SECRETS_RECEIPT"; then
+                echo "[ERROR] Could not inventory repository secrets" >&2
+                rm -f "$SECRETS_RECEIPT"
+                exit 1
+              fi
+              if ! jq -e '
+                type == "array" and length > 0 and
+                all(.[]; type == "object" and
+                  (.total_count | type == "number" and floor == . and . >= 0) and
+                  (.secrets | type == "array") and
+                  all(.secrets[]; .name | type == "string" and length > 0)) and
+                ([.[].total_count] | unique | length == 1) and
+                ([.[].secrets[].name] | length) ==
+                  ([.[].secrets[].name] | unique | length) and
+                .[0].total_count == ([.[].secrets[].name] | length)
+              ' "$SECRETS_RECEIPT" >/dev/null; then
+                echo "[ERROR] Repository secret inventory is incomplete or invalid" >&2
+                rm -f "$SECRETS_RECEIPT"
+                exit 1
+              fi
+              CURRENT_SECRETS=$(jq -r '[.[].secrets[].name] | sort | .[]' "$SECRETS_RECEIPT")
+              rm -f "$SECRETS_RECEIPT"
 
               # Detect missing
               MISSING=0
@@ -617,7 +761,11 @@ jobs:
                 fi
               done <<< "$CURRENT_SECRETS"
 
-              echo "[OK] Secrets audit: missing=${MISSING}, unexpected=${UNEXPECTED}"
+              if [ "$MISSING" -gt 0 ]; then
+                echo "[ERROR] Missing required repository secret(s): ${MISSING}" >&2
+                exit 1
+              fi
+              echo "[OK] Secrets audit: missing=0, unexpected=${UNEXPECTED}"
             fi
           fi
 
@@ -699,7 +847,8 @@ jobs:
               fi
             fi
 
-            VERIFY_PROTECTION=$(retry 3 gh api "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" 2>/dev/null) || true
+            VERIFY_PROTECTION=$(retry 3 gh api \
+              "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection")
 
             if [ -z "$VERIFY_PROTECTION" ]; then
               echo "[FAIL] Branch protection for $BRANCH not found after apply"
@@ -707,31 +856,12 @@ jobs:
               continue
             fi
 
-            desired_enforce=$(echo "$DESIRED_PAYLOAD" | jq '.enforce_admins')
-            actual_enforce=$(echo "$VERIFY_PROTECTION" | jq '.enforce_admins.enabled')
-            if [ "$desired_enforce" != "$actual_enforce" ]; then
-              echo "[FAIL] $BRANCH enforce_admins: expected=$desired_enforce actual=$actual_enforce"
+            DESIRED_PROTECTION_STATE=$(echo "$DESIRED_PAYLOAD" | normalize_desired_protection)
+            VERIFIED_PROTECTION_STATE=$(echo "$VERIFY_PROTECTION" | normalize_current_protection)
+            if [ "$DESIRED_PROTECTION_STATE" != "$VERIFIED_PROTECTION_STATE" ]; then
+              echo "[FAIL] Branch protection failed exact verification for $BRANCH"
               VERIFY_FAILED=true
             fi
-
-            desired_reviews=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_pull_request_reviews')
-            if [ "$desired_reviews" != "null" ]; then
-              desired_approvals=$(echo "$desired_reviews" | jq '.required_approving_review_count')
-              actual_approvals=$(echo "$VERIFY_PROTECTION" | jq '.required_pull_request_reviews.required_approving_review_count // empty')
-              if [ "$desired_approvals" != "$actual_approvals" ]; then
-                echo "[FAIL] $BRANCH required_approving_review_count: expected=$desired_approvals actual=$actual_approvals"
-                VERIFY_FAILED=true
-              fi
-            fi
-
-            for flag in required_linear_history allow_force_pushes allow_deletions block_creations required_conversation_resolution lock_branch allow_fork_syncing; do
-              desired_flag=$(echo "$DESIRED_PAYLOAD" | jq ".$flag")
-              actual_flag=$(echo "$VERIFY_PROTECTION" | jq ".$flag.enabled // false")
-              if [ "$desired_flag" != "$actual_flag" ]; then
-                echo "[FAIL] $BRANCH $flag: expected=$desired_flag actual=$actual_flag"
-                VERIFY_FAILED=true
-              fi
-            done
           done
 
           if [ "$PAGES_ENABLED" = "true" ]; then
@@ -740,13 +870,21 @@ jobs:
               echo "[FAIL] Pages status could not be determined -- state is unverified, not confirmed"
               VERIFY_FAILED=true
             elif [ "$VERIFY_PAGES_CODE" = "404" ]; then
-              echo "[WARN] Pages not found after apply -- repo may lack a deploy workflow"
+              echo "[FAIL] Pages not found after apply"
+              VERIFY_FAILED=true
             else
-              VERIFY_PAGES=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages" 2>/dev/null) || true
-              ACTUAL_BUILD_TYPE=$(echo "$VERIFY_PAGES" | jq -r '.build_type // empty')
-              if [ "$ACTUAL_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
-                echo "[FAIL] pages.build_type: expected=$DESIRED_BUILD_TYPE actual=$ACTUAL_BUILD_TYPE"
+              VERIFY_PAGES=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages")
+              if ! echo "$VERIFY_PAGES" | jq -e '
+                type == "object" and (.build_type | type == "string" and length > 0)
+              ' >/dev/null; then
+                echo "[FAIL] Pages API returned an invalid verification response"
                 VERIFY_FAILED=true
+              else
+                ACTUAL_BUILD_TYPE=$(echo "$VERIFY_PAGES" | jq -r '.build_type')
+                if [ "$ACTUAL_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
+                  echo "[FAIL] pages.build_type: expected=$DESIRED_BUILD_TYPE actual=$ACTUAL_BUILD_TYPE"
+                  VERIFY_FAILED=true
+                fi
               fi
             fi
           fi

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -107,10 +107,19 @@ jobs:
           }
 
           # Retry with JSON body (for gh api --input - calls)
-          retry_json() {
-            local max="$1"; shift
-            local json="$1"; shift
-            retry "$max" bash -c 'printf "%s" "$0" | gh api "$@" --input -' "$json" "$@"
+          current_json_request() {
+            local json="$1"
+            shift
+            require_current_source_main
+            printf '%s' "$json" | gh api "$@" --input -
+          }
+
+          retry_current_json() {
+            local max="$1"
+            shift
+            local json="$1"
+            shift
+            retry "$max" current_json_request "$json" "$@"
           }
 
           api_value_or_404() {
@@ -347,6 +356,50 @@ jobs:
             rm -f "$api_file" "$decoded_file" "$err_file"
           }
 
+          ensure_current_source_main() {
+            local current_source_sha source_status
+            if ! current_source_sha=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha'); then
+              echo "[ERROR] Could not resolve protected docs-control main" >&2
+              return 1
+            fi
+            if ! printf '%s' "$current_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] Protected docs-control main returned an invalid commit" >&2
+              return 1
+            fi
+            if [ "$expected_source_sha" = "$current_source_sha" ]; then
+              return 0
+            fi
+            if ! source_status=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/compare/${expected_source_sha}...${current_source_sha}" \
+              --jq '.status'); then
+              echo "[ERROR] Could not prove the source receipt is on protected docs-control main" >&2
+              return 1
+            fi
+            if [ "$source_status" != "ahead" ]; then
+              echo "[ERROR] Source receipt is not an approved protected-main commit" >&2
+              return 1
+            fi
+            if ! gh workflow run enforce-repo-settings.yml \
+              --repo "$GITHUB_REPOSITORY" --ref main \
+              -f source_sha="$current_source_sha"; then
+              echo "[ERROR] Could not enqueue the current protected-main receipt" >&2
+              return 1
+            fi
+            echo "[DEFER] Docs-control protected main advanced; enqueued its exact receipt"
+            return 78
+          }
+
+          require_current_source_main() {
+            local receipt_rc=0
+            ensure_current_source_main || receipt_rc=$?
+            case "$receipt_rc" in
+              0) return 0 ;;
+              78) exit 0 ;;
+              *) exit 1 ;;
+            esac
+          }
+
           expected_source_sha="${SOURCE_SHA:-}"
           if [ -z "$expected_source_sha" ] && [ "$EVENT_NAME" != "workflow_call" ]; then
             expected_source_sha="$EVENT_SHA"
@@ -356,35 +409,7 @@ jobs:
             echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
             exit 1
           fi
-          if ! current_source_sha=$(retry 3 gh api \
-            "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha'); then
-            echo "[ERROR] Could not resolve protected docs-control main" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$current_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
-            echo "[ERROR] Protected docs-control main returned an invalid commit" >&2
-            exit 1
-          fi
-          if [ "$expected_source_sha" != "$current_source_sha" ]; then
-            if ! source_status=$(retry 3 gh api \
-              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/compare/${expected_source_sha}...${current_source_sha}" \
-              --jq '.status'); then
-              echo "[ERROR] Could not prove the source receipt is on protected docs-control main" >&2
-              exit 1
-            fi
-            if [ "$source_status" = "ahead" ]; then
-              echo "[DEFER] Historical protected-main receipt; enqueueing current main"
-              if ! gh workflow run enforce-repo-settings.yml \
-                --repo "$GITHUB_REPOSITORY" \
-                -f source_sha="$current_source_sha"; then
-                echo "[ERROR] Could not enqueue the current protected-main receipt" >&2
-                exit 1
-              fi
-              exit 0
-            fi
-            echo "[ERROR] Source receipt is not an approved protected-main commit" >&2
-            exit 1
-          fi
+          require_current_source_main
           echo "[OK] Governed reads bound to source ${expected_source_sha:0:8}"
 
           OWNER="${GITHUB_REPOSITORY_OWNER}"
@@ -453,7 +478,8 @@ jobs:
 
           if [ "$REPO_DRIFT" = true ]; then
             echo "[INFO] Patching repository settings..."
-            retry_json 3 "$REPO_PATCH" "repos/${OWNER}/${REPO}" --method PATCH >/dev/null
+            require_current_source_main
+            retry_current_json 3 "$REPO_PATCH" "repos/${OWNER}/${REPO}" --method PATCH >/dev/null
             echo "[OK] Repository settings updated"
           else
             echo "[OK] Repository settings match -- no changes needed"
@@ -480,7 +506,8 @@ jobs:
 
             if [ "$ACTIONS_DRIFT" = true ]; then
               echo "[INFO] Updating Actions workflow permissions..."
-              retry_json 3 "$DESIRED_ACTIONS" "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
+              require_current_source_main
+              retry_current_json 3 "$DESIRED_ACTIONS" "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
                 --method PUT >/dev/null
               echo "[OK] Actions permissions updated"
             else
@@ -509,7 +536,8 @@ jobs:
             current_policy=$(echo "$CURRENT_FORK_APPROVAL" | jq -r '.approval_policy // empty')
             if [ "$desired_policy" != "$current_policy" ]; then
               echo "[WARN] Drift in fork_pr_approval: current=$current_policy desired=$desired_policy"
-              retry_json 3 "$DESIRED_FORK_APPROVAL" "$FORK_APPROVAL_EP" --method PUT >/dev/null
+              require_current_source_main
+              retry_current_json 3 "$DESIRED_FORK_APPROVAL" "$FORK_APPROVAL_EP" --method PUT >/dev/null
               echo "[OK] Fork-PR approval policy updated to $desired_policy"
             else
               echo "[OK] Fork-PR approval policy matches ($current_policy) -- no changes needed"
@@ -619,7 +647,8 @@ jobs:
                   allow_fork_syncing: $desired.allow_fork_syncing
                 }')
 
-              retry_json 3 "$PUT_PAYLOAD" "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
+              require_current_source_main
+              retry_current_json 3 "$PUT_PAYLOAD" "repos/${OWNER}/${REPO}/branches/${BRANCH}/protection" \
                 --method PUT >/dev/null
               echo "[OK] Branch protection updated for $BRANCH"
             else
@@ -638,7 +667,8 @@ jobs:
               echo "[WARN] Drift in topics: current=$CURRENT_TOPICS desired=$DESIRED_TOPICS"
               echo "[INFO] Updating topics..."
               TOPICS_JSON=$(jq -n --argjson names "$DESIRED_TOPICS" '{"names": $names}')
-              retry_json 3 "$TOPICS_JSON" "repos/${OWNER}/${REPO}/topics" --method PUT >/dev/null
+              require_current_source_main
+              retry_current_json 3 "$TOPICS_JSON" "repos/${OWNER}/${REPO}/topics" --method PUT >/dev/null
               echo "[OK] Topics updated"
             else
               echo "[OK] Topics match -- no changes needed"
@@ -660,7 +690,8 @@ jobs:
               echo "[WARN] Pages status unknown -- skipping Pages phase rather than guessing between create and update"
             elif [ "$PAGES_HTTP_CODE" = "404" ]; then
               echo "[INFO] Enabling GitHub Pages with ${DESIRED_BUILD_TYPE} source..."
-              retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1
+              require_current_source_main
+              retry_current_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method POST >/dev/null 2>&1
               echo "[OK] Pages enabled with build_type=${DESIRED_BUILD_TYPE}"
             else
               PAGES_RESPONSE=$(retry 3 gh api "repos/${OWNER}/${REPO}/pages")
@@ -674,7 +705,8 @@ jobs:
               if [ "$CURRENT_BUILD_TYPE" != "$DESIRED_BUILD_TYPE" ]; then
                 echo "[WARN] Drift in pages.build_type: current=$CURRENT_BUILD_TYPE desired=$DESIRED_BUILD_TYPE"
                 echo "[INFO] Updating Pages build_type to ${DESIRED_BUILD_TYPE}..."
-                retry_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method PUT >/dev/null 2>&1
+                require_current_source_main
+                retry_current_json 3 "$PAGES_JSON" "repos/${OWNER}/${REPO}/pages" --method PUT >/dev/null 2>&1
                 echo "[OK] Pages build_type updated to ${DESIRED_BUILD_TYPE}"
               else
                 echo "[OK] Pages build_type matches (${CURRENT_BUILD_TYPE}) -- no changes needed"
@@ -895,4 +927,5 @@ jobs:
             exit 1
           fi
 
+          require_current_source_main
           echo "[OK] All settings verified successfully"

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,10 +1,12 @@
 ---
 name: Build and Deploy Docs
 on:
-  push:
-    branches: [main]
   workflow_call:
     inputs:
+      content-ref:
+        description: 'Exact 40-character commit SHA to build from the calling repo'
+        required: true
+        type: string
       content-path:
         description: 'Path to content directory in the calling repo'
         required: false
@@ -24,28 +26,6 @@ on:
         required: false
         default: 'https://f5-sales-demo.github.io'
         type: string
-  workflow_dispatch:
-    inputs:
-      content-path:
-        description: 'Path to content directory'
-        required: false
-        default: 'docs'
-        type: string
-      builder-image:
-        description: 'Builder Docker image URI'
-        required: false
-        default: 'ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163'
-        type: string
-      docs-title:
-        description: 'Documentation site title'
-        required: false
-        type: string
-      docs-site:
-        description: 'Documentation site URL'
-        required: false
-        default: 'https://f5-sales-demo.github.io'
-        type: string
-
 permissions: {}
 
 concurrency:
@@ -65,8 +45,51 @@ jobs:
     outputs:
       build-status: ${{ job.status }}
     steps:
+      - name: Resolve immutable content commit
+        id: content
+        env:
+          REQUESTED_REF: ${{ inputs.content-ref }}
+          REQUESTED_IMAGE: ${{ inputs.builder-image }}
+        run: |
+          CONTENT_REF="$REQUESTED_REF"
+          if [[ ! "$CONTENT_REF" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::content-ref must be a full lowercase 40-character commit SHA"
+            exit 1
+          fi
+          BUILDER_IMAGE="$REQUESTED_IMAGE"
+          if [[ ! "$BUILDER_IMAGE" =~ ^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::builder-image must use the approved repository and an immutable SHA-256 digest"
+            exit 1
+          fi
+          echo "content_ref=$CONTENT_REF" >> "$GITHUB_OUTPUT"
+          echo "builder_image=$BUILDER_IMAGE" >> "$GITHUB_OUTPUT"
+
       - name: Checkout content repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.content.outputs.content_ref }}
+
+      - name: Verify checked-out content commit
+        env:
+          CONTENT_REF: ${{ steps.content.outputs.content_ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          if [ "$CHECKED_OUT_SHA" != "$CONTENT_REF" ]; then
+            echo "::error::Checked-out commit does not match content-ref"
+            exit 1
+          fi
+          if [ "$DEFAULT_BRANCH" != "main" ]; then
+            echo "::error::Pages publication requires protected main"
+            exit 1
+          fi
+          git fetch --no-tags origin "+refs/heads/main:refs/remotes/origin/main"
+          PROTECTED_MAIN_SHA=$(git rev-parse refs/remotes/origin/main)
+          if [[ ! "$PROTECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            [ "$PROTECTED_MAIN_SHA" != "$CONTENT_REF" ]; then
+            echo "::error::content-ref is not current protected main"
+            exit 1
+          fi
 
       - name: Login to GHCR
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
@@ -121,7 +144,7 @@ jobs:
             -e DOCS_SITE="${{ inputs.docs-site || format('https://{0}.github.io', github.repository_owner) }}" \
             -e GITHUB_REPOSITORY="${{ github.repository }}" \
             ${{ inputs.docs-title && format('-e DOCS_TITLE="{0}"', inputs.docs-title) || '' }} \
-            ${{ inputs.builder-image || 'ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163' }}
+            ${{ steps.content.outputs.builder_image }}
 
           echo "✅ Build completed successfully"
           ls -lah ${{ runner.temp }}/docs-output/
@@ -140,6 +163,9 @@ jobs:
           find "$OUTPUT_DIR" -type f | head -20
 
       - name: Stage governance assets for /api/
+        env:
+          CONTENT_REF: ${{ steps.content.outputs.content_ref }}
+          BUILDER_IMAGE: ${{ steps.content.outputs.builder_image }}
         run: |
           OUTPUT_DIR="${{ runner.temp }}/docs-output"
           API_DIR="${OUTPUT_DIR}/api"
@@ -171,11 +197,13 @@ jobs:
             done
           fi
 
-          # Revision marker — lets downstreams detect Pages deploy lag
+          # Deterministic publication identity: requested and resolved content.
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
           jq -n \
-            --arg commit "${GITHUB_SHA}" \
-            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{commit:$commit, generated_at:$generated_at}' \
+            --arg content_ref "${CONTENT_REF}" \
+            --arg commit "${CHECKED_OUT_SHA}" \
+            --arg builder_image "${BUILDER_IMAGE}" \
+            '{content_ref:$content_ref, commit:$commit, builder_image:$builder_image}' \
             > "${API_DIR}/revision.json"
           echo "Published: /api/revision.json"
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -460,6 +460,14 @@ jobs:
         if: hashFiles('tests/test-source-receipt-ordering.sh') != ''
         run: bash tests/test-source-receipt-ordering.sh
 
+      - name: Run source mutation guard test
+        if: hashFiles('tests/test-source-mutation-guard.sh') != ''
+        run: bash tests/test-source-mutation-guard.sh
+
+      - name: Run downstream sync receipt test
+        if: hashFiles('tests/test-sync-downstream-receipt.sh') != ''
+        run: bash tests/test-sync-downstream-receipt.sh
+
       - name: Run check-review-deps test
         if: hashFiles('tests/test-check-review-deps.sh') != ''
         run: bash tests/test-check-review-deps.sh

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -8,6 +8,10 @@ on:
         description: 'Exact docs-control commit receipt for every governed read.'
         required: true
         type: string
+      downstream_sha:
+        description: 'Exact protected-main commit receipt for the calling repository.'
+        required: true
+        type: string
     secrets:
       repo-sync-token:
         description: 'PAT with contents, issues, and pull-request permissions for file sync'
@@ -26,12 +30,15 @@ jobs:
     steps:
       - name: Checkout calling repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.downstream_sha }}
 
       - name: Sync managed files
         env:
           GH_TOKEN: ${{ secrets.repo-sync-token }}
           REPO_SETTINGS_TOKEN: ${{ secrets.repo-settings-token }}
           SOURCE_SHA: ${{ inputs.source_sha }}
+          DOWNSTREAM_SHA: ${{ inputs.downstream_sha }}
         run: |
           set -euo pipefail
 
@@ -92,11 +99,20 @@ jobs:
             done
           }
 
-          # Retry with JSON body (for gh api --input - calls)
-          retry_json() {
-            local max="$1"; shift
-            local json="$1"; shift
-            retry "$max" bash -c 'printf "%s" "$0" | gh api "$@" --input -' "$json" "$@"
+          current_json_request() {
+            local json="$1"
+            shift
+            require_current_source_main
+            require_current_downstream_main
+            printf '%s' "$json" | gh api "$@" --input -
+          }
+
+          retry_current_json() {
+            local max="$1"
+            shift
+            local json="$1"
+            shift
+            retry "$max" current_json_request "$json" "$@"
           }
 
           api_value_or_404() {
@@ -199,43 +215,115 @@ jobs:
             mv "$temp_file" "$output_file"
           }
 
+          require_sha() {
+            local label="$1" value="$2"
+            if ! printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] ${label} is not a commit SHA" >&2
+              return 1
+            fi
+          }
+
+          ensure_current_source_main() {
+            local current_source_sha source_status
+            if ! current_source_sha=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha'); then
+              echo "[ERROR] Could not resolve protected docs-control main" >&2
+              return 1
+            fi
+            require_sha "protected docs-control main" "$current_source_sha" || return 1
+            if [ "$expected_source_sha" = "$current_source_sha" ]; then
+              return 0
+            fi
+            if ! source_status=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/compare/${expected_source_sha}...${current_source_sha}" \
+              --jq '.status'); then
+              echo "[ERROR] Could not prove the source receipt is on protected docs-control main" >&2
+              return 1
+            fi
+            if [ "$source_status" != "ahead" ]; then
+              echo "[ERROR] Source receipt is not an approved protected-main commit" >&2
+              return 1
+            fi
+            if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh workflow run \
+              enforce-repo-settings.yml --repo "$GITHUB_REPOSITORY" --ref main \
+              -f source_sha="$current_source_sha"; then
+              echo "[ERROR] Could not enqueue the current protected-main receipt" >&2
+              return 1
+            fi
+            echo "[DEFER] Docs-control protected main advanced; enqueued its exact receipt"
+            return 78
+          }
+
+          require_current_source_main() {
+            local receipt_rc=0
+            ensure_current_source_main || receipt_rc=$?
+            case "$receipt_rc" in
+              0) return 0 ;;
+              78) exit 0 ;;
+              *) exit 1 ;;
+            esac
+          }
+
+          ensure_current_downstream_main() {
+            local current_downstream_sha downstream_status
+            if ! current_downstream_sha=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha'); then
+              echo "[ERROR] Could not resolve downstream protected main" >&2
+              return 1
+            fi
+            require_sha "downstream protected main" "$current_downstream_sha" || return 1
+            if [ "$expected_downstream_sha" = "$current_downstream_sha" ]; then
+              return 0
+            fi
+            if ! downstream_status=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${expected_downstream_sha}...${current_downstream_sha}" \
+              --jq '.status'); then
+              echo "[ERROR] Could not prove the downstream receipt is on protected main" >&2
+              return 1
+            fi
+            if [ "$downstream_status" != "ahead" ]; then
+              echo "[ERROR] Downstream receipt is not an approved protected-main commit" >&2
+              return 1
+            fi
+            if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh workflow run \
+              enforce-repo-settings.yml --repo "$GITHUB_REPOSITORY" --ref main \
+              -f source_sha="$expected_source_sha"; then
+              echo "[ERROR] Could not enqueue current downstream protected main" >&2
+              return 1
+            fi
+            echo "[DEFER] Downstream protected main advanced; enqueued the exact current caller"
+            return 78
+          }
+
+          require_current_downstream_main() {
+            local receipt_rc=0
+            ensure_current_downstream_main || receipt_rc=$?
+            case "$receipt_rc" in
+              0) return 0 ;;
+              78) exit 0 ;;
+              *) exit 1 ;;
+            esac
+          }
+
           expected_source_sha="${SOURCE_SHA:-}"
+          expected_downstream_sha="${DOWNSTREAM_SHA:-}"
 
           if ! printf '%s' "$expected_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
             echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
             exit 1
           fi
-          if ! current_source_sha=$(retry 3 gh api \
-            "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha'); then
-            echo "[ERROR] Could not resolve protected docs-control main" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$current_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
-            echo "[ERROR] Protected docs-control main returned an invalid commit" >&2
-            exit 1
-          fi
-          if [ "$expected_source_sha" != "$current_source_sha" ]; then
-            if ! source_status=$(retry 3 gh api \
-              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/compare/${expected_source_sha}...${current_source_sha}" \
-              --jq '.status'); then
-              echo "[ERROR] Could not prove the source receipt is on protected docs-control main" >&2
-              exit 1
-            fi
-            if [ "$source_status" = "ahead" ]; then
-              echo "[DEFER] Historical protected-main receipt; enqueueing current main"
-              if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh workflow run \
-                enforce-repo-settings.yml \
-                --repo "$GITHUB_REPOSITORY" \
-                -f source_sha="$current_source_sha"; then
-                echo "[ERROR] Could not enqueue the current protected-main receipt" >&2
-                exit 1
-              fi
-              exit 0
-            fi
-            echo "[ERROR] Source receipt is not an approved protected-main commit" >&2
-            exit 1
-          fi
+          require_current_source_main
           echo "[OK] Governed reads bound to source ${expected_source_sha:0:8}"
+
+          require_sha "expected downstream receipt" "$expected_downstream_sha"
+          CHECKED_OUT_SHA=$(git rev-parse HEAD)
+          require_sha "checked-out downstream receipt" "$CHECKED_OUT_SHA"
+          if [ "$CHECKED_OUT_SHA" != "$expected_downstream_sha" ]; then
+            echo "[ERROR] Downstream checkout does not match its exact receipt" >&2
+            exit 1
+          fi
+          require_current_downstream_main
+          echo "[OK] Downstream reads bound to protected main ${expected_downstream_sha:0:8}"
 
           OWNER="${GITHUB_REPOSITORY_OWNER}"
           REPO="${GITHUB_REPOSITORY#*/}"
@@ -247,14 +335,6 @@ jobs:
             exit 1
           fi
           SYNC_BRANCH="governance/sync-managed-files-${expected_source_sha:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-
-          require_sha() {
-            local label="$1" value="$2"
-            if ! printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$'; then
-              echo "[ERROR] ${label} is not a commit SHA" >&2
-              return 1
-            fi
-          }
 
           read_sync_prs() {
             local destination="$1"
@@ -395,29 +475,28 @@ jobs:
             '
           }
 
-          # --- Helper: enable auto-merge (replaces polling) -----------------
+          # --- Helper: merge only while both receipts remain current --------
           auto_merge() {
             local pr_num="$1"
             local repo_slug="$2"
             local expected_sha="$3"
             require_sha "expected auto-merge head" "$expected_sha" || return 1
 
-            echo "[INFO] Enabling auto-merge for PR #${pr_num}..."
-
-            if gh pr merge "${pr_num}" --repo "${repo_slug}" --auto --squash \
-              --delete-branch --match-head-commit "$expected_sha" 2>/dev/null; then
-              echo "[OK] Auto-merge enabled for PR #${pr_num} -- will merge when checks pass"
-              return 0
-            fi
-
-            echo "[WARN] Auto-merge not available for ${repo_slug} -- falling back to poll-and-merge"
+            echo "[INFO] Waiting to merge PR #${pr_num} while exact receipts remain current..."
+            require_current_source_main
+            require_current_downstream_main
             local elapsed=0
-            local max_wait=300
+            # api-specs-enriched's required pytest context is measured at
+            # 13:47. Allow a full hour so a healthy slow fleet check converges
+            # instead of timing out, replacing its PR, and restarting CI.
+            local max_wait=3600
             local poll_interval=60
 
             while [ "$elapsed" -lt "$max_wait" ]; do
               sleep "$poll_interval"
               elapsed=$((elapsed + poll_interval))
+              require_current_source_main
+              require_current_downstream_main
 
               BUCKET=$(gh pr checks "${pr_num}" --repo "${repo_slug}" \
                 --json bucket --jq '[.[].bucket] | unique |
@@ -426,12 +505,15 @@ jobs:
                   else "pending" end' 2>/dev/null) || BUCKET="pending"
 
               if [ "$BUCKET" = "pass" ]; then
+                retry 3 assert_sync_pr_head "$pr_num" "$SYNC_BRANCH" "$expected_sha"
+                require_current_source_main
+                require_current_downstream_main
                 if gh pr merge "${pr_num}" --repo "${repo_slug}" --squash \
                   --delete-branch --match-head-commit "$expected_sha" 2>/dev/null; then
                   echo "[OK] Merged sync PR #${pr_num}"
                   return 0
                 fi
-                echo "[WARN] Failed to merge PR #${pr_num} -- may need manual merge"
+                echo "[ERROR] Failed to merge exact sync PR #${pr_num}" >&2
                 return 1
               elif [ "$BUCKET" = "fail" ]; then
                 echo "[WARN] CI checks failed on PR #${pr_num} -- skipping merge"
@@ -439,7 +521,7 @@ jobs:
               fi
             done
 
-            echo "[WARN] Timed out waiting for CI on PR #${pr_num} -- skipping merge"
+            echo "[ERROR] Timed out waiting for CI on exact sync PR #${pr_num}" >&2
             return 1
           }
 
@@ -573,7 +655,9 @@ jobs:
 
             local ref_update
             ref_update=$(jq -n --arg sha "$new_commit_sha" '{"sha": $sha}')
-            retry_json 3 "$ref_update" "repos/${repo_slug}/git/refs/heads/${branch}" --method PATCH >/dev/null
+            require_current_source_main
+            require_current_downstream_main
+            retry_current_json 3 "$ref_update" "repos/${repo_slug}/git/refs/heads/${branch}" --method PATCH >/dev/null
 
             rm -r "$payload_dir"
             LAST_COMMIT_SHA="$new_commit_sha"
@@ -997,6 +1081,12 @@ jobs:
                 fi
               fi
 
+              # The reusable jobs run independently. Re-prove the exact
+              # downstream receipt after every local comparison and before a
+              # clean result or any issue, branch, or PR mutation.
+              require_current_source_main
+              require_current_downstream_main
+
               if [ "$DRIFT_COUNT" -eq 0 ]; then
                 echo "[OK] All managed files match canonical"
               else
@@ -1016,6 +1106,8 @@ jobs:
                 if [ -n "$EXISTING_PR" ]; then
                   retry 3 assert_sync_pr_head \
                     "$EXISTING_PR" "$EXISTING_BRANCH" "$EXISTING_HEAD"
+                  require_current_source_main
+                  require_current_downstream_main
                   gh pr close "$EXISTING_PR" --repo "${OWNER}/${REPO}" \
                     --comment "Superseded by exact managed-file receipt ${expected_source_sha:0:12} on run-owned branch ${SYNC_BRANCH}."
                   echo "[OK] Closed superseded sync PR #${EXISTING_PR} without deleting its branch"
@@ -1038,6 +1130,8 @@ jobs:
                 fi
                 rm -f "$STALE_ISSUE_INVENTORY"
                 for stale_num in $STALE_ISSUES; do
+                  require_current_source_main
+                  require_current_downstream_main
                   gh issue close "$stale_num" --repo "${OWNER}/${REPO}" \
                     --comment "Superseded by exact managed-file receipt ${expected_source_sha:0:12}."
                   echo "[OK] Closed stale owned sync issue #${stale_num}"
@@ -1046,6 +1140,8 @@ jobs:
                 DRIFT_LIST=$(printf '%b' "$DRIFT_FILES" | sed '/^$/d' | sed 's/^/- /')
                 ISSUE_BODY=$(printf 'The following managed files have drifted from the canonical source in `%s`:\n\n%s\n\nThis issue was created automatically by the governance enforcement workflow.' \
                   "$SOURCE_REPO" "$DRIFT_LIST")
+                require_current_source_main
+                require_current_downstream_main
                 ISSUE_NUM=$(gh issue create --repo "${OWNER}/${REPO}" \
                   --title "chore: sync managed files from governance template" \
                   --body "$ISSUE_BODY" | grep -o '[0-9]*$')
@@ -1057,8 +1153,7 @@ jobs:
 
                 # The run-owned branch must be absent. Never move or reuse an
                 # unproved ref, even if an earlier attempt used the same name.
-                MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
-                require_sha "protected main" "$MAIN_SHA"
+                MAIN_SHA="$expected_downstream_sha"
                 set +e
                 EXISTING_BRANCH_SHA=$(api_value_or_404 \
                   "repos/${OWNER}/${REPO}/git/ref/heads/${SYNC_BRANCH}" \
@@ -1074,7 +1169,9 @@ jobs:
                   44)
                     BRANCH_CREATE_JSON=$(jq -n --arg sha "$MAIN_SHA" --arg branch "$SYNC_BRANCH" \
                       '{"ref":("refs/heads/" + $branch),"sha":$sha}')
-                    retry_json 3 "$BRANCH_CREATE_JSON" \
+                    require_current_source_main
+                    require_current_downstream_main
+                    retry_current_json 3 "$BRANCH_CREATE_JSON" \
                       "repos/${OWNER}/${REPO}/git/refs" --method POST >/dev/null
                     ;;
                   *) exit 1 ;;
@@ -1086,6 +1183,8 @@ jobs:
 
                 PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \
                   "$ISSUE_NUM" "$SOURCE_REPO" "$DRIFT_LIST")
+                require_current_source_main
+                require_current_downstream_main
                 PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
                   --base main --head "$SYNC_BRANCH" \
                   --title "chore: sync managed files from governance template" \
@@ -1107,6 +1206,9 @@ jobs:
           # --- Phase 3: Verify --------------------------------------------------
           echo ""
           echo "=== Phase 3: Verify ==="
+
+          require_current_source_main
+          require_current_downstream_main
 
           if [ -n "$MANAGED_FILES" ] && [ "${OWNER}/${REPO}" != "$SOURCE_REPO" ]; then
             if [ "$SYNC_PR_CREATED" = true ]; then

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -5,13 +5,15 @@ on:
   workflow_call:
     inputs:
       source_sha:
-        description: 'Commit SHA of the docs-control push that triggered this run.'
-        required: false
+        description: 'Exact docs-control commit receipt for every governed read.'
+        required: true
         type: string
-        default: ''
     secrets:
       repo-sync-token:
         description: 'PAT with contents, issues, and pull-request permissions for file sync'
+        required: true
+      repo-settings-token:
+        description: 'PAT used to enqueue the current protected-main receipt'
         required: true
 
 concurrency:
@@ -28,6 +30,7 @@ jobs:
       - name: Sync managed files
         env:
           GH_TOKEN: ${{ secrets.repo-sync-token }}
+          REPO_SETTINGS_TOKEN: ${{ secrets.repo-settings-token }}
           SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
@@ -96,96 +99,313 @@ jobs:
             retry "$max" bash -c 'printf "%s" "$0" | gh api "$@" --input -' "$json" "$@"
           }
 
-          # --- Pages-first fetch helper (canonical: tests/fixtures/fetch-governed.sh) ---
-          PAGES_BASE="https://${GITHUB_REPOSITORY_OWNER}.github.io/docs-control"
-
-          fetch_governed() {
-            local key="$1" fallback="$2" body err_file
-            local url="${PAGES_BASE}/api/${key}"
-
-            body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
-            if [ -n "$body" ]; then
-              printf '%s' "$body"
+          api_value_or_404() {
+            local endpoint="$1" jq_filter="$2"
+            local out_file err_file rc value
+            out_file=$(mktemp)
+            err_file=$(mktemp)
+            set +e
+            gh api "$endpoint" --jq "$jq_filter" >"$out_file" 2>"$err_file"
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              value=$(cat "$out_file")
+              rm -f "$out_file" "$err_file"
+              if [ -z "$value" ]; then
+                echo "[ERROR] GitHub API returned an empty value for ${endpoint}" >&2
+                return 1
+              fi
+              printf '%s' "$value"
               return 0
             fi
+            if grep -qE '\(HTTP 404\)$' "$err_file"; then
+              rm -f "$out_file" "$err_file"
+              return 44
+            fi
+            echo "[ERROR] GitHub API read failed closed for ${endpoint}" >&2
+            sed -E 's/(Request-Id:).*/\1 [redacted]/I' "$err_file" >&2
+            rm -f "$out_file" "$err_file"
+            return 1
+          }
 
-            echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
+          # --- Exact-receipt fetch helper (canonical: tests/fixtures/fetch-governed.sh) ---
+          fetch_governed() {
+            local key="$1" fallback="$2" api_file decoded_file err_file
+            local receipt_sha receipt_size decoded_sha decoded_size
+
+            if ! printf '%s' "${expected_source_sha:-}" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
+              return 1
+            fi
+            if [[ "$fallback" == *[?#]* ]]; then
+              echo "[ERROR] Governed API path already contains a query or fragment for ${key}" >&2
+              return 1
+            fi
+
+            api_file=$(mktemp)
+            decoded_file=$(mktemp)
             err_file=$(mktemp)
-            if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+            if ! retry 3 gh api "${fallback}?ref=${expected_source_sha}" >"$api_file" 2>"$err_file"; then
               echo "[ERROR] gh api failed for ${key}:" >&2
               cat "$err_file" >&2
-              rm -f "$err_file"
+              rm -f "$api_file" "$decoded_file" "$err_file"
               return 1
             fi
-            rm -f "$err_file"
-            if [ -z "$body" ]; then
-              echo "[ERROR] gh api returned empty body for ${key}" >&2
+            if ! jq -e '
+              .type == "file" and .encoding == "base64" and
+              (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+              (.size | type == "number" and floor == . and . >= 0) and
+              (.content | type == "string") and
+              (.size == 0 or (.content | length > 0))
+            ' "$api_file" >/dev/null 2>&1; then
+              echo "[ERROR] gh api returned an invalid content envelope for ${key}" >&2
+              rm -f "$api_file" "$decoded_file" "$err_file"
               return 1
             fi
-
-            printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
+            if ! jq -r '.content' "$api_file" | tr -d '\n' | base64 -d >"$decoded_file"; then
+              echo "[ERROR] gh api returned invalid base64 content for ${key}" >&2
+              rm -f "$api_file" "$decoded_file" "$err_file"
+              return 1
+            fi
+            receipt_sha=$(jq -r '.sha' "$api_file")
+            receipt_size=$(jq -r '.size' "$api_file")
+            decoded_sha=$(git hash-object "$decoded_file")
+            decoded_size=$(wc -c <"$decoded_file" | tr -d ' ')
+            if [ "$decoded_sha" != "$receipt_sha" ] || [ "$decoded_size" != "$receipt_size" ]; then
+              echo "[ERROR] Decoded bytes do not match the content receipt for ${key}" >&2
+              rm -f "$api_file" "$decoded_file" "$err_file"
+              return 1
+            fi
+            cat "$decoded_file"
+            rm -f "$api_file" "$decoded_file" "$err_file"
           }
 
-          # Freshness of the Pages-published governance mirror. When a source_sha is
-          # supplied (dispatch from a docs-control push) we require an EXACT match.
-          # Otherwise (schedule / manual workflow_dispatch, where source_sha is
-          # empty) we compare Pages' own revision marker against docs-control's live
-          # main HEAD — see expected_source_sha below.
-          revision_is_fresh() {
-            local source_sha="${1:-}" rev pages_sha
-            [ -z "$source_sha" ] && return 1
-
-            rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
-              "${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
-            [ -z "$rev" ] && return 1
-
-            pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
-            [ "$pages_sha" = "$source_sha" ]
+          cache_managed_content() {
+            local label="$1" api_path="$2" expected_sha="$3" expected_size="$4" output_file="$5"
+            local temp_file canonical_sha canonical_size
+            temp_file=$(mktemp)
+            if ! fetch_governed "$label" "$api_path" >"$temp_file"; then
+              echo "[ERROR] Could not fetch required canonical content: ${api_path}" >&2
+              rm -f "$temp_file"
+              return 1
+            fi
+            canonical_sha=$(git hash-object "$temp_file")
+            canonical_size=$(wc -c <"$temp_file" | tr -d ' ')
+            if [ "$canonical_sha" != "$expected_sha" ] || [ "$canonical_size" != "$expected_size" ]; then
+              echo "[ERROR] Canonical blob mismatch for ${api_path}" >&2
+              rm -f "$temp_file"
+              return 1
+            fi
+            mv "$temp_file" "$output_file"
           }
 
-          # The sha the Pages mirror must have published for governed reads to be
-          # trustworthy. Prefer the dispatching push's sha; when absent, fall back
-          # to docs-control's current main HEAD.
-          #
-          # WHY this must not be conditional on SOURCE_SHA: `fetch_governed` prefers
-          # the Pages mirror, and Pages lags a merge by however long its deploy
-          # takes. Previously the staleness check ran ONLY when SOURCE_SHA was
-          # non-empty, so schedule/manual runs (source_sha empty) silently read a
-          # STALE manifest. Drift detection then compared downstream files against
-          # OLD canonical SHAs, matched them, and reported "[OK] All managed files
-          # match canonical" — so governance changes never propagated and no sync PR
-          # was opened. Observed: a run read a manifest from a 1-day-old commit and
-          # passed four caller templates that had genuinely drifted.
           expected_source_sha="${SOURCE_SHA:-}"
-          if [ -z "$expected_source_sha" ]; then
-            expected_source_sha=$(retry 3 gh api \
-              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha' 2>/dev/null || echo "")
-          fi
 
-          if [ -z "$expected_source_sha" ]; then
-            echo "[WARN] Could not determine docs-control main HEAD — using API for governed reads" >&2
-            PAGES_BASE="https://invalid.pages.local"
-          elif ! revision_is_fresh "$expected_source_sha"; then
-            echo "[WARN] Pages revision lags source ${expected_source_sha:0:8} — this run will fall back to API for governed reads" >&2
-            # Force fallback by making Pages calls error.
-            PAGES_BASE="https://invalid.pages.local"
-          else
-            echo "[OK] Pages governance mirror is fresh at ${expected_source_sha:0:8}"
+          if ! printf '%s' "$expected_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
+            exit 1
           fi
+          if ! current_source_sha=$(retry 3 gh api \
+            "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/commits/main" --jq '.sha'); then
+            echo "[ERROR] Could not resolve protected docs-control main" >&2
+            exit 1
+          fi
+          if ! printf '%s' "$current_source_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "[ERROR] Protected docs-control main returned an invalid commit" >&2
+            exit 1
+          fi
+          if [ "$expected_source_sha" != "$current_source_sha" ]; then
+            if ! source_status=$(retry 3 gh api \
+              "repos/${GITHUB_REPOSITORY_OWNER}/docs-control/compare/${expected_source_sha}...${current_source_sha}" \
+              --jq '.status'); then
+              echo "[ERROR] Could not prove the source receipt is on protected docs-control main" >&2
+              exit 1
+            fi
+            if [ "$source_status" = "ahead" ]; then
+              echo "[DEFER] Historical protected-main receipt; enqueueing current main"
+              if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh workflow run \
+                enforce-repo-settings.yml \
+                --repo "$GITHUB_REPOSITORY" \
+                -f source_sha="$current_source_sha"; then
+                echo "[ERROR] Could not enqueue the current protected-main receipt" >&2
+                exit 1
+              fi
+              exit 0
+            fi
+            echo "[ERROR] Source receipt is not an approved protected-main commit" >&2
+            exit 1
+          fi
+          echo "[OK] Governed reads bound to source ${expected_source_sha:0:8}"
 
           OWNER="${GITHUB_REPOSITORY_OWNER}"
           REPO="${GITHUB_REPOSITORY#*/}"
           CONFIG_REPO="${GITHUB_REPOSITORY_OWNER}/docs-control"
           CONFIG_PATH=".github/config/repo-settings.json"
+          if ! printf '%s\n%s\n' "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" |
+            awk '/^[1-9][0-9]*$/ { valid++ } END { exit valid != 2 }'; then
+            echo "[ERROR] Workflow run ownership identifiers are invalid" >&2
+            exit 1
+          fi
+          SYNC_BRANCH="governance/sync-managed-files-${expected_source_sha:0:12}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          require_sha() {
+            local label="$1" value="$2"
+            if ! printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] ${label} is not a commit SHA" >&2
+              return 1
+            fi
+          }
+
+          read_sync_prs() {
+            local destination="$1"
+            if ! gh api "repos/${OWNER}/${REPO}/pulls?state=open&per_page=100" \
+              --paginate --slurp >"$destination"; then
+              echo "[ERROR] Could not inventory open sync PRs" >&2
+              return 1
+            fi
+            if ! jq -e --arg prefix 'governance/sync-managed-files' '
+              type == "array" and all(.[]; type == "array") and
+              all(.[][] | select(.head.ref | startswith($prefix));
+                (.number | type == "number" and floor == . and . >= 1) and
+                (.head.ref | type == "string" and
+                  test("^governance/sync-managed-files(-[0-9a-f]{12}-[1-9][0-9]*-[1-9][0-9]*)?$")) and
+                (.head.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.head.repo.full_name | type == "string") and
+                (.base.ref | type == "string"))
+            ' "$destination" >/dev/null; then
+              echo "[ERROR] Open sync PR inventory is invalid" >&2
+              return 1
+            fi
+          }
+
+          select_owned_sync_pr() {
+            local inventory="$1" count row pr_num pr_repo pr_base pr_branch pr_head
+            count=$(jq '
+              [.[][] | select(.head.ref | startswith("governance/sync-managed-files"))] | length
+            ' "$inventory")
+            case "$count" in
+              0) return 0 ;;
+              1)
+                row=$(jq -r '
+                  .[][] | select(.head.ref | startswith("governance/sync-managed-files")) |
+                  [.number, .head.repo.full_name, .base.ref, .head.ref, .head.sha] | @tsv
+                ' "$inventory")
+                IFS=$'\t' read -r pr_num pr_repo pr_base pr_branch pr_head <<<"$row"
+                if [ "$pr_repo" != "${OWNER}/${REPO}" ] || [ "$pr_base" != "main" ]; then
+                  echo "[ERROR] Open sync PR is not owned by protected ${OWNER}/${REPO} main" >&2
+                  return 1
+                fi
+                printf '%s\t%s\t%s\n' "$pr_num" "$pr_branch" "$pr_head"
+                ;;
+              *)
+                echo "[ERROR] Multiple open sync PRs claim governance/sync-managed-files" >&2
+                return 1
+                ;;
+            esac
+          }
+
+          assert_sync_pr_head() {
+            local pr_num="$1" expected_branch="$2" expected_sha="$3" response
+            if ! printf '%s' "$pr_num" | grep -qE '^[1-9][0-9]*$'; then
+              echo "[ERROR] Invalid sync PR number" >&2
+              return 1
+            fi
+            if ! printf '%s' "$expected_branch" |
+              grep -qE '^governance/sync-managed-files(-[0-9a-f]{12}-[1-9][0-9]*-[1-9][0-9]*)?$'; then
+              echo "[ERROR] Invalid sync PR branch" >&2
+              return 1
+            fi
+            require_sha "expected sync PR head" "$expected_sha" || return 1
+            response=$(gh api "repos/${OWNER}/${REPO}/pulls/${pr_num}")
+            if ! echo "$response" | jq -e \
+              --arg repo "${OWNER}/${REPO}" \
+              --arg branch "$expected_branch" \
+              --arg sha "$expected_sha" '
+                .state == "open" and
+                .head.repo.full_name == $repo and
+                .head.ref == $branch and
+                .head.sha == $sha and
+                .base.ref == "main"
+              ' >/dev/null; then
+              echo "[ERROR] Sync PR ownership or exact head changed before auto-merge" >&2
+              return 1
+            fi
+          }
+
+          managed_cache_path() {
+            local dest_file="$1" cache_key
+            cache_key=$(printf '%s' "$dest_file" | git hash-object --stdin)
+            require_sha "managed cache key" "$cache_key" || return 1
+            printf '/tmp/drift_content/%s' "$cache_key"
+          }
+
+          validate_managed_routing() {
+            jq -e '
+              type == "object" and
+              (.source_repo | type == "string" and length > 0) and
+              (.files | type == "array" and length > 0) and
+              all(.files[];
+                (.src | type == "string" and length > 0) and
+                (.dest | type == "string" and length > 0) and
+                ((has("only_repos") | not) or
+                  (.only_repos | type == "array" and
+                    all(.[]; type == "string" and test("^[A-Za-z0-9_.-]+$")) and
+                    length == (unique | length)))) and
+              (.skip_files | type == "object") and
+              all(.skip_files | to_entries[];
+                (.key | test("^[A-Za-z0-9_.-]+$")) and
+                (.value | type == "array" and
+                  all(.[]; type == "string" and length > 0) and
+                  length == (unique | length)))
+            ' >/dev/null
+          }
+
+          validate_docs_sites() {
+            jq -e --arg owner "$OWNER" '
+              type == "array" and
+              all(.[];
+                (.label | type == "string" and length > 0) and
+                (.description | type == "string" and length > 0) and
+                (.url | type == "string" and
+                  test("^https://" + $owner + "\\.github\\.io/[A-Za-z0-9_.-]+/llms-full\\.txt$")) and
+                ((has("badges") | not) or
+                  (.badges | type == "array" and
+                    all(.[]; (.name | type == "string" and length > 0) and
+                      (.workflow | type == "string" and test("^[A-Za-z0-9_.-]+\\.ya?ml$"))))) and
+                ((has("readme_english_only") | not) or
+                  (.readme_english_only | type == "boolean")) and
+                ((has("readme_content") | not) or
+                  (.readme_content | type == "string"))) and
+              ([.[].url] | length == (unique | length))
+            ' >/dev/null
+          }
+
+          select_owned_stale_issues() {
+            jq -r '
+              if type != "array" or
+                any(.[]; (.number | type != "number" or floor != . or . < 1) or
+                  (.title | type != "string") or (.body | type != "string"))
+              then error("invalid issue inventory")
+              else
+                .[] |
+                select(.title == "chore: sync managed files from governance template") |
+                select(.body | contains("This issue was created automatically by the governance enforcement workflow.")) |
+                .number
+              end
+            '
+          }
 
           # --- Helper: enable auto-merge (replaces polling) -----------------
           auto_merge() {
             local pr_num="$1"
             local repo_slug="$2"
+            local expected_sha="$3"
+            require_sha "expected auto-merge head" "$expected_sha" || return 1
 
             echo "[INFO] Enabling auto-merge for PR #${pr_num}..."
 
-            if gh pr merge "${pr_num}" --repo "${repo_slug}" --auto --squash --delete-branch 2>/dev/null; then
+            if gh pr merge "${pr_num}" --repo "${repo_slug}" --auto --squash \
+              --delete-branch --match-head-commit "$expected_sha" 2>/dev/null; then
               echo "[OK] Auto-merge enabled for PR #${pr_num} -- will merge when checks pass"
               return 0
             fi
@@ -206,7 +426,8 @@ jobs:
                   else "pending" end' 2>/dev/null) || BUCKET="pending"
 
               if [ "$BUCKET" = "pass" ]; then
-                if gh pr merge "${pr_num}" --repo "${repo_slug}" --squash --delete-branch 2>/dev/null; then
+                if gh pr merge "${pr_num}" --repo "${repo_slug}" --squash \
+                  --delete-branch --match-head-commit "$expected_sha" 2>/dev/null; then
                   echo "[OK] Merged sync PR #${pr_num}"
                   return 0
                 fi
@@ -236,8 +457,13 @@ jobs:
           append_tree_item() {
             local tree_items_file="$1"
             local dest_file="$2"
-            local content_file="$3"
+            local file_mode="$3"
+            local content_file="$4"
             local next_items_file
+            if ! printf '%s' "$file_mode" | grep -qE '^100(644|755)$'; then
+              echo "[ERROR] Invalid Git mode for ${dest_file}: ${file_mode}" >&2
+              return 1
+            fi
             next_items_file=$(mktemp "${tree_items_file}.next.XXXXXX")
 
             # Both the existing tree and managed content are unbounded payloads.
@@ -245,8 +471,9 @@ jobs:
             # smaller per-argument MAX_ARG_STRLEN limit.
             if ! jq \
               --arg path "$dest_file" \
+              --arg mode "$file_mode" \
               --rawfile content "$content_file" \
-              '. + [{"path": $path, "mode": "100644", "type": "blob", "content": $content}]' \
+              '. + [{"path": $path, "mode": $mode, "type": "blob", "content": $content}]' \
               "$tree_items_file" >"$next_items_file"; then
               rm -f "$next_items_file"
               return 1
@@ -269,31 +496,10 @@ jobs:
           commit_tree() {
             local branch="$1"
             local commit_msg="$2"
-            # Optional base commit. When given, the new commit is parented on it and the
-            # branch ref is force-moved -- which rebases the branch and adds the drift in a
-            # SINGLE ref update. Doing those as two calls empties the PR in between: the
-            # branch briefly equals main, so it has zero commits ahead of base and GitHub
-            # closes it and disables auto-merge (#836).
-            local base_override="${3:-}"
             local repo_slug="${OWNER}/${REPO}"
 
-            # Never interpolate a non-SHA into a URL: that is what turned a transient
-            # 404 into three attempts against an unresolvable request (issue #805).
-            require_sha() {
-              local label="$1" value="$2"
-              if ! printf '%s' "$value" | grep -qE '^[0-9a-f]{40}$'; then
-                echo "[ERROR] ${label} is not a commit SHA: ${value}" >&2
-                return 1
-              fi
-            }
-
-            local ref_sha force_update="false"
-            if [ -n "$base_override" ]; then
-              ref_sha="$base_override"
-              force_update="true"
-            else
-              ref_sha=$(retry 3 gh api "repos/${repo_slug}/git/ref/heads/${branch}" --jq '.object.sha')
-            fi
+            local ref_sha
+            ref_sha=$(retry 3 gh api "repos/${repo_slug}/git/ref/heads/${branch}" --jq '.object.sha')
             require_sha "ref_sha for ${branch}" "$ref_sha" || return 1
 
             local base_tree
@@ -308,25 +514,38 @@ jobs:
             local item_index=0
             for dest_file in $(printf '%b' "$DRIFT_FILES" | sed '/^$/d'); do
               local source_file=""
-              local normalized_file
-              local key
-              key=$(echo "$dest_file" | tr '/' '__')
+              local content_file
+              local file_mode
 
               if [ "$dest_file" = ".github/dependabot.yml" ] && [ "$DEPENDABOT_DRIFT" = true ]; then
                 source_file="/tmp/generated_dependabot.yml"
+                item_index=$((item_index + 1))
+                content_file="${payload_dir}/content-${item_index}"
+                normalize_tree_content "$source_file" "$content_file"
+                file_mode=100644
               elif [ "$dest_file" = "README.md" ] && [ "$README_DRIFT" = true ]; then
                 source_file="/tmp/generated_readme.md"
-              elif [ -f "/tmp/drift_content/${key}" ]; then
-                source_file="/tmp/drift_content/${key}"
+                item_index=$((item_index + 1))
+                content_file="${payload_dir}/content-${item_index}"
+                normalize_tree_content "$source_file" "$content_file"
+                file_mode=100644
+              elif source_file=$(managed_cache_path "$dest_file") &&
+                [ -f "$source_file" ]; then
+                content_file="$source_file"
+                if ! file_mode=$(jq -er --arg dest "$dest_file" \
+                  '.files[$dest].mode | select(test("^100(644|755)$"))' \
+                  "$MANIFEST_RECEIPT_FILE"); then
+                  echo "[ERROR] Missing canonical Git mode for ${dest_file}" >&2
+                  rm -r "$payload_dir"
+                  return 1
+                fi
               else
-                echo "[WARN] No cached content for ${dest_file} -- skipping"
-                continue
+                echo "[ERROR] No cached content for required drift path ${dest_file}" >&2
+                rm -r "$payload_dir"
+                return 1
               fi
 
-              item_index=$((item_index + 1))
-              normalized_file="${payload_dir}/content-${item_index}"
-              normalize_tree_content "$source_file" "$normalized_file"
-              append_tree_item "$tree_items_file" "$dest_file" "$normalized_file"
+              append_tree_item "$tree_items_file" "$dest_file" "$file_mode" "$content_file"
             done
 
             local item_count
@@ -350,13 +569,14 @@ jobs:
               '{"message": $msg, "tree": $tree, "parents": [$parent]}')
             local new_commit_sha
             new_commit_sha=$(echo "$commit_json" | retry 3 gh api "repos/${repo_slug}/git/commits" --method POST --input - --jq '.sha')
+            require_sha "new_commit_sha for ${branch}" "$new_commit_sha" || return 1
 
             local ref_update
-            ref_update=$(jq -n --arg sha "$new_commit_sha" --argjson force "$force_update" \
-              '{"sha": $sha, "force": $force}')
+            ref_update=$(jq -n --arg sha "$new_commit_sha" '{"sha": $sha}')
             retry_json 3 "$ref_update" "repos/${repo_slug}/git/refs/heads/${branch}" --method PATCH >/dev/null
 
             rm -r "$payload_dir"
+            LAST_COMMIT_SHA="$new_commit_sha"
             echo "[OK] Atomic commit ${new_commit_sha:0:8} (${item_count} files)"
           }
 
@@ -379,6 +599,8 @@ jobs:
           if ! echo "$CONFIG" | jq empty 2>/dev/null; then
             echo "[ERROR] Failed to fetch or parse config from ${CONFIG_REPO}" >&2; exit 1
           fi
+          CONFIG_RECEIPT_FILE=$(mktemp)
+          printf '%s' "$CONFIG" >"$CONFIG_RECEIPT_FILE"
           echo "[OK] Fetched config from ${CONFIG_REPO}"
 
           echo "[OK] Config validated for ${OWNER}/${REPO}"
@@ -395,7 +617,15 @@ jobs:
           if [ -z "$MANAGED_FILES" ]; then
             echo "[SKIP] No managed_files in config"
           else
+            if ! echo "$MANAGED_FILES" | validate_managed_routing; then
+              echo "[ERROR] Managed-file routing schema is invalid" >&2
+              exit 1
+            fi
             SOURCE_REPO=$(echo "$MANAGED_FILES" | jq -r '.source_repo')
+            if [ "$SOURCE_REPO" != "$CONFIG_REPO" ]; then
+              echo "[ERROR] Managed source must be the exact governance repository" >&2
+              exit 1
+            fi
 
             # Guard: skip if running in the source repo itself
             if [ "${OWNER}/${REPO}" = "$SOURCE_REPO" ]; then
@@ -407,24 +637,95 @@ jobs:
               # Per-repo opt-out list (files this repo maintains independently)
               SKIP_LIST=$(echo "$MANAGED_FILES" | jq -c --arg repo "$REPO" '.skip_files[$repo] // []')
 
-              # Fetch the pre-computed manifest once (1 API call vs 34×2 per-file
-              # content fetches). Manifest is produced by
-              # build-managed-files-manifest.yml in docs-control on every change
-              # to a managed-file source. Downstream side uses local
-              # `git hash-object` to compare against manifest SHAs -- no API call
-              # per file. Falls back to per-file fetch if manifest is missing or
-              # an entry isn't listed there yet.
+              # The manifest is required receipt evidence. Missing or malformed
+              # entries fail closed; no mutable per-file fallback is admissible.
               MANIFEST_PATH=".github/config/managed-files-manifest.json"
-              MANIFEST=$(fetch_governed "managed-files-manifest.json" "repos/${SOURCE_REPO}/contents/${MANIFEST_PATH}" 2>/dev/null || echo "")
-              MANIFEST_AVAILABLE=false
-              if [ -n "$MANIFEST" ] && echo "$MANIFEST" | jq -e '.files' >/dev/null 2>&1; then
-                MANIFEST_AVAILABLE=true
-                MANIFEST_COMMIT=$(echo "$MANIFEST" | jq -r '.source_commit // "unknown"')
-                echo "[INFO] Using manifest from ${SOURCE_REPO}@${MANIFEST_COMMIT} for drift detection"
+              MANIFEST_RECEIPT_FILE=$(mktemp)
+              if ! fetch_governed \
+                "managed-files-manifest.json" \
+                "repos/${SOURCE_REPO}/contents/${MANIFEST_PATH}" \
+                >"$MANIFEST_RECEIPT_FILE"; then
+                echo "[ERROR] Required managed-files manifest is unavailable" >&2
+                exit 1
               fi
-              if [ "$MANIFEST_AVAILABLE" = false ]; then
-                echo "[WARN] No manifest available -- falling back to per-file API fetch"
+              if ! jq -e '
+                type == "object" and
+                (.source_commit | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.files | type == "object" and length > 0) and
+                all(.files | to_entries[];
+                  .key == .value.dest and
+                  (.value.src | type == "string" and length > 0) and
+                  (.value.dest | type == "string" and length > 0) and
+                  (.value.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+                  (.value.size | type == "number" and floor == . and . >= 0) and
+                  (.value.mode | type == "string" and test("^100(644|755)$")))
+              ' "$MANIFEST_RECEIPT_FILE" >/dev/null; then
+                echo "[ERROR] Required managed-files manifest is malformed" >&2
+                exit 1
               fi
+              MANIFEST_COMMIT=$(jq -r '.source_commit' "$MANIFEST_RECEIPT_FILE")
+              MANIFEST_STATUS=identical
+              if [ "$MANIFEST_COMMIT" != "$expected_source_sha" ]; then
+                if ! MANIFEST_STATUS=$(retry 3 gh api \
+                  "repos/${SOURCE_REPO}/compare/${MANIFEST_COMMIT}...${expected_source_sha}" \
+                  --jq '.status'); then
+                  echo "[ERROR] Could not prove managed manifest provenance" >&2
+                  exit 1
+                fi
+              fi
+              if [ "$MANIFEST_STATUS" != "identical" ] && [ "$MANIFEST_STATUS" != "ahead" ]; then
+                echo "[ERROR] Managed manifest source is not on protected-main history" >&2
+                exit 1
+              fi
+
+              SOURCE_TREE_FILE=$(mktemp)
+              MANIFEST_TREE_FILE=$(mktemp)
+              if ! retry 3 gh api \
+                "repos/${SOURCE_REPO}/git/trees/${expected_source_sha}?recursive=1" \
+                >"$SOURCE_TREE_FILE" ||
+                ! retry 3 gh api \
+                  "repos/${SOURCE_REPO}/git/trees/${MANIFEST_COMMIT}?recursive=1" \
+                  >"$MANIFEST_TREE_FILE"; then
+                echo "[ERROR] Could not resolve exact managed source trees" >&2
+                exit 1
+              fi
+              if ! jq -e \
+                --slurpfile config "$CONFIG_RECEIPT_FILE" \
+                --slurpfile source_tree "$SOURCE_TREE_FILE" \
+                --slurpfile manifest_tree "$MANIFEST_TREE_FILE" '
+                  . as $manifest |
+                  ($config[0].managed_files.files) as $configured |
+                  ($source_tree[0]) as $current |
+                  ($manifest_tree[0]) as $provenance |
+                  ($configured | type == "array" and length > 0) and
+                  (($configured | map(.dest) | length) ==
+                    ($configured | map(.dest) | unique | length)) and
+                  (($manifest.files | keys | sort) ==
+                    ($configured | map(.dest) | sort)) and
+                  ($current.truncated == false) and
+                  ($current.tree | type == "array") and
+                  ($provenance.truncated == false) and
+                  ($provenance.tree | type == "array") and
+                  all($configured[];
+                    . as $file |
+                    ($manifest.files[$file.dest]) as $receipt |
+                    ([$current.tree[] | select(.path == $file.src)]) as $current_entries |
+                    ([$provenance.tree[] | select(.path == $file.src)]) as $provenance_entries |
+                    ($receipt | type == "object") and
+                    ($receipt.src == $file.src) and
+                    ($receipt.dest == $file.dest) and
+                    ($current_entries | length == 1) and
+                    ($provenance_entries | length == 1) and
+                    all([$current_entries[0], $provenance_entries[0]][];
+                      .type == "blob" and
+                      .sha == $receipt.sha and
+                      .size == $receipt.size and
+                      .mode == $receipt.mode))
+                ' "$MANIFEST_RECEIPT_FILE" >/dev/null; then
+                echo "[ERROR] Exact source tree does not match the managed manifest" >&2
+                exit 1
+              fi
+              echo "[INFO] Using exact manifest from ${SOURCE_REPO}@${MANIFEST_COMMIT} for drift detection"
 
               mkdir -p /tmp/drift_content
 
@@ -448,53 +749,34 @@ jobs:
                   continue
                 fi
 
-                # Manifest-based path: compare git blob SHA locally (no API)
-                if [ "$MANIFEST_AVAILABLE" = true ]; then
-                  CANONICAL_SHA=$(echo "$MANIFEST" | jq -r --arg d "$dest" '.files[$d].sha // empty')
-                  if [ -n "$CANONICAL_SHA" ]; then
-                    if [ -f "$dest" ]; then
-                      LOCAL_SHA=$(git hash-object "$dest")
-                      if [ "$LOCAL_SHA" != "$CANONICAL_SHA" ]; then
-                        echo "[DRIFT] Content mismatch: ${dest}"
-                        DRIFT_FILES="${DRIFT_FILES}${dest}\n"
-                        DRIFT_COUNT=$((DRIFT_COUNT + 1))
-                        DRIFT_CONTENT=$(fetch_governed "files/${dest}" "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
-                        if [ -n "$DRIFT_CONTENT" ]; then
-                          printf '%s' "$DRIFT_CONTENT" > "/tmp/drift_content/$(echo "$dest" | tr '/' '__')"
-                        fi
-                      else
-                        echo "[OK] ${dest}"
-                      fi
-                    else
-                      echo "[DRIFT] Missing downstream: ${dest}"
-                      DRIFT_FILES="${DRIFT_FILES}${dest}\n"
-                      DRIFT_COUNT=$((DRIFT_COUNT + 1))
-                      DRIFT_CONTENT=$(fetch_governed "files/${dest}" "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
-                      if [ -n "$DRIFT_CONTENT" ]; then
-                        printf '%s' "$DRIFT_CONTENT" > "/tmp/drift_content/$(echo "$dest" | tr '/' '__')"
-                      fi
-                    fi
-                    continue
-                  fi
-                  # Fall through to API path when entry is missing from manifest
-                  # (e.g. a new managed file added but manifest not yet regenerated)
-                  echo "[INFO] ${dest} not in manifest -- falling back to API fetch"
+                MANIFEST_ENTRY=$(jq -c --arg d "$dest" '.files[$d] // empty' "$MANIFEST_RECEIPT_FILE")
+                if [ -z "$MANIFEST_ENTRY" ] || ! echo "$MANIFEST_ENTRY" | jq -e \
+                  --arg src "$src" --arg dest "$dest" '
+                    .src == $src and .dest == $dest and
+                    (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+                    (.size | type == "number" and floor == . and . >= 0)
+                  ' >/dev/null; then
+                  echo "[ERROR] Manifest entry missing or inconsistent for ${dest}" >&2
+                  exit 1
                 fi
-
-                # Fallback API path (manifest unavailable or entry missing)
-                CANONICAL_CONTENT=$(fetch_governed "files/${dest}" "repos/${SOURCE_REPO}/contents/${src}" 2>/dev/null) || true
-                if [ -z "$CANONICAL_CONTENT" ]; then
-                  echo "[WARN] Could not fetch canonical: ${src}"
-                  continue
-                fi
+                CANONICAL_SHA=$(echo "$MANIFEST_ENTRY" | jq -r '.sha')
+                CANONICAL_SIZE=$(echo "$MANIFEST_ENTRY" | jq -r '.size')
+                CANONICAL_MODE=$(echo "$MANIFEST_ENTRY" | jq -r '.mode')
+                CACHE_FILE=$(managed_cache_path "$dest")
 
                 if [ -f "$dest" ]; then
-                  DOWNSTREAM_CONTENT=$(cat "$dest")
-                  if [ "$CANONICAL_CONTENT" != "$DOWNSTREAM_CONTENT" ]; then
+                  LOCAL_SHA=$(git hash-object "$dest")
+                  LOCAL_MODE=$(git ls-files -s -- "$dest" | awk 'NR == 1 { print $1 }')
+                  if [ "$LOCAL_SHA" != "$CANONICAL_SHA" ] || [ "$LOCAL_MODE" != "$CANONICAL_MODE" ]; then
                     echo "[DRIFT] Content mismatch: ${dest}"
                     DRIFT_FILES="${DRIFT_FILES}${dest}\n"
                     DRIFT_COUNT=$((DRIFT_COUNT + 1))
-                    printf '%s' "$CANONICAL_CONTENT" > "/tmp/drift_content/$(echo "$dest" | tr '/' '__')"
+                    if ! cache_managed_content \
+                      "files/${dest}" \
+                      "repos/${SOURCE_REPO}/contents/${src}" \
+                      "$CANONICAL_SHA" "$CANONICAL_SIZE" "$CACHE_FILE"; then
+                      exit 1
+                    fi
                   else
                     echo "[OK] ${dest}"
                   fi
@@ -502,7 +784,12 @@ jobs:
                   echo "[DRIFT] Missing downstream: ${dest}"
                   DRIFT_FILES="${DRIFT_FILES}${dest}\n"
                   DRIFT_COUNT=$((DRIFT_COUNT + 1))
-                  printf '%s' "$CANONICAL_CONTENT" > "/tmp/drift_content/$(echo "$dest" | tr '/' '__')"
+                  if ! cache_managed_content \
+                    "files/${dest}" \
+                    "repos/${SOURCE_REPO}/contents/${src}" \
+                    "$CANONICAL_SHA" "$CANONICAL_SIZE" "$CACHE_FILE"; then
+                    exit 1
+                  fi
                 fi
               done
 
@@ -575,48 +862,40 @@ jobs:
               else
                 # Fetch docs-sites.json from docs-control
                 DOCS_SITES_JSON=$(fetch_governed "docs-sites.json" "repos/${CONFIG_REPO}/contents/.github/config/docs-sites.json")
-
-                # Look up label and description by matching repo name in URL
-                README_TITLE=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
-                  '.[] | select(.url | contains("/" + $r + "/")) | .label' 2>/dev/null) || true
-                README_DESC=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
-                  '.[] | select(.url | contains("/" + $r + "/")) | .description' 2>/dev/null) || true
-
-                # Fallback: capitalize repo name for title
-                if [ -z "$README_TITLE" ] || [ "$README_TITLE" = "null" ]; then
-                  README_TITLE=$(echo "$REPO" | sed 's/-/ /g; s/\b\(.\)/\u\1/g')
-                  echo "[INFO] No docs-sites.json match -- using capitalized repo name: ${README_TITLE}"
-                fi
-
-                # Fallback: GitHub API repo description
-                if [ -z "$README_DESC" ] || [ "$README_DESC" = "null" ]; then
-                  README_DESC=$(gh api "repos/${OWNER}/${REPO}" --jq '.description // ""') || true
-                  if [ -z "$README_DESC" ] || [ "$README_DESC" = "null" ]; then
-                    README_DESC=""
-                  fi
-                  echo "[INFO] No docs-sites.json description -- using GitHub API description"
-                fi
-
-                DOCS_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO}/"
-
-                # Extract per-repo extra badges from docs-sites.json
-                README_BADGES=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" --arg o "$OWNER" \
-                  '[.[] | select(.url | contains("/" + $r + "/")) | .badges // [] | .[]] |
-                   if length == 0 then empty
-                   else .[] | "[![\(.name)](https://github.com/\($o)/\($r)/actions/workflows/\(.workflow)/badge.svg)](https://github.com/\($o)/\($r)/actions/workflows/\(.workflow))"
-                   end' 2>/dev/null) || true
-
-                README_ENGLISH_ONLY=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
-                  '[.[] | select(.url | contains("/" + $r + "/")) |
-                    if has("readme_english_only") then
-                      if (.readme_english_only | type) == "boolean" then .readme_english_only
-                      else error("readme_english_only must be a JSON boolean") end
-                    else false end] |
-                   if length == 0 then false elif length == 1 then .[0] else error("duplicate docs site") end' \
-                  2>/dev/null) || {
-                  echo "[ERROR] Invalid README language policy for ${REPO}" >&2
+                if ! printf '%s' "$DOCS_SITES_JSON" | validate_docs_sites; then
+                  echo "[ERROR] Canonical docs-sites.json is invalid" >&2
                   exit 1
-                }
+                fi
+
+                DOCS_SITE_URL="https://${OWNER}.github.io/${REPO}/llms-full.txt"
+                DOCS_SITE_ENTRY=$(printf '%s' "$DOCS_SITES_JSON" | jq -ec \
+                  --arg url "$DOCS_SITE_URL" '
+                    [.[] | select(.url == $url)] |
+                    if length == 0 then null
+                    elif length == 1 then .[0]
+                    else error("duplicate canonical docs site")
+                    end')
+
+                if [ "$DOCS_SITE_ENTRY" = "null" ]; then
+                  echo "[ERROR] No canonical docs-site metadata for ${OWNER}/${REPO}; add the exact entry or an explicit README.md opt-out" >&2
+                  exit 1
+                else
+                  README_TITLE=$(printf '%s' "$DOCS_SITE_ENTRY" | jq -er '.label')
+                  README_DESC=$(printf '%s' "$DOCS_SITE_ENTRY" | jq -er '.description')
+                  DOCS_URL=$(printf '%s' "$DOCS_SITE_ENTRY" | jq -er \
+                    '.url | sub("llms-full\\.txt$"; "")')
+
+                  # Generate badges only from the selected canonical site entry.
+                  README_BADGES=$(printf '%s' "$DOCS_SITE_ENTRY" | jq -r \
+                    --arg r "$REPO" --arg o "$OWNER" '
+                      .badges // [] |
+                      if length == 0 then empty
+                      else .[] |
+                        "[![\(.name)](https://github.com/\($o)/\($r)/actions/workflows/\(.workflow)/badge.svg)](https://github.com/\($o)/\($r)/actions/workflows/\(.workflow))"
+                      end')
+
+                  README_ENGLISH_ONLY=$(printf '%s' "$DOCS_SITE_ENTRY" |
+                    jq -er '.readme_english_only // false')
                 case "$README_ENGLISH_ONLY" in
                   true)
                     printf '%s\n' '🌐 English' > /tmp/language_nav.tmp
@@ -680,8 +959,7 @@ jobs:
                 fi
 
                 # Replace __EXTRA_CONTENT__ placeholder — inject per-repo markdown content or remove
-                README_CONTENT=$(echo "$DOCS_SITES_JSON" | jq -r --arg r "$REPO" \
-                  '.[] | select(.url | contains("/" + $r + "/")) | .readme_content // empty' 2>/dev/null) || true
+                README_CONTENT=$(printf '%s' "$DOCS_SITE_ENTRY" | jq -r '.readme_content // ""')
 
                 if [ -n "$README_CONTENT" ]; then
                   printf '%s\n' "$README_CONTENT" > /tmp/extra_content.tmp
@@ -716,6 +994,7 @@ jobs:
                 else
                   echo "[OK] README.md"
                 fi
+                fi
               fi
 
               if [ "$DRIFT_COUNT" -eq 0 ]; then
@@ -723,77 +1002,104 @@ jobs:
               else
                 echo "[INFO] Found ${DRIFT_COUNT} drifted file(s)"
 
-                # Check for existing open sync PR (idempotency)
-                EXISTING_PR=$(gh pr list --repo "${OWNER}/${REPO}" \
-                  --head "governance/sync-managed-files" \
-                  --state open --json number --jq '.[0].number // empty' 2>/dev/null) || true
-                if [ -n "$EXISTING_PR" ]; then
-                  echo "[INFO] Open sync PR #${EXISTING_PR} already exists -- updating drifted files"
-
-                  # Rebase onto main AND add the drift in one ref update, by handing
-                  # commit_tree main's SHA as the base. Two calls -- reset the branch to
-                  # main, then commit -- leave the branch equal to main in between, so the
-                  # PR has zero commits ahead of base and GitHub closes it and disables
-                  # auto-merge. The content returns on the next call but the PR does not
-                  # reopen, stranding the change on an unmerged branch (#836).
-                  MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
-
-                  commit_tree "governance/sync-managed-files" \
-                    "chore: sync managed files from governance template" \
-                    "$MAIN_SHA"
-                  echo "[OK] Rebased onto main and committed drift in one update"
-
-                  echo "[INFO] PR branch updated -- attempting merge"
-                  auto_merge "${EXISTING_PR}" "${OWNER}/${REPO}" || true
-                else
-                  # Close any orphaned sync issues from previous runs
-                  STALE_ISSUES=$(gh issue list --repo "${OWNER}/${REPO}" \
-                    --state open \
-                    --search "chore: sync managed files from governance template" \
-                    --json number --jq '.[].number' 2>/dev/null) || true
-                  for stale_num in $STALE_ISSUES; do
-                    gh issue close "$stale_num" --repo "${OWNER}/${REPO}" \
-                      --comment "Superseded by new sync run. Closing stale issue." 2>/dev/null || true
-                    echo "[INFO] Closed stale sync issue #${stale_num}"
-                  done
-
-                  # Create issue
-                  DRIFT_LIST=$(printf '%b' "$DRIFT_FILES" | sed '/^$/d' | sed 's/^/- /')
-                  ISSUE_BODY=$(printf 'The following managed files have drifted from the canonical source in `%s`:\n\n%s\n\nThis issue was created automatically by the governance enforcement workflow.' \
-                    "$SOURCE_REPO" "$DRIFT_LIST")
-                  ISSUE_NUM=$(gh issue create --repo "${OWNER}/${REPO}" \
-                    --title "chore: sync managed files from governance template" \
-                    --body "$ISSUE_BODY" | grep -o '[0-9]*$')
-                  echo "[OK] Created issue #${ISSUE_NUM}"
-
-                  # Create branch from main HEAD (try create, fall back to update if concurrent run created it)
-                  MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
-                  BRANCH_CREATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"ref":"refs/heads/governance/sync-managed-files","sha":$sha}')
-                  if ! retry_json 3 "$BRANCH_CREATE_JSON" "repos/${OWNER}/${REPO}/git/refs" --method POST >/dev/null 2>&1; then
-                    BRANCH_UPDATE_JSON=$(jq -n --arg sha "$MAIN_SHA" '{"sha":$sha,"force":true}')
-                    retry_json 3 "$BRANCH_UPDATE_JSON" "repos/${OWNER}/${REPO}/git/refs/heads/governance/sync-managed-files" --method PATCH >/dev/null
-                  fi
-                  echo "[OK] Created or updated branch governance/sync-managed-files"
-
-                  commit_tree "governance/sync-managed-files" \
-                    "chore: sync managed files from governance template"
-
-
-                  # Create PR
-                  PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \
-                    "$ISSUE_NUM" "$SOURCE_REPO" "$DRIFT_LIST")
-                  PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
-                    --head governance/sync-managed-files \
-                    --title "chore: sync managed files from governance template" \
-                    --body "$PR_BODY")
-                  PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
-                  echo "[OK] Created sync PR #${PR_NUM}"
-
-                  # --- Auto-merge governance PR ---------------------------
-                  auto_merge "${PR_NUM}" "${OWNER}/${REPO}" || true
-
-                  SYNC_PR_CREATED=true
+                # Inventory every same-named PR across all head repositories.
+                # The CLI head filter cannot express owner-qualified heads, so
+                # selecting its first result could merge a same-named fork PR.
+                SYNC_PR_INVENTORY=$(mktemp)
+                read_sync_prs "$SYNC_PR_INVENTORY"
+                SYNC_PR_ROW=$(select_owned_sync_pr "$SYNC_PR_INVENTORY")
+                rm -f "$SYNC_PR_INVENTORY"
+                EXISTING_PR=""
+                if [ -n "$SYNC_PR_ROW" ]; then
+                  IFS=$'\t' read -r EXISTING_PR EXISTING_BRANCH EXISTING_HEAD <<<"$SYNC_PR_ROW"
                 fi
+                if [ -n "$EXISTING_PR" ]; then
+                  retry 3 assert_sync_pr_head \
+                    "$EXISTING_PR" "$EXISTING_BRANCH" "$EXISTING_HEAD"
+                  gh pr close "$EXISTING_PR" --repo "${OWNER}/${REPO}" \
+                    --comment "Superseded by exact managed-file receipt ${expected_source_sha:0:12} on run-owned branch ${SYNC_BRANCH}."
+                  echo "[OK] Closed superseded sync PR #${EXISTING_PR} without deleting its branch"
+                fi
+
+                # Close only issues carrying the exact automation ownership marker.
+                STALE_ISSUE_INVENTORY=$(mktemp)
+                if ! gh issue list --repo "${OWNER}/${REPO}" \
+                  --state open \
+                  --search 'chore: sync managed files from governance template' \
+                  --limit 1000 --json number,title,body >"$STALE_ISSUE_INVENTORY"; then
+                  echo "[ERROR] Could not inventory stale sync issues" >&2
+                  rm -f "$STALE_ISSUE_INVENTORY"
+                  exit 1
+                fi
+                if ! STALE_ISSUES=$(select_owned_stale_issues <"$STALE_ISSUE_INVENTORY"); then
+                  echo "[ERROR] Stale sync issue inventory is invalid" >&2
+                  rm -f "$STALE_ISSUE_INVENTORY"
+                  exit 1
+                fi
+                rm -f "$STALE_ISSUE_INVENTORY"
+                for stale_num in $STALE_ISSUES; do
+                  gh issue close "$stale_num" --repo "${OWNER}/${REPO}" \
+                    --comment "Superseded by exact managed-file receipt ${expected_source_sha:0:12}."
+                  echo "[OK] Closed stale owned sync issue #${stale_num}"
+                done
+
+                DRIFT_LIST=$(printf '%b' "$DRIFT_FILES" | sed '/^$/d' | sed 's/^/- /')
+                ISSUE_BODY=$(printf 'The following managed files have drifted from the canonical source in `%s`:\n\n%s\n\nThis issue was created automatically by the governance enforcement workflow.' \
+                  "$SOURCE_REPO" "$DRIFT_LIST")
+                ISSUE_NUM=$(gh issue create --repo "${OWNER}/${REPO}" \
+                  --title "chore: sync managed files from governance template" \
+                  --body "$ISSUE_BODY" | grep -o '[0-9]*$')
+                if ! printf '%s' "$ISSUE_NUM" | grep -qE '^[1-9][0-9]*$'; then
+                  echo "[ERROR] Issue creation returned an invalid URL" >&2
+                  exit 1
+                fi
+                echo "[OK] Created issue #${ISSUE_NUM}"
+
+                # The run-owned branch must be absent. Never move or reuse an
+                # unproved ref, even if an earlier attempt used the same name.
+                MAIN_SHA=$(retry 3 gh api "repos/${OWNER}/${REPO}/git/ref/heads/main" --jq '.object.sha')
+                require_sha "protected main" "$MAIN_SHA"
+                set +e
+                EXISTING_BRANCH_SHA=$(api_value_or_404 \
+                  "repos/${OWNER}/${REPO}/git/ref/heads/${SYNC_BRANCH}" \
+                  '.object.sha')
+                BRANCH_LOOKUP_RC=$?
+                set -e
+                case "$BRANCH_LOOKUP_RC" in
+                  0)
+                    require_sha "unexpected run-owned sync branch" "$EXISTING_BRANCH_SHA"
+                    echo "[ERROR] Run-owned sync branch ${SYNC_BRANCH} already exists" >&2
+                    exit 1
+                    ;;
+                  44)
+                    BRANCH_CREATE_JSON=$(jq -n --arg sha "$MAIN_SHA" --arg branch "$SYNC_BRANCH" \
+                      '{"ref":("refs/heads/" + $branch),"sha":$sha}')
+                    retry_json 3 "$BRANCH_CREATE_JSON" \
+                      "repos/${OWNER}/${REPO}/git/refs" --method POST >/dev/null
+                    ;;
+                  *) exit 1 ;;
+                esac
+                echo "[OK] Created run-owned branch ${SYNC_BRANCH} at protected main"
+
+                commit_tree "$SYNC_BRANCH" \
+                  "chore: sync managed files from governance template"
+
+                PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \
+                  "$ISSUE_NUM" "$SOURCE_REPO" "$DRIFT_LIST")
+                PR_URL=$(gh pr create --repo "${OWNER}/${REPO}" \
+                  --base main --head "$SYNC_BRANCH" \
+                  --title "chore: sync managed files from governance template" \
+                  --body "$PR_BODY")
+                PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
+                if ! printf '%s' "$PR_NUM" | grep -qE '^[1-9][0-9]*$'; then
+                  echo "[ERROR] PR creation returned an invalid URL" >&2
+                  exit 1
+                fi
+                echo "[OK] Created sync PR #${PR_NUM}"
+
+                retry 3 assert_sync_pr_head "$PR_NUM" "$SYNC_BRANCH" "$LAST_COMMIT_SHA"
+                auto_merge "$PR_NUM" "${OWNER}/${REPO}" "$LAST_COMMIT_SHA"
+                SYNC_PR_CREATED=true
               fi
             fi
           fi
@@ -804,9 +1110,9 @@ jobs:
 
           if [ -n "$MANAGED_FILES" ] && [ "${OWNER}/${REPO}" != "$SOURCE_REPO" ]; then
             if [ "$SYNC_PR_CREATED" = true ]; then
-              echo "[OK] Sync PR created and merge attempted -- check logs above for result"
+              echo "[OK] Sync PR created with a confirmed merge transition"
             elif [ -n "$EXISTING_PR" ]; then
-              echo "[OK] Existing sync PR #${EXISTING_PR} merge attempted -- check logs above for result"
+              echo "[OK] Existing sync PR #${EXISTING_PR} has a confirmed merge transition"
             else
               echo "[OK] Managed files verified"
             fi
@@ -814,4 +1120,4 @@ jobs:
             echo "[SKIP] No managed files to verify"
           fi
 
-          echo "[OK] Managed file sync complete"
+          echo "[OK] Managed-file enforcement run complete"

--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -101,6 +101,28 @@ retry() {
   done
 }
 
+active_run_ids() {
+  local slug="$1" state_filter
+  # Filter server-side so quiescence is proportional to active work, not the
+  # repository's unbounded workflow history. Inventory repository-wide runs
+  # and select the exact workflow path locally: the workflow-scoped endpoint
+  # returns 404 after the file is deleted even while a legacy run remains active.
+  for state_filter in \
+    status=queued \
+    status=in_progress \
+    status=waiting \
+    status=requested \
+    status=pending; do
+    if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+      "repos/${slug}/actions/runs?${state_filter}&per_page=100" \
+      --paginate --jq \
+      '.workflow_runs[] | select(.path == ".github/workflows/enforce-repo-settings.yml") | .id'; then
+      echo "[ERROR] Could not inventory ${state_filter#status=} enforcement runs for ${slug}" >&2
+      return 1
+    fi
+  done
+}
+
 assert_source_current() {
   local current_main
   current_main=$(gh api "repos/${repository}/commits/main" --jq '.sha')
@@ -264,7 +286,7 @@ reconcile_bootstrap_prs() {
 }
 
 quiesce_one() {
-  local name="$1" slug state runs run_id status attempt rc
+  local name="$1" slug state runs run_id status attempt rc workflow_present=true empty_sweeps=0
   slug="${owner}/${name}"
   set +e
   state=$(api_value_or_404 \
@@ -274,39 +296,55 @@ quiesce_one() {
   set -e
   case "$rc" in
   0) ;;
-  44) return 0 ;;
+  44) workflow_present=false ;;
   *) return 1 ;;
   esac
-  if [ "$state" != "disabled_manually" ]; then
+  if [ "$workflow_present" = true ] && [ "$state" != "disabled_manually" ]; then
     GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
       "repos/${slug}/actions/workflows/enforce-repo-settings.yml/disable" \
       --method PUT >/dev/null
   fi
 
-  runs=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
-    "repos/${slug}/actions/workflows/enforce-repo-settings.yml/runs?per_page=100" \
-    --paginate --jq '.workflow_runs[] | select(.status != "completed") | .id')
-  while IFS= read -r run_id; do
-    [ -n "$run_id" ] || continue
-    if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
-      "repos/${slug}/actions/runs/${run_id}/cancel" --method POST >/dev/null 2>&1; then
-      status=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
-        "repos/${slug}/actions/runs/${run_id}" --jq '.status')
-      [ "$status" = "completed" ] || return 1
+  # A run may change status between filtered API queries and escape one sweep.
+  # Require two consecutive empty inventories after disabling, and cancel every
+  # run found in every sweep, before certifying quiescence.
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    if ! runs=$(active_run_ids "$slug"); then
+      return 1
     fi
-  done <<<"$runs"
-
-  for attempt in 1 2 3 4 5; do
-    runs=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
-      "repos/${slug}/actions/workflows/enforce-repo-settings.yml/runs?per_page=100" \
-      --paginate --jq '.workflow_runs[] | select(.status != "completed") | .id')
-    [ -z "$runs" ] && break
-    sleep "$((attempt * 2))"
+    while IFS= read -r run_id; do
+      [ -n "$run_id" ] || continue
+      if [[ ! "$run_id" =~ ^[1-9][0-9]*$ ]]; then
+        echo "[ERROR] Active-run inventory returned an invalid run ID for ${slug}" >&2
+        return 1
+      fi
+      if ! GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+        "repos/${slug}/actions/runs/${run_id}/cancel" --method POST >/dev/null 2>&1; then
+        status=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+          "repos/${slug}/actions/runs/${run_id}" --jq '.status')
+        [ "$status" = "completed" ] || return 1
+      fi
+    done <<<"$runs"
+    if [ -z "$runs" ]; then
+      empty_sweeps=$((empty_sweeps + 1))
+      [ "$empty_sweeps" -ge 2 ] && break
+    else
+      empty_sweeps=0
+    fi
+    sleep "$((attempt < 5 ? attempt : 5))"
   done
-  [ -z "$runs" ] || return 1
-  state=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
-    "repos/${slug}/actions/workflows/enforce-repo-settings.yml" --jq '.state')
-  [ "$state" = "disabled_manually" ]
+  [ "$empty_sweeps" -ge 2 ] || return 1
+  set +e
+  state=$(api_value_or_404 \
+    "repos/${slug}/actions/workflows/enforce-repo-settings.yml" '.state' \
+    "$REPO_SETTINGS_TOKEN")
+  rc=$?
+  set -e
+  case "$rc" in
+  0) [ "$state" = "disabled_manually" ] ;;
+  44) return 0 ;;
+  *) return 1 ;;
+  esac
 }
 
 quiesce_fleet() {
@@ -565,7 +603,8 @@ bootstrap_one() {
     echo "[ERROR] Bootstrap caller changed after exact PR verification for ${name}" >&2
     return 1
   fi
-  gh pr merge "$pr_number" --repo "$slug" --auto --squash --delete-branch
+  gh pr merge "$pr_number" --repo "$slug" --auto --squash --delete-branch \
+    --match-head-commit "$verified_head"
   echo "[BOOTSTRAP] ${name} caller PR #${pr_number} is queued for exact merge"
 }
 
@@ -683,6 +722,10 @@ if [ "$source_superseded" = true ]; then
   exit 78
 fi
 if [ "$enable_failures" -gt 0 ]; then
+  if ! quiesce_fleet; then
+    echo "[ERROR] Enable failed and fleet rollback could not be verified" >&2
+    exit 1
+  fi
   echo "[ERROR] ${enable_failures} exact enforcement workflow(s) remain disabled" >&2
   exit 1
 fi

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -125,7 +125,7 @@ PHONE_FIELD_RE = re.compile(
 PERSON_FIELD_RE = re.compile(
     r"(?i)(?:^|[,{\s])['\"]?"
     r"(?P<key>full_name|first_name|last_name|given_name|family_name|display_name)"
-    r"['\"]?\s*[:=]\s*(?P<quote>['\"`]?)"
+    r"['\"]?\s*(?P<separator>[:=])\s*(?P<quote>['\"`]?)"
     r"(?P<value>(?:(?!\\[rn])[^'\"`#,\r\n}\]])+)"
 )
 LOCALIZATION_BUNDLE_RE = re.compile(

--- a/tests/fixtures/fetch-governed.sh
+++ b/tests/fixtures/fetch-governed.sh
@@ -7,8 +7,8 @@
 # inlined copies stay in sync with this file.
 #
 # Environment:
-#   PAGES_BASE   e.g. "https://f5-sales-demo.github.io/docs-control"
-#   GH_TOKEN     used by fallback `gh api` path
+#   expected_source_sha  exact docs-control commit for every governed read
+#   GH_TOKEN             used by `gh api`
 #
 # Dependencies:
 #   retry(max_attempts, cmd...)   consumer workflows define a richer
@@ -26,55 +26,56 @@ declare -F retry >/dev/null 2>&1 || retry() {
   "$@"
 }
 
-# fetch_governed <pages-key> <api-fallback-path>
-#   pages-key          : relative path under ${PAGES_BASE}/api/ (e.g. "repo-settings.json")
-#   api-fallback-path  : argument for `gh api` when Pages is unavailable
-#                        (e.g. "repos/f5-sales-demo/docs-control/contents/.github/config/repo-settings.json")
-# Prints: raw file content to stdout.
-# Returns: 0 on success (via Pages or API), non-zero if both fail.
+# fetch_governed <label> <api-content-path>
+# Reads one GitHub Contents object at the exact source receipt, validates the
+# response metadata against the decoded bytes, and prints those bytes.
 fetch_governed() {
-  local key="$1" fallback="$2" body err_file
-  local url="${PAGES_BASE}/api/${key}"
+  local key="$1" fallback="$2" api_file decoded_file err_file
+  local receipt_sha receipt_size decoded_sha decoded_size
 
-  body=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 "$url" 2>/dev/null || true)
-  if [ -n "$body" ]; then
-    printf '%s' "$body"
-    return 0
+  if ! printf '%s' "${expected_source_sha:-}" | grep -qE '^[0-9a-f]{40}$'; then
+    echo "[ERROR] Could not resolve an exact docs-control source commit" >&2
+    return 1
+  fi
+  if [[ "$fallback" == *[?#]* ]]; then
+    echo "[ERROR] Governed API path already contains a query or fragment for ${key}" >&2
+    return 1
   fi
 
-  echo "[WARN] Pages unavailable for ${key} — falling back to API" >&2
+  api_file=$(mktemp)
+  decoded_file=$(mktemp)
   err_file=$(mktemp)
-  if ! body=$(retry 3 gh api "$fallback" 2>"$err_file"); then
+  if ! retry 3 gh api "${fallback}?ref=${expected_source_sha}" >"$api_file" 2>"$err_file"; then
     echo "[ERROR] gh api failed for ${key}:" >&2
     cat "$err_file" >&2
-    rm -f "$err_file"
+    rm -f "$api_file" "$decoded_file" "$err_file"
     return 1
   fi
-  rm -f "$err_file"
-  if [ -z "$body" ]; then
-    echo "[ERROR] gh api returned empty body for ${key}" >&2
+  if ! jq -e '
+    .type == "file" and .encoding == "base64" and
+    (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+    (.size | type == "number" and floor == . and . >= 0) and
+    (.content | type == "string") and
+    (.size == 0 or (.content | length > 0))
+  ' "$api_file" >/dev/null 2>&1; then
+    echo "[ERROR] gh api returned an invalid content envelope for ${key}" >&2
+    rm -f "$api_file" "$decoded_file" "$err_file"
     return 1
   fi
-
-  # API returns {"content": "<base64>", "encoding": "base64"} envelope.
-  # Unwrap to raw bytes.
-  printf '%s' "$body" | jq -r '.content' | tr -d '\n' | base64 -d
-}
-
-# revision_is_fresh <source-sha>
-#   Fetch ${PAGES_BASE}/api/revision.json and compare its .commit
-#   against source-sha (the SHA that triggered the consumer run).
-# Returns: 0 when the Pages deploy has caught up to source-sha;
-#          non-zero when Pages is stale or unreachable or when
-#          source-sha is empty.
-revision_is_fresh() {
-  local source_sha="${1:-}" rev pages_sha
-  [ -z "$source_sha" ] && return 1
-
-  rev=$(curl -fsSL --retry 2 --retry-delay 2 --max-time 10 \
-    "${PAGES_BASE}/api/revision.json" 2>/dev/null || true)
-  [ -z "$rev" ] && return 1
-
-  pages_sha=$(printf '%s' "$rev" | jq -r '.commit // empty')
-  [ "$pages_sha" = "$source_sha" ]
+  if ! jq -r '.content' "$api_file" | tr -d '\n' | base64 -d >"$decoded_file"; then
+    echo "[ERROR] gh api returned invalid base64 content for ${key}" >&2
+    rm -f "$api_file" "$decoded_file" "$err_file"
+    return 1
+  fi
+  receipt_sha=$(jq -r '.sha' "$api_file")
+  receipt_size=$(jq -r '.size' "$api_file")
+  decoded_sha=$(git hash-object "$decoded_file")
+  decoded_size=$(wc -c <"$decoded_file" | tr -d ' ')
+  if [ "$decoded_sha" != "$receipt_sha" ] || [ "$decoded_size" != "$receipt_size" ]; then
+    echo "[ERROR] Decoded bytes do not match the content receipt for ${key}" >&2
+    rm -f "$api_file" "$decoded_file" "$err_file"
+    return 1
+  fi
+  cat "$decoded_file"
+  rm -f "$api_file" "$decoded_file" "$err_file"
 }

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -106,6 +106,27 @@ case "$1 $endpoint" in
       touch "$FAKE_STATE/advance-main"
     fi
     ;;
+  'api repos/f5-sales-demo/example-two/commits/main') printf '%s\n' "$BASE_SHA" ;;
+  'api repos/f5-sales-demo/example-two/actions/workflows/enforce-repo-settings.yml')
+    if [ -f "$FAKE_STATE/disabled-example-two" ]; then
+      printf 'disabled_manually\n'
+    else
+      printf 'active\n'
+    fi
+    ;;
+  'api repos/f5-sales-demo/example-two/actions/workflows/enforce-repo-settings.yml/disable')
+    touch "$FAKE_STATE/disabled-example-two"
+    ;;
+  'api repos/f5-sales-demo/example-two/actions/workflows/enforce-repo-settings.yml/enable')
+    if [ "${FAKE_FAIL_ENABLE_REPO:-}" = example-two ]; then
+      exit 1
+    fi
+    rm -f "$FAKE_STATE/disabled-example-two"
+    ;;
+  'api repos/f5-sales-demo/example-two/actions/runs?status='*) printf '\n' ;;
+  'api repos/f5-sales-demo/example-two/contents/.github/workflows/enforce-repo-settings.yml?ref='*)
+    printf '%s\n' "$DOWNSTREAM_BLOB"
+    ;;
   'api repos/f5-sales-demo/example/actions/runs?status='*)
     if [ -n "${FAKE_RUN_QUERY_FAIL_STATUS:-}" ] &&
       [[ "$endpoint" == *"status=${FAKE_RUN_QUERY_FAIL_STATUS}"* ]]; then
@@ -307,6 +328,7 @@ run_bootstrap() {
     FAKE_MISSING_WORKFLOW="${FAKE_MISSING_WORKFLOW:-}" \
     FAKE_MERGE_LANDS="${FAKE_MERGE_LANDS:-}" \
     FAKE_ADVANCE_AFTER_ENABLE="${FAKE_ADVANCE_AFTER_ENABLE:-}" \
+    FAKE_FAIL_ENABLE_REPO="${FAKE_FAIL_ENABLE_REPO:-}" \
     FAKE_RUN_QUERY_FAIL_STATUS="${FAKE_RUN_QUERY_FAIL_STATUS:-}" \
     FAKE_TRANSITIONAL_RUN="${FAKE_TRANSITIONAL_RUN:-}" \
     FAKE_LEGACY_RUN="${FAKE_LEGACY_RUN:-}" \
@@ -636,6 +658,50 @@ if [ "$rc" != 78 ] || ! grep -q '/enable --method PUT' "$WORK/gh.log" ||
   exit 1
 fi
 echo "[OK] source advancement during enable re-quiesces the fleet"
+
+printf '["example","example-two"]\n' >"$WORK/repos-two.json"
+state="$WORK/state-partial-enable-failure"
+mkdir -p "$state"
+touch "$state/disabled" "$state/disabled-example-two"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+FAKE_FAIL_ENABLE_REPO=example-two
+set +e
+TEST_DOWNSTREAM_CONFIG="$WORK/repos-two.json" run_bootstrap "$state" \
+  >"$WORK/partial-enable.out" 2>"$WORK/partial-enable.err"
+rc=$?
+set -e
+unset FAKE_FAIL_ENABLE_REPO TEST_DOWNSTREAM_CONFIG
+example_enable_line=$(grep -n \
+  'example/actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+  "$WORK/gh.log" | tail -1 | cut -d: -f1)
+example_rollback_line=$(grep -n \
+  'example/actions/workflows/enforce-repo-settings.yml/disable --method PUT' \
+  "$WORK/gh.log" | tail -1 | cut -d: -f1)
+second_enable_attempts=$(grep -c \
+  'example-two/actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+  "$WORK/gh.log" || true)
+second_enable_first_line=$(grep -n \
+  'example-two/actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+  "$WORK/gh.log" | head -1 | cut -d: -f1)
+second_enable_last_line=$(grep -n \
+  'example-two/actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+  "$WORK/gh.log" | tail -1 | cut -d: -f1)
+if [ "$rc" = 0 ] || [ -z "$example_enable_line" ] ||
+  [ -z "$example_rollback_line" ] ||
+  [ "$example_rollback_line" -le "$example_enable_line" ] ||
+  [ "$second_enable_attempts" -ne 3 ] ||
+  [ -z "$second_enable_first_line" ] || [ -z "$second_enable_last_line" ] ||
+  [ "$second_enable_first_line" -le "$example_enable_line" ] ||
+  [ "$second_enable_last_line" -ge "$example_rollback_line" ] ||
+  ! grep -q '\[FAIL\] Could not enable exact enforcement for example-two' \
+    "$WORK/partial-enable.err" ||
+  [ ! -f "$state/disabled" ] || [ ! -f "$state/disabled-example-two" ]; then
+  echo "[FAIL] a later enable failure left part of the fleet active"
+  sed 's/^/  /' "$WORK/partial-enable.err"
+  exit 1
+fi
+echo "[OK] partial enable failure behaviorally returns the whole fleet to quiescence"
 
 state="$WORK/state-missing-workflow-active-run"
 mkdir -p "$state"

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -22,6 +22,38 @@ printf '["example"]\n' >"$WORK/repos.json"
 printf '{"revision":"%s"}\n' "$PIN_SHA" >"$WORK/pin.json"
 printf '{"state":"active"}\n' >"$WORK/rollout.json"
 
+for run_status in queued in_progress waiting requested pending; do
+  if ! grep -Fq "status=${run_status}" "$SOURCE"; then
+    echo "[FAIL] bootstrap does not query bounded ${run_status} workflow runs"
+    exit 1
+  fi
+done
+if ! grep -Fq 'actions/runs?${state_filter}' "$SOURCE" ||
+  ! grep -Fq 'select(.path == ".github/workflows/enforce-repo-settings.yml")' "$SOURCE"; then
+  echo "[FAIL] repository-wide active-run inventory is not filtered to the exact workflow path"
+  exit 1
+fi
+if grep -Fq 'actions/workflows/enforce-repo-settings.yml/runs?' "$SOURCE"; then
+  echo "[FAIL] bootstrap cannot inventory legacy runs after the workflow file is deleted"
+  exit 1
+fi
+if grep -Fq 'runs?per_page=100' "$SOURCE"; then
+  echo "[FAIL] bootstrap still paginates complete workflow-run history"
+  exit 1
+fi
+echo "[OK] bootstrap inventories only bounded active workflow-run states"
+
+if ! grep -q -- '--match-head-commit "$verified_head"' "$SOURCE"; then
+  echo "[FAIL] bootstrap auto-merge is not bound to the verified PR head"
+  exit 1
+fi
+enable_failure_block=$(sed -n '/if \[ "$enable_failures" -gt 0 \]; then/,/^fi$/p' "$SOURCE")
+if ! grep -q 'quiesce_fleet' <<<"$enable_failure_block"; then
+  echo "[FAIL] partial enable failure does not return the fleet to quiescence"
+  exit 1
+fi
+echo "[OK] merge and enable transitions retain exact safe ownership"
+
 cat >"$WORK/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$FAKE_LOG"
@@ -74,8 +106,54 @@ case "$1 $endpoint" in
       touch "$FAKE_STATE/advance-main"
     fi
     ;;
-  'api repos/f5-sales-demo/example/actions/workflows/enforce-repo-settings.yml/runs?per_page=100')
-    if [ -f "$FAKE_STATE/active-run" ] && [ ! -f "$FAKE_STATE/canceled" ]; then
+  'api repos/f5-sales-demo/example/actions/runs?status='*)
+    if [ -n "${FAKE_RUN_QUERY_FAIL_STATUS:-}" ] &&
+      [[ "$endpoint" == *"status=${FAKE_RUN_QUERY_FAIL_STATUS}"* ]]; then
+      echo 'gh: synthetic active-run query failure (HTTP 500)' >&2
+      exit 1
+    fi
+    if [ "${FAKE_MALFORMED_RUN_ID:-}" = 1 ] && [[ "$endpoint" == *'status=queued'* ]]; then
+      printf 'not-a-run-id\n'
+    elif [ "${FAKE_UNRELATED_RUN:-}" = 1 ] &&
+      [[ "$*" != *'select(.path == ".github/workflows/enforce-repo-settings.yml")'* ]] &&
+      [[ "$endpoint" == *'status=queued'* ]]; then
+      printf '903\n'
+    elif [ "${FAKE_TRANSITIONAL_RUN:-}" = 1 ] && [[ "$endpoint" == *'status=queued'* ]]; then
+      if [ ! -f "$FAKE_STATE/transition-started" ]; then
+        touch "$FAKE_STATE/transition-started"
+        printf '\n'
+      elif [ ! -f "$FAKE_STATE/transition-canceled" ]; then
+        printf '901\n'
+      else
+        printf '\n'
+      fi
+    elif [[ "$endpoint" == *'status=in_progress'* ]] &&
+      [ "${FAKE_LEGACY_RUN:-}" = 1 ] && [ ! -f "$FAKE_STATE/legacy-canceled" ]; then
+      printf '902\n'
+    elif [[ "$endpoint" == *'status=in_progress'* ]] &&
+      [ -f "$FAKE_STATE/active-run" ] && [ ! -f "$FAKE_STATE/canceled" ]; then
+      printf '900\n'
+    else
+      printf '\n'
+    fi
+    ;;
+  'api repos/f5-sales-demo/example/actions/workflows/enforce-repo-settings.yml/runs?status='*)
+    if [ -n "${FAKE_RUN_QUERY_FAIL_STATUS:-}" ] &&
+      [[ "$endpoint" == *"status=${FAKE_RUN_QUERY_FAIL_STATUS}"* ]]; then
+      echo 'gh: synthetic active-run query failure (HTTP 500)' >&2
+      exit 1
+    fi
+    if [ "${FAKE_TRANSITIONAL_RUN:-}" = 1 ] && [[ "$endpoint" == *'status=queued'* ]]; then
+      if [ ! -f "$FAKE_STATE/transition-started" ]; then
+        touch "$FAKE_STATE/transition-started"
+        printf '\n'
+      elif [ ! -f "$FAKE_STATE/transition-canceled" ]; then
+        printf '901\n'
+      else
+        printf '\n'
+      fi
+    elif [[ "$endpoint" == *'status=in_progress'* ]] &&
+      [ -f "$FAKE_STATE/active-run" ] && [ ! -f "$FAKE_STATE/canceled" ]; then
       printf '900\n'
     else
       printf '\n'
@@ -83,6 +161,15 @@ case "$1 $endpoint" in
     ;;
   'api repos/f5-sales-demo/example/actions/runs/900/cancel')
     touch "$FAKE_STATE/canceled"
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/901/cancel')
+    touch "$FAKE_STATE/transition-canceled"
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/902/cancel')
+    touch "$FAKE_STATE/legacy-canceled"
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/903/cancel')
+    touch "$FAKE_STATE/unrelated-canceled"
     ;;
   'api repos/f5-sales-demo/example/contents/.github/workflows/enforce-repo-settings.yml?ref='*)
     if [ "${FAKE_READ_ERROR:-}" = 403 ]; then
@@ -220,6 +307,11 @@ run_bootstrap() {
     FAKE_MISSING_WORKFLOW="${FAKE_MISSING_WORKFLOW:-}" \
     FAKE_MERGE_LANDS="${FAKE_MERGE_LANDS:-}" \
     FAKE_ADVANCE_AFTER_ENABLE="${FAKE_ADVANCE_AFTER_ENABLE:-}" \
+    FAKE_RUN_QUERY_FAIL_STATUS="${FAKE_RUN_QUERY_FAIL_STATUS:-}" \
+    FAKE_TRANSITIONAL_RUN="${FAKE_TRANSITIONAL_RUN:-}" \
+    FAKE_LEGACY_RUN="${FAKE_LEGACY_RUN:-}" \
+    FAKE_UNRELATED_RUN="${FAKE_UNRELATED_RUN:-}" \
+    FAKE_MALFORMED_RUN_ID="${FAKE_MALFORMED_RUN_ID:-}" \
     REPO_SETTINGS_TOKEN=settings-token \
     "$SOURCE"
 }
@@ -309,6 +401,59 @@ if [ "$rc" = 0 ] || grep -qE 'git/refs --method POST| --method PUT|^pr (create|m
   exit 1
 fi
 echo "[OK] non-404 read failure causes zero mutations"
+
+state="$WORK/state-run-query-failure"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+FAKE_RUN_QUERY_FAIL_STATUS=queued
+set +e
+run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+unset FAKE_RUN_QUERY_FAIL_STATUS
+if [ "$rc" = 0 ] ||
+  grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr (create|merge)' "$WORK/gh.log"; then
+  echo "[FAIL] partial active-run inventory was treated as fleet quiescence"
+  exit 1
+fi
+echo "[OK] any active-run status query failure blocks caller mutation"
+
+state="$WORK/state-malformed-run-inventory"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+FAKE_MALFORMED_RUN_ID=1
+set +e
+run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+unset FAKE_MALFORMED_RUN_ID
+if [ "$rc" = 0 ] || grep -q 'actions/runs/not-a-run-id' "$WORK/gh.log" ||
+  grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr (create|merge)' "$WORK/gh.log"; then
+  echo "[FAIL] malformed active-run inventory was used as a cancellation target"
+  exit 1
+fi
+echo "[OK] malformed active-run inventory fails before cancellation or caller mutation"
+
+state="$WORK/state-transitioning-run"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+FAKE_TRANSITIONAL_RUN=1
+set +e
+run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+unset FAKE_TRANSITIONAL_RUN
+if [ "$rc" != 83 ] ||
+  ! grep -q 'actions/runs/901/cancel --method POST' "$WORK/gh.log" ||
+  [ ! -f "$state/transition-canceled" ] ||
+  [ "$(grep -c 'runs?status=queued' "$WORK/gh.log")" -lt 4 ]; then
+  echo "[FAIL] status transition escaped the settled quiescence proof"
+  exit 1
+fi
+echo "[OK] repeated empty inventories catch and cancel status transitions"
 
 state="$WORK/state-newer"
 mkdir -p "$state"
@@ -491,6 +636,27 @@ if [ "$rc" != 78 ] || ! grep -q '/enable --method PUT' "$WORK/gh.log" ||
   exit 1
 fi
 echo "[OK] source advancement during enable re-quiesces the fleet"
+
+state="$WORK/state-missing-workflow-active-run"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+FAKE_MISSING_WORKFLOW=1
+FAKE_MERGE_LANDS=1
+FAKE_LEGACY_RUN=1
+FAKE_UNRELATED_RUN=1
+set +e
+run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+unset FAKE_MISSING_WORKFLOW FAKE_MERGE_LANDS FAKE_LEGACY_RUN FAKE_UNRELATED_RUN
+if [ "$rc" != 0 ] || [ ! -f "$state/legacy-canceled" ] ||
+  ! grep -q 'actions/runs/902/cancel --method POST' "$WORK/gh.log" ||
+  grep -q 'actions/runs/903/cancel' "$WORK/gh.log" || [ -f "$state/unrelated-canceled" ]; then
+  echo "[FAIL] active legacy run escaped quiescence after its workflow file was deleted"
+  exit 1
+fi
+echo "[OK] missing current workflow still inventories and cancels active legacy runs"
 
 state="$WORK/state-missing-workflow"
 mkdir -p "$state"

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -688,6 +688,23 @@ git -C "$repo" add fixture.mdx
 git -C "$repo" commit -qm jq-options
 assert_clean "jq indentation and option arguments preserve filter context" "$repo" --scope head --mode enforce
 
+repo=$(new_repo jq-person-field-expression)
+cat >"${repo}/fixture.sh" <<'EOF'
+jq -n --arg repo "$repo_name" '{full_name: $repo}'
+EOF
+git -C "$repo" add fixture.sh
+git -C "$repo" commit -qm jq-person-field-expression
+assert_clean "computed person fields inside jq filters do not crash the scanner" "$repo" --scope head --mode enforce
+
+repo=$(new_repo jq-person-field-literal)
+cat >"${repo}/fixture.sh" <<'EOF'
+jq -n '{full_name: "Literal Person"}'
+EOF
+git -C "$repo" add fixture.sh
+git -C "$repo" commit -qm jq-person-field-literal
+assert_single_finding "literal person fields inside jq filters remain enforced" \
+  "$repo" person-name high --scope head --mode enforce
+
 repo=$(new_repo jq-numeric-literal)
 cat >"${repo}/fixture.mdx" <<'EOF'
 ```bash

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -59,6 +59,8 @@ check "triggers when fleet membership changes" \
   "grep -q 'downstream-repos.json' '$WF'"
 check "triggers when the dispatcher contract changes" \
   "grep -q 'dispatch-downstream.yml' '$WF'"
+check "triggers when the exact managed caller changes" \
+  "grep -q 'workflows/enforce-repo-settings.yml' '$WF'"
 check "triggers after the immutable governed workflow pin rolls forward" \
   "grep -q 'governed-workflow-pin.json' '$WF'"
 check "triggers when the explicit governance rollout state changes" \
@@ -67,6 +69,8 @@ check "does NOT trigger on build workflow_run (stale-manifest race)" \
   "! grep -q 'workflow_run:' '$WF'"
 check "keeps manual workflow_dispatch fallback" \
   "grep -q 'workflow_dispatch:' '$WF'"
+check "queues transitions instead of cancelling a mutating bootstrap" \
+  "grep -A5 '^concurrency:' '$WF' | grep -q 'cancel-in-progress: false'"
 
 # Receipt: every downstream workflow must receive the exact docs-control commit
 # that caused this dispatch. Without this field, callers resolve mutable main at

--- a/tests/test-fetch-governed.sh
+++ b/tests/test-fetch-governed.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Unit tests for tests/fixtures/fetch-governed.sh
-# Run: bash tests/test-fetch-governed.sh
+# Unit tests for exact governed-content reads.
 set -euo pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
@@ -49,17 +48,10 @@ teardown_stubs() {
   unset STUB_DIR FAKE_LOG
 }
 stub_curl() {
-  local mode="$1" body="${2:-}"
-  printf '%s' "$body" >"${STUB_DIR}/curl.body"
   cat >"${STUB_DIR}/curl" <<EOF
 #!/usr/bin/env bash
 echo "curl \$*" >> "${FAKE_LOG}"
-case "${mode}" in
-  200)   cat "${STUB_DIR}/curl.body"; exit 0 ;;
-  404)   exit 22 ;;
-  empty) exit 0 ;;
-  hang)  exit 28 ;;
-esac
+exit 99
 EOF
   chmod +x "${STUB_DIR}/curl"
 }
@@ -77,61 +69,55 @@ EOF
   chmod +x "${STUB_DIR}/gh"
 }
 
-# --- Tests ----------------------------------------------------------
-export PAGES_BASE="https://example.test/docs-control"
+expected_source_sha="1111111111111111111111111111111111111111"
 
 # shellcheck source=fixtures/fetch-governed.sh disable=SC1091
 . "$SOURCE"
 
-CURRENT_TEST="pages 200 -> use pages, no gh call"
+CURRENT_TEST="exact API read returns verified receipt bytes"
 setup_stubs
-stub_curl 200 '{"hello":"world"}'
-stub_gh fail
+stub_curl
+stub_gh ok '{"type":"file","sha":"e4e07a17cff3c298ae171a752a8186ff4484638d","size":19,"content":"ZXhhY3QtcmVjZWlwdC1ieXRlcw==","encoding":"base64"}'
 out=$(fetch_governed repo-settings.json "repos/x/y/contents/.github/config/repo-settings.json")
-_assert_eq '{"hello":"world"}' "$out" "body matches"
-if grep -q "^gh " "$FAKE_LOG"; then
-  FAIL=$((FAIL + 1))
-  echo "  [FAIL] ${CURRENT_TEST} — gh was called"
-else
-  PASS=$((PASS + 1))
-  echo "  [PASS] ${CURRENT_TEST} — gh was NOT called"
-fi
+_assert_eq 'exact-receipt-bytes' "$out" "decoded body"
+_assert_eq \
+  "gh api repos/x/y/contents/.github/config/repo-settings.json?ref=${expected_source_sha}" \
+  "$(grep '^gh ' "$FAKE_LOG")" \
+  "API read is bound to the exact source receipt"
+_assert_eq "" "$(grep '^curl ' "$FAKE_LOG" || true)" \
+  "mutable Pages/CDN bytes are never requested"
 teardown_stubs
 
-CURRENT_TEST="pages 404 -> fallback to gh api"
+CURRENT_TEST="invalid source receipt fails before any read"
 setup_stubs
-stub_curl 404
-stub_gh ok '{"content":"aGVsbG8=","encoding":"base64"}'
-out=$(fetch_governed repo-settings.json "repos/x/y/contents/.github/config/repo-settings.json")
-_assert_eq 'hello' "$out" "decoded body"
-if grep -q "^gh " "$FAKE_LOG"; then
-  PASS=$((PASS + 1))
-  echo "  [PASS] ${CURRENT_TEST} — gh invoked"
-else
-  FAIL=$((FAIL + 1))
-  echo "  [FAIL] ${CURRENT_TEST} — gh not invoked"
-fi
+stub_curl
+stub_gh ok '{"type":"file","sha":"e4e07a17cff3c298ae171a752a8186ff4484638d","size":19,"content":"ZXhhY3QtcmVjZWlwdC1ieXRlcw==","encoding":"base64"}'
+saved_source_sha="$expected_source_sha"
+expected_source_sha=""
+set +e
+fetch_governed x.json "repos/x/y/contents/x.json" >/dev/null 2>&1
+rc=$?
+set -e
+expected_source_sha="$saved_source_sha"
+_assert_nonzero "$rc"
+_assert_eq "" "$(cat "$FAKE_LOG")" "no network read attempted"
 teardown_stubs
 
-CURRENT_TEST="pages empty body -> fallback"
+CURRENT_TEST="pre-existing query cannot override the exact receipt"
 setup_stubs
-stub_curl empty
-stub_gh ok '{"content":"Zm9v","encoding":"base64"}'
-out=$(fetch_governed x.json "repos/x/y/contents/x.json")
-_assert_eq 'foo' "$out"
+stub_curl
+stub_gh ok '{"type":"file","sha":"e4e07a17cff3c298ae171a752a8186ff4484638d","size":19,"content":"ZXhhY3QtcmVjZWlwdC1ieXRlcw==","encoding":"base64"}'
+set +e
+fetch_governed x.json "repos/x/y/contents/x.json?ref=main" >/dev/null 2>&1
+rc=$?
+set -e
+_assert_nonzero "$rc"
+_assert_eq "" "$(cat "$FAKE_LOG")" "ambiguous API path rejected locally"
 teardown_stubs
 
-CURRENT_TEST="pages timeout -> fallback"
+CURRENT_TEST="API failure returns non-zero"
 setup_stubs
-stub_curl hang
-stub_gh ok '{"content":"YmFy","encoding":"base64"}'
-out=$(fetch_governed x.json "repos/x/y/contents/x.json")
-_assert_eq 'bar' "$out"
-teardown_stubs
-
-CURRENT_TEST="both fail -> non-zero exit"
-setup_stubs
-stub_curl 404
+stub_curl
 stub_gh fail
 set +e
 fetch_governed x.json "repos/x/y/contents/x.json" >/dev/null 2>&1
@@ -140,24 +126,26 @@ set -e
 _assert_nonzero "$rc"
 teardown_stubs
 
-CURRENT_TEST="revision_is_fresh: SHA matches"
+CURRENT_TEST="malformed API envelope returns non-zero"
 setup_stubs
-stub_curl 200 '{"commit":"abc123","generated_at":"2026-04-20T00:00:00Z"}'
+stub_curl
+stub_gh ok '{"type":"file","sha":"bad","size":19,"content":"","encoding":"none"}'
 set +e
-revision_is_fresh abc123
+fetch_governed x.json "repos/x/y/contents/x.json" >/dev/null 2>&1
 rc=$?
 set -e
-_assert_eq 0 "$rc" "fresh when SHA equal"
+_assert_nonzero "$rc" "invalid content response rejected"
 teardown_stubs
 
-CURRENT_TEST="revision_is_fresh: SHA mismatch"
+CURRENT_TEST="content digest mismatch returns non-zero"
 setup_stubs
-stub_curl 200 '{"commit":"old0000","generated_at":"2026-04-20T00:00:00Z"}'
+stub_curl
+stub_gh ok '{"type":"file","sha":"0000000000000000000000000000000000000000","size":19,"content":"ZXhhY3QtcmVjZWlwdC1ieXRlcw==","encoding":"base64"}'
 set +e
-revision_is_fresh abc123
+fetch_governed x.json "repos/x/y/contents/x.json" >/dev/null 2>&1
 rc=$?
 set -e
-_assert_nonzero "$rc" "stale when SHA differs"
+_assert_nonzero "$rc" "decoded bytes must match GitHub blob receipt"
 teardown_stubs
 
 echo ""

--- a/tests/test-inlined-helpers-match.sh
+++ b/tests/test-inlined-helpers-match.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Ensures the inlined fetch_governed/revision_is_fresh functions in
+# Ensures the inlined fetch_governed function in
 # consumer workflows stay byte-identical with the canonical source at
 # tests/fixtures/fetch-governed.sh.
 set -euo pipefail
@@ -13,7 +13,6 @@ SOURCE="${REPO_ROOT}/tests/fixtures/fetch-governed.sh"
 # to find verbatim (modulo leading whitespace) inside each consumer.
 canonical=$(awk '
   /^fetch_governed\(\)/,/^}$/ { print; next }
-  /^revision_is_fresh\(\)/,/^}$/ { print }
 ' "$SOURCE" | sed -e 's/^[[:space:]]*//' -e '/^$/d' -e '/^#/d')
 
 FAIL=0
@@ -22,7 +21,6 @@ for wf in \
   "${REPO_ROOT}/.github/workflows/enforce-repo-settings.yml"; do
   inlined=$(awk '
     /fetch_governed\(\)/,/^[[:space:]]*}[[:space:]]*$/ { print; next }
-    /revision_is_fresh\(\)/,/^[[:space:]]*}[[:space:]]*$/ { print }
   ' "$wf" | sed -e 's/^[[:space:]]*//' -e '/^$/d' -e '/^#/d')
   if [ "$inlined" = "$canonical" ]; then
     echo "[OK] $(basename "$wf") helper matches canonical"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1100,6 +1100,50 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 15: every docs-control shell test is a guarded CI step
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 15: complete shell-test CI inventory ==="
+
+if python3 - "$REPO_ROOT" "$SUPER_LINTER_WORKFLOW" <<'PY'; then
+import pathlib
+import re
+import sys
+
+import yaml
+
+repo_root = pathlib.Path(sys.argv[1])
+workflow_path = pathlib.Path(sys.argv[2])
+with workflow_path.open(encoding="utf-8") as workflow_file:
+    workflow = yaml.safe_load(workflow_file)
+
+expected = {
+    path.relative_to(repo_root).as_posix()
+    for path in (repo_root / "tests").glob("test-*.sh")
+    if path.is_file()
+}
+steps = workflow["jobs"]["shell-unit-tests"]["steps"]
+observed: list[str] = []
+for step in steps:
+    command = step.get("run", "")
+    match = re.fullmatch(r"bash (tests/test-[A-Za-z0-9._-]+[.]sh)", command)
+    if not match:
+        continue
+    path = match.group(1)
+    if step.get("if") != f"hashFiles('{path}') != ''":
+        raise SystemExit(1)
+    observed.append(path)
+
+if len(observed) != len(set(observed)) or set(observed) != expected:
+    raise SystemExit(1)
+PY
+  pass "15.1 every shell test has exactly one guarded CI step"
+else
+  fail "15.1 every shell test has exactly one guarded CI step" \
+    "shell-unit-tests does not exactly cover tests/test-*.sh"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # Summary
 # ════════════════════════════════════════════════════════════════════
 echo ""

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1086,14 +1086,17 @@ else
     "the group needs a reusable-workflow-specific prefix"
 fi
 
-# Two workflow_call defaults and the runtime fallback must resolve to identical
-# bytes. A caller can still opt into a different immutable digest explicitly.
-if [ "$(grep -cF "$EXPECTED_BUILDER" "$PAGES_WORKFLOW")" = "3" ] &&
-  ! grep -Fq 'docs-builder:latest' "$PAGES_WORKFLOW"; then
-  pass "14.3 every default documentation builder input uses the measured digest"
+# One workflow_call default is validated before use; there is no runtime
+# fallback. Callers may select a different immutable digest only in the approved
+# builder repository.
+if [ "$(grep -cF "$EXPECTED_BUILDER" "$PAGES_WORKFLOW")" = "1" ] &&
+  grep -qF '^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$' "$PAGES_WORKFLOW" &&
+  grep -qF '${{ steps.content.outputs.builder_image }}' "$PAGES_WORKFLOW" &&
+  ! grep -Eq 'docs-builder:latest|inputs\.builder-image \|\|' "$PAGES_WORKFLOW"; then
+  pass "14.3 documentation builder identity is validated and digest-pinned"
 else
-  fail "14.3 every default documentation builder input uses the measured digest" \
-    "expected three identical digest pins and no latest tag"
+  fail "14.3 documentation builder identity is validated and digest-pinned" \
+    "expected one measured default, approved digest validation, and no fallback"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -7,6 +7,7 @@ DEPLOY_WORKFLOW="$REPO_ROOT/.github/workflows/github-pages-deploy.yml"
 SELF_CALLER="$REPO_ROOT/.github/workflows/docs-site-deploy.yml"
 PAGES_CALLER="$REPO_ROOT/workflows/github-pages-deploy.yml"
 GOVERNANCE_CALLER="$REPO_ROOT/workflows/enforce-repo-settings.yml"
+SYNC_WORKFLOW="$REPO_ROOT/.github/workflows/sync-managed-files.yml"
 FAIL=0
 
 ok() { echo "[OK] $1"; }
@@ -120,7 +121,7 @@ for workflow_file in \
   fi
 
   if grep -q 'compare/${expected_source_sha}...${current_source_sha}' "$workflow_file" &&
-    grep -q 'Historical protected-main receipt; enqueueing current main' "$workflow_file" &&
+    grep -q 'Docs-control protected main advanced; enqueued its exact receipt' "$workflow_file" &&
     grep -q 'gh workflow run' "$workflow_file"; then
     ok "$workflow_name independently enforces monotonic protected-main delivery"
   else
@@ -145,6 +146,17 @@ if grep -q 'DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}' "$GOV
   ok "managed caller accepts only current downstream protected main"
 else
   bad "manual or historical downstream refs can feed reusable governance jobs"
+fi
+
+downstream_input=$(sed -n '/^      downstream_sha:/,/^        type: string/p' "$SYNC_WORKFLOW")
+if grep -q '^        required: true$' <<<"$downstream_input" &&
+  grep -qF 'ref: ${{ inputs.downstream_sha }}' "$SYNC_WORKFLOW" &&
+  grep -qF 'downstream_sha: ${{ github.sha }}' "$GOVERNANCE_CALLER" &&
+  grep -q 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' "$SYNC_WORKFLOW" &&
+  [ "$(grep -c 'require_current_downstream_main' "$SYNC_WORKFLOW")" -ge 3 ]; then
+  ok "managed sync binds comparisons and mutations to one downstream protected-main receipt"
+else
+  bad "managed sync can compare one downstream commit and mutate another"
 fi
 
 exit "$FAIL"

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -1,28 +1,13 @@
 #!/usr/bin/env bash
-# Hermetic regression test for the Pages-freshness guard in the governed-read
-# workflows (sync-managed-files.yml, enforce-repo-settings.yml).
-#
-# WHY: `fetch_governed` prefers the Pages-published governance mirror, which lags a
-# docs-control merge by however long its deploy takes. The guard must force an API
-# fallback whenever Pages is behind. It previously ran ONLY when a source_sha was
-# passed, so schedule/manual runs read a STALE manifest and drift detection reported
-# "[OK] All managed files match canonical" for files that had genuinely drifted —
-# governance changes silently never propagated. enforce-repo-settings.yml defined
-# revision_is_fresh but never called it at all.
-#
-# This test locks two properties, statically (no network):
-#   1. Both workflows CALL the guard, and do so UNCONDITIONALLY on SOURCE_SHA
-#      (i.e. an empty source_sha must still be checked, via a main-HEAD fallback).
-#   2. The revision_is_fresh comparison semantics stay exact-match.
+# Contracts for exact Pages publication identity and governed source receipts.
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+DEPLOY_WORKFLOW="$REPO_ROOT/.github/workflows/github-pages-deploy.yml"
+SELF_CALLER="$REPO_ROOT/.github/workflows/docs-site-deploy.yml"
+PAGES_CALLER="$REPO_ROOT/workflows/github-pages-deploy.yml"
+GOVERNANCE_CALLER="$REPO_ROOT/workflows/enforce-repo-settings.yml"
 FAIL=0
-
-WORKFLOWS=(
-  "${REPO_ROOT}/.github/workflows/sync-managed-files.yml"
-  "${REPO_ROOT}/.github/workflows/enforce-repo-settings.yml"
-)
 
 ok() { echo "[OK] $1"; }
 bad() {
@@ -30,52 +15,136 @@ bad() {
   FAIL=1
 }
 
-for wf in "${WORKFLOWS[@]}"; do
-  name=$(basename "$wf")
+input_block=$(sed -n '/^      content-ref:/,/^        type: string/p' "$DEPLOY_WORKFLOW")
+checkout_block=$(sed -n '/^      - name: Checkout content repo/,/^      - name: Login to GHCR/p' "$DEPLOY_WORKFLOW")
+validation_block=$(sed -n '/^      - name: Resolve immutable content commit/,/^      - name: Checkout content repo/p' "$DEPLOY_WORKFLOW")
+revision_block=$(sed -n '/^      - name: Stage governance assets for \/api\//,/^      - name: Upload artifact/p' "$DEPLOY_WORKFLOW")
 
-  # 1. The guard must actually be invoked, not merely defined.
-  if grep -qE '^\s*(elif ! |if ! )?revision_is_fresh "' "$wf"; then
-    ok "$name calls revision_is_fresh"
+if grep -q '^        required: true$' <<<"$input_block" &&
+  grep -q '^        type: string$' <<<"$input_block"; then
+  ok "Pages deploy requires an explicit workflow_call content-ref"
+else
+  bad "Pages deploy workflow_call content-ref is not required"
+fi
+
+if grep -qF 'CONTENT_REF="$REQUESTED_REF"' <<<"$validation_block" &&
+  grep -qF '^[0-9a-f]{40}$' <<<"$validation_block" &&
+  ! grep -qE 'GITHUB_SHA|\|\|' <<<"$validation_block"; then
+  ok "Pages deploy accepts only a full immutable commit"
+else
+  bad "Pages deploy has a mutable or fallback content identity"
+fi
+
+if grep -qF 'BUILDER_IMAGE="$REQUESTED_IMAGE"' <<<"$validation_block" &&
+  grep -qF '^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$' <<<"$validation_block" &&
+  grep -qF 'builder_image=$BUILDER_IMAGE' <<<"$validation_block"; then
+  ok "Pages deploy accepts only the approved digest-pinned builder"
+else
+  bad "Pages deploy permits a mutable or unapproved builder image"
+fi
+
+if grep -qF 'ref: ${{ steps.content.outputs.content_ref }}' <<<"$checkout_block" &&
+  grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$checkout_block" &&
+  grep -qF 'if [ "$CHECKED_OUT_SHA" != "$CONTENT_REF" ]' <<<"$checkout_block"; then
+  ok "Pages checkout resolves and verifies the requested commit"
+else
+  bad "Pages checkout is not bound to the requested commit"
+fi
+
+if grep -qF 'DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}' <<<"$checkout_block" &&
+  grep -qF 'refs/remotes/origin/main' <<<"$checkout_block" &&
+  grep -qF '[ "$PROTECTED_MAIN_SHA" != "$CONTENT_REF" ]' <<<"$checkout_block"; then
+  ok "Pages publication proves content-ref is current protected main"
+else
+  bad "manual Pages dispatch can publish an unmerged commit"
+fi
+
+if grep -qF '${{ steps.content.outputs.builder_image }}' "$DEPLOY_WORKFLOW" &&
+  ! grep -qF 'inputs.builder-image ||' "$DEPLOY_WORKFLOW"; then
+  ok "Pages build uses the validated builder identity without fallback"
+else
+  bad "Pages build bypasses the validated builder identity"
+fi
+
+if ! grep -qE '^  (push|workflow_dispatch):' "$DEPLOY_WORKFLOW" &&
+  [ -f "$SELF_CALLER" ] &&
+  grep -qF 'uses: ./.github/workflows/github-pages-deploy.yml' "$SELF_CALLER" &&
+  grep -qF 'content-ref: ${{ github.sha }}' "$SELF_CALLER"; then
+  ok "direct docs-control triggers use a thin exact-ref caller"
+else
+  bad "reusable Pages workflow owns a direct trigger or lacks an exact-ref caller"
+fi
+
+if grep -qF 'CONTENT_REF: ${{ steps.content.outputs.content_ref }}' <<<"$revision_block" &&
+  grep -qF 'BUILDER_IMAGE: ${{ steps.content.outputs.builder_image }}' <<<"$revision_block" &&
+  grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$revision_block" &&
+  grep -qF -- '--arg content_ref "${CONTENT_REF}"' <<<"$revision_block" &&
+  grep -qF -- '--arg commit "${CHECKED_OUT_SHA}"' <<<"$revision_block" &&
+  grep -qF -- '--arg builder_image "${BUILDER_IMAGE}"' <<<"$revision_block" &&
+  grep -qF "'{content_ref:\$content_ref, commit:\$commit, builder_image:\$builder_image}'" <<<"$revision_block"; then
+  ok "revision.json binds content and validated builder identities"
+else
+  bad "revision.json does not identify the exact published content and builder"
+fi
+
+if grep -qE 'GITHUB_SHA|generated_at|date -u' <<<"$revision_block"; then
+  bad "revision.json contains incidental or wall-clock inputs"
+else
+  ok "revision.json is deterministic for one content commit"
+fi
+
+if grep -qF 'content-ref: ${{ github.sha }}' "$PAGES_CALLER"; then
+  ok "governed Pages caller forwards its exact commit"
+else
+  bad "governed Pages caller omits content-ref"
+fi
+
+for workflow_file in \
+  "$REPO_ROOT/.github/workflows/sync-managed-files.yml" \
+  "$REPO_ROOT/.github/workflows/enforce-repo-settings.yml"; do
+  workflow_name=$(basename "$workflow_file")
+  source_block=$(sed -n '/^      source_sha:/,/^        type: string/p' "$workflow_file" | head -4)
+
+  if grep -q '^        required: true$' <<<"$source_block" &&
+    ! grep -q 'default:' <<<"$source_block"; then
+    ok "$workflow_name requires an exact workflow_call receipt"
   else
-    bad "$name never calls revision_is_fresh (guard defined but unused = no protection)"
+    bad "$workflow_name permits an empty workflow_call receipt"
   fi
 
-  # 2. The invocation must NOT be gated on a non-empty SOURCE_SHA. The old bug was
-  #    `if [ -n "${SOURCE_SHA:-}" ] && ! revision_is_fresh ...`, which skipped the
-  #    check entirely on schedule/manual runs.
-  if grep -qE '\[ -n "\$\{SOURCE_SHA:-\}" \][[:space:]]*&&[[:space:]]*! revision_is_fresh' "$wf"; then
-    bad "$name gates the freshness check on a non-empty SOURCE_SHA (stale reads on schedule/manual runs)"
+  if grep -Fq '?ref=${expected_source_sha}' "$workflow_file" &&
+    ! grep -qE 'PAGES_BASE|revision_is_fresh|curl .*github\.io' "$workflow_file"; then
+    ok "$workflow_name reads governance only from the exact API ref"
   else
-    ok "$name does not gate the freshness check on SOURCE_SHA"
+    bad "$workflow_name can consume mutable governance bytes"
   fi
 
-  # 3. There must be a fallback that resolves the expected sha when SOURCE_SHA is
-  #    empty (docs-control main HEAD), so the guard has something to compare.
-  if grep -q 'expected_source_sha' "$wf" &&
-    grep -qE 'docs-control/commits/main' "$wf"; then
-    ok "$name resolves docs-control main HEAD when source_sha is empty"
+  if grep -q 'compare/${expected_source_sha}...${current_source_sha}' "$workflow_file" &&
+    grep -q 'Historical protected-main receipt; enqueueing current main' "$workflow_file" &&
+    grep -q 'gh workflow run' "$workflow_file"; then
+    ok "$workflow_name independently enforces monotonic protected-main delivery"
   else
-    bad "$name has no main-HEAD fallback for the expected sha"
-  fi
-
-  # 4. A failed/indeterminate freshness check must force the API fallback by
-  #    poisoning PAGES_BASE (that is how fetch_governed is made to error).
-  if grep -q 'PAGES_BASE="https://invalid.pages.local"' "$wf"; then
-    ok "$name forces API fallback when Pages is stale"
-  else
-    bad "$name does not force an API fallback on stale Pages"
-  fi
-
-  # 5. Freshness must be an EXACT sha match (no prefix/substring comparison).
-  if grep -qE '\[ "\$pages_sha" = "\$source_sha" \]' "$wf"; then
-    ok "$name compares pages_sha to source_sha exactly"
-  else
-    bad "$name freshness comparison is not an exact sha match"
+    bad "$workflow_name can apply a historical or unmerged receipt"
   fi
 done
 
-if [ "$FAIL" -ne 0 ]; then
-  echo "pages-staleness-guard tests FAILED"
-  exit 1
+if grep -q 'docs-control/commits/main' "$GOVERNANCE_CALLER" &&
+  grep -q 'compare/${source_sha}...${current_source_sha}' "$GOVERNANCE_CALLER" &&
+  grep -q '\[DEFER\].*historical docs-control receipt' "$GOVERNANCE_CALLER" &&
+  grep -q 'ready=false' "$GOVERNANCE_CALLER"; then
+  ok "managed governance caller resolves one monotonic receipt"
+else
+  bad "managed governance caller can invoke reusable jobs with a stale receipt"
 fi
-echo "pages-staleness-guard tests passed"
+
+if grep -q 'DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}' "$GOVERNANCE_CALLER" &&
+  grep -Fq 'repos/${GITHUB_REPOSITORY}/commits/main' "$GOVERNANCE_CALLER" &&
+  grep -q 'compare/${DOWNSTREAM_SHA}...${current_downstream_sha}' "$GOVERNANCE_CALLER" &&
+  grep -q -- '--ref main' "$GOVERNANCE_CALLER" &&
+  grep -q 'ready=false' "$GOVERNANCE_CALLER"; then
+  ok "managed caller accepts only current downstream protected main"
+else
+  bad "manual or historical downstream refs can feed reusable governance jobs"
+fi
+
+exit "$FAIL"

--- a/tests/test-readme-generation.sh
+++ b/tests/test-readme-generation.sh
@@ -162,10 +162,24 @@ else
     "generated prose must use 'prerelease', never 'pre-release'"
 fi
 
-if grep -q 'readme_english_only' "$SYNC_WORKFLOW" &&
-  grep -q '__LANGUAGE_NAV__' "$SYNC_WORKFLOW" &&
-  grep -q 'type) == "boolean"' "$SYNC_WORKFLOW" &&
-  grep -q 'readme_english_only must be a JSON boolean' "$SYNC_WORKFLOW"; then
+awk '
+  /^          validate_docs_sites\(\) \{/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$SYNC_WORKFLOW" >"$WORK/validate-docs-sites.sh"
+if (
+  # shellcheck source=/dev/null
+  source "$WORK/validate-docs-sites.sh"
+  OWNER=f5-sales-demo
+  validate_docs_sites <"$DOCS_SITES" &&
+    ! jq 'map(if .url | contains("/api-specs-enriched/") then
+      .readme_english_only = "true" else . end)' "$DOCS_SITES" |
+    validate_docs_sites
+) && grep -q '__LANGUAGE_NAV__' "$SYNC_WORKFLOW"; then
   pass "4.5 sync-managed-files renders a strictly typed per-repository language policy"
 else
   fail "4.5 sync-managed-files renders a strictly typed per-repository language policy" \

--- a/tests/test-retry-stdout.sh
+++ b/tests/test-retry-stdout.sh
@@ -322,8 +322,8 @@ fi
 # phase, and a 404 after apply must fail verification rather than be downgraded to
 # a warning that still permits the final success message.
 pages_apply_block=$(sed -n '/# --- Phase 6: Apply Pages/,/# --- Phase 7: Enforce secrets/p' "$ENFORCE_WF")
-if grep -qE 'retry_json .*--method POST' <<<"$pages_apply_block" &&
-  ! grep -qE 'retry_json .*--method POST.*\|\| true' <<<"$pages_apply_block"; then
+if grep -qE 'retry_current_json .*--method POST' <<<"$pages_apply_block" &&
+  ! grep -qE 'retry_current_json .*--method POST.*\|\| true' <<<"$pages_apply_block"; then
   pass "Pages creation failure is fatal"
 else
   fail "Pages creation failure is fatal" "the required POST is absent or its failure is suppressed"

--- a/tests/test-retry-stdout.sh
+++ b/tests/test-retry-stdout.sh
@@ -318,6 +318,86 @@ else
   fail "unknown Pages status fails verification" "unknown status does not set VERIFY_FAILED"
 fi
 
+# A configured Pages site is required state. Creation errors must stop the apply
+# phase, and a 404 after apply must fail verification rather than be downgraded to
+# a warning that still permits the final success message.
+pages_apply_block=$(sed -n '/# --- Phase 6: Apply Pages/,/# --- Phase 7: Enforce secrets/p' "$ENFORCE_WF")
+if grep -qE 'retry_json .*--method POST' <<<"$pages_apply_block" &&
+  ! grep -qE 'retry_json .*--method POST.*\|\| true' <<<"$pages_apply_block"; then
+  pass "Pages creation failure is fatal"
+else
+  fail "Pages creation failure is fatal" "the required POST is absent or its failure is suppressed"
+fi
+
+pages_missing_verification_block=$(
+  awk '
+    /elif \[ "\$VERIFY_PAGES_CODE" = "404" \]; then/ { found=1; next }
+    found && /^[[:space:]]*else$/ { exit }
+    found { print }
+  ' "$ENFORCE_WF"
+)
+if grep -q 'VERIFY_FAILED=true' <<<"$pages_missing_verification_block"; then
+  pass "Pages 404 after apply fails verification"
+else
+  fail "Pages 404 after apply fails verification" "missing required Pages state can still report success"
+fi
+
+# Enforcement reads that decide whether to mutate protected settings must
+# distinguish a proved 404 from transport, authorization, and schema failures.
+protection_apply_block=$(sed -n '/# --- Phase 4: Apply branch protection/,/# --- Phase 5: Apply topics/p' "$ENFORCE_WF")
+if grep -q 'api_value_or_404' <<<"$protection_apply_block" &&
+  ! grep -qE '(HTTP_CODE|CURRENT_PROTECTION)=.*\|\| true' <<<"$protection_apply_block"; then
+  pass "branch-protection inventory distinguishes absence from read failure"
+else
+  fail "branch-protection inventory distinguishes absence from read failure" \
+    "an unreadable protection can still be treated as missing and overwritten"
+fi
+
+secrets_apply_block=$(sed -n '/# --- Phase 7: Enforce secrets/,/# --- Phase 8: Verify/p' "$ENFORCE_WF")
+if grep -q 'actions/secrets?per_page=100' <<<"$secrets_apply_block" &&
+  grep -q -- '--paginate --slurp' <<<"$secrets_apply_block" &&
+  ! grep -qE 'CURRENT_SECRETS=.*\|\| true' <<<"$secrets_apply_block"; then
+  pass "secret inventory is complete and fatal on read failure"
+else
+  fail "secret inventory is complete and fatal on read failure" \
+    "partial or failed secret inventory can still report an audit result"
+fi
+
+verify_protection_block=$(sed -n '/VERIFY_PROTECTION=/,/desired_enforce=/p' "$ENFORCE_WF")
+if ! grep -qE 'VERIFY_PROTECTION=.*\|\| true' <<<"$verify_protection_block"; then
+  pass "branch-protection verification read failure is fatal"
+else
+  fail "branch-protection verification read failure is fatal" \
+    "failed verification reads are still converted to an empty value"
+fi
+
+if grep -q 'normalize_desired_protection()' "$ENFORCE_WF" &&
+  grep -q 'normalize_current_protection()' "$ENFORCE_WF" &&
+  grep -q 'Branch protection does not match desired state' "$ENFORCE_WF" &&
+  grep -q 'Branch protection failed exact verification' "$ENFORCE_WF"; then
+  pass "branch protection compares one complete normalized state during apply and verify"
+else
+  fail "branch protection compares one complete normalized state during apply and verify" \
+    "null reviews, status checks, restrictions, or flags can escape convergence"
+fi
+
+if grep -q '\[ "$MISSING" -gt 0 \]' <<<"$secrets_apply_block" &&
+  grep -q '\[ERROR\].*required repository secret' <<<"$secrets_apply_block"; then
+  pass "missing required secrets fail enforcement"
+else
+  fail "missing required secrets fail enforcement" \
+    "measured missing secrets can still lead to an OK result"
+fi
+
+pages_apply_block=$(sed -n '/# --- Phase 6: Apply Pages/,/# --- Phase 7: Enforce secrets/p' "$ENFORCE_WF")
+if ! grep -qE 'PAGES_RESPONSE=.*\|\| true' <<<"$pages_apply_block" &&
+  grep -q 'Pages API returned an invalid response' <<<"$pages_apply_block"; then
+  pass "Pages body read and schema failures are fatal before PUT"
+else
+  fail "Pages body read and schema failures are fatal before PUT" \
+    "a failed body GET can still be converted into corrective mutation"
+fi
+
 # The probes must stay off retry(), or the regression returns silently.
 if grep -qE 'retry [0-9]+ gh api .*--include' "$ENFORCE_WF"; then
   fail "status probes do not use retry()" "a --include probe is still wrapped in retry"

--- a/tests/test-source-mutation-guard.sh
+++ b/tests/test-source-mutation-guard.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Prove governed workflows stop mutating when docs-control main advances.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin"
+
+cat >"$WORK/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+case "$*" in
+  'api repos/f5-sales-demo/docs-control/commits/main --jq .sha')
+    if [ -n "${FAKE_ADVANCE_FILE:-}" ] && [ -f "$FAKE_ADVANCE_FILE" ]; then
+      printf '%s\n' "$FAKE_ADVANCED_SOURCE_SHA"
+    else
+      printf '%s\n' "$FAKE_CURRENT_SOURCE_SHA"
+    fi
+    ;;
+  'api repos/f5-sales-demo/docs-control/compare/'*' --jq .status')
+    printf '%s\n' "$FAKE_SOURCE_STATUS"
+    ;;
+  'workflow run enforce-repo-settings.yml --repo f5-sales-demo/example --ref main -f source_sha='*)
+    exit 0
+    ;;
+  'api repos/f5-sales-demo/example/commits/main --jq .sha')
+    printf '%s\n' "$FAKE_CURRENT_DOWNSTREAM_SHA"
+    ;;
+  'api repos/f5-sales-demo/example --method PATCH --input -')
+    touch "$FAKE_ADVANCE_FILE"
+    exit 1
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+chmod +x "$WORK/bin/gh"
+
+extract_function() {
+  local workflow="$1" function_name="$2"
+  awk -v signature="          ${function_name}() {" '
+    $0 == signature { found=1 }
+    found {
+      line=$0
+      sub(/^          /, "")
+      print
+      if (line == "          }") exit
+    }
+  ' "$workflow"
+}
+
+PASS=0
+FAIL=0
+OLD_SOURCE_SHA=1111111111111111111111111111111111111111
+NEW_SOURCE_SHA=2222222222222222222222222222222222222222
+
+for workflow in \
+  "$REPO_ROOT/.github/workflows/sync-managed-files.yml" \
+  "$REPO_ROOT/.github/workflows/enforce-repo-settings.yml"; do
+  workflow_name=$(basename "$workflow")
+  helper_file="$WORK/${workflow_name}.helpers.sh"
+  extract_function "$workflow" retry >"$helper_file"
+  if [ "$workflow_name" = sync-managed-files.yml ]; then
+    extract_function "$workflow" require_sha >>"$helper_file"
+  fi
+  extract_function "$workflow" ensure_current_source_main >>"$helper_file"
+
+  rc=0
+  : >"$WORK/gh.log"
+  (
+    # shellcheck source=/dev/null
+    source "$helper_file"
+    export PATH="$WORK/bin:$PATH"
+    export FAKE_GH_LOG="$WORK/gh.log"
+    export FAKE_CURRENT_SOURCE_SHA="$OLD_SOURCE_SHA"
+    export FAKE_SOURCE_STATUS=ahead
+    export GITHUB_REPOSITORY_OWNER=f5-sales-demo
+    export GITHUB_REPOSITORY=f5-sales-demo/example
+    export REPO_SETTINGS_TOKEN=fake-token
+    expected_source_sha="$OLD_SOURCE_SHA"
+    ensure_current_source_main
+
+    # This is the mutation-boundary call after main advances during the run.
+    export FAKE_CURRENT_SOURCE_SHA="$NEW_SOURCE_SHA"
+    ensure_current_source_main
+  ) >"$WORK/stdout" 2>"$WORK/stderr" || rc=$?
+
+  dispatches=$(grep -c '^workflow run enforce-repo-settings.yml' "$WORK/gh.log" || true)
+  if [ "$rc" -eq 78 ] && [ "$dispatches" -eq 1 ] && grep -q \
+    "^workflow run enforce-repo-settings.yml --repo f5-sales-demo/example --ref main -f source_sha=${NEW_SOURCE_SHA}$" \
+    "$WORK/gh.log"; then
+    echo "[OK] ${workflow_name} defers stale mutation and enqueues exact source main"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] ${workflow_name} did not stop a stale mutation (rc=$rc dispatches=$dispatches)"
+    sed 's/^/  /' "$WORK/stderr"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+for workflow in \
+  "$REPO_ROOT/.github/workflows/sync-managed-files.yml" \
+  "$REPO_ROOT/.github/workflows/enforce-repo-settings.yml"; do
+  workflow_name=$(basename "$workflow")
+  helper_file="$WORK/${workflow_name}.retry-helpers.sh"
+  extract_function "$workflow" retry >"$helper_file"
+  if [ "$workflow_name" = sync-managed-files.yml ]; then
+    for function_name in \
+      require_sha ensure_current_downstream_main require_current_downstream_main; do
+      extract_function "$workflow" "$function_name" >>"$helper_file"
+    done
+  fi
+  for function_name in \
+    ensure_current_source_main require_current_source_main \
+    current_json_request retry_current_json; do
+    extract_function "$workflow" "$function_name" >>"$helper_file"
+  done
+
+  rc=0
+  : >"$WORK/gh.log"
+  advance_file="$WORK/${workflow_name}.advanced"
+  rm -f "$advance_file"
+  (
+    # shellcheck source=/dev/null
+    source "$helper_file"
+    export PATH="$WORK/bin:$PATH"
+    export FAKE_GH_LOG="$WORK/gh.log"
+    export FAKE_CURRENT_SOURCE_SHA="$OLD_SOURCE_SHA"
+    export FAKE_ADVANCED_SOURCE_SHA="$NEW_SOURCE_SHA"
+    export FAKE_ADVANCE_FILE="$advance_file"
+    export FAKE_SOURCE_STATUS=ahead
+    export FAKE_CURRENT_DOWNSTREAM_SHA=3333333333333333333333333333333333333333
+    export GITHUB_REPOSITORY_OWNER=f5-sales-demo
+    export GITHUB_REPOSITORY=f5-sales-demo/example
+    export REPO_SETTINGS_TOKEN=fake-token
+    expected_source_sha="$OLD_SOURCE_SHA"
+    expected_downstream_sha="$FAKE_CURRENT_DOWNSTREAM_SHA"
+    retry_current_json 3 '{}' "repos/${GITHUB_REPOSITORY}" --method PATCH
+  ) >"$WORK/stdout" 2>"$WORK/stderr" || rc=$?
+
+  mutations=$(grep -c '^api repos/f5-sales-demo/example --method PATCH --input -$' \
+    "$WORK/gh.log" || true)
+  dispatches=$(grep -c '^workflow run enforce-repo-settings.yml' "$WORK/gh.log" || true)
+  if [ "$rc" -eq 0 ] && [ "$mutations" -eq 1 ] && [ "$dispatches" -eq 1 ]; then
+    echo "[OK] ${workflow_name} re-proves source before a mutation retry"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] ${workflow_name} retried a mutation after source advancement"
+    sed 's/^/  /' "$WORK/stderr"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+sync_guard_count=$(grep -c 'require_current_source_main' \
+  "$REPO_ROOT/.github/workflows/sync-managed-files.yml")
+settings_guard_count=$(grep -c 'require_current_source_main' \
+  "$REPO_ROOT/.github/workflows/enforce-repo-settings.yml")
+sync_max_wait=$(sed -n 's/^[[:space:]]*local max_wait=//p' \
+  "$REPO_ROOT/.github/workflows/sync-managed-files.yml")
+if [ "$sync_guard_count" -ge 10 ] && [ "$settings_guard_count" -ge 10 ] &&
+  [ "$sync_max_wait" -ge 1800 ] &&
+  ! grep -q -- '--auto' "$REPO_ROOT/.github/workflows/sync-managed-files.yml"; then
+  echo "[OK] source guards run initially and again at every governed result or mutation boundary"
+  PASS=$((PASS + 1))
+else
+  echo "[FAIL] source guards are not repeated at governed mutation boundaries"
+  FAIL=$((FAIL + 1))
+fi
+
+echo "=== Summary: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test-source-receipt-ordering.sh
+++ b/tests/test-source-receipt-ordering.sh
@@ -25,8 +25,18 @@ cat >"$WORK/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$FAKE_GH_LOG"
 case "$*" in
-  *'/commits/main'*) printf '%s\n' "$FAKE_CURRENT_SHA" ;;
-  *'/compare/'*) printf '%s\n' "$FAKE_COMPARE_STATUS" ;;
+  *'repos/f5-sales-demo/docs-control/commits/main'*)
+    printf '%s\n' "$FAKE_CURRENT_SOURCE_SHA"
+    ;;
+  *'repos/f5-sales-demo/example/commits/main'*)
+    printf '%s\n' "$FAKE_CURRENT_DOWNSTREAM_SHA"
+    ;;
+  *'repos/f5-sales-demo/docs-control/compare/'*)
+    printf '%s\n' "$FAKE_SOURCE_COMPARE_STATUS"
+    ;;
+  *'repos/f5-sales-demo/example/compare/'*)
+    printf '%s\n' "$FAKE_DOWNSTREAM_COMPARE_STATUS"
+    ;;
   *'docs-control/contents/workflows/enforce-repo-settings.yml?ref='*)
     printf '{"type":"file","encoding":"base64","sha":"%s","content":"%s"}\n' \
       "$FAKE_CALLER_BLOB" "$FAKE_CALLER_CONTENT"
@@ -60,6 +70,9 @@ chmod +x "$WORK/bin/gh"
 OLD_SHA=1111111111111111111111111111111111111111
 NEW_SHA=2222222222222222222222222222222222222222
 BRANCH_SHA=3333333333333333333333333333333333333333
+OLD_DOWNSTREAM_SHA=8888888888888888888888888888888888888888
+CURRENT_DOWNSTREAM_SHA=9999999999999999999999999999999999999999
+BRANCH_DOWNSTREAM_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ENFORCE_BLOB=5555555555555555555555555555555555555555
 SYNC_BLOB=6666666666666666666666666666666666666666
 PIN_SHA=7777777777777777777777777777777777777777
@@ -72,8 +85,11 @@ PASS=0
 FAIL=0
 
 run_case() {
-  local label="$1" requested="$2" current="$3" status="$4" expected_rc="$5" expected_ready="$6"
-  local expected_requeues="$7" expected_bootstraps="$8" rc ready requeues bootstraps
+  local label="$1" requested="$2" current_source="$3" source_status="$4"
+  local downstream_sha="$5" current_downstream="$6" downstream_status="$7"
+  local default_branch="$8" expected_rc="$9" expected_ready="${10}"
+  local expected_requeues="${11}" expected_bootstraps="${12}"
+  local rc ready requeues bootstraps exact_requeue=true
   : >"$WORK/output"
   : >"$WORK/gh.log"
   set +e
@@ -82,10 +98,13 @@ run_case() {
     GITHUB_OUTPUT="$WORK/output" \
     GITHUB_REPOSITORY_OWNER=f5-sales-demo \
     GITHUB_REPOSITORY=f5-sales-demo/example \
-    DOWNSTREAM_SHA=8888888888888888888888888888888888888888 \
+    DOWNSTREAM_SHA="$downstream_sha" \
+    DEFAULT_BRANCH="$default_branch" \
     REQUESTED_SOURCE_SHA="$requested" \
-    FAKE_CURRENT_SHA="$current" \
-    FAKE_COMPARE_STATUS="$status" \
+    FAKE_CURRENT_SOURCE_SHA="$current_source" \
+    FAKE_SOURCE_COMPARE_STATUS="$source_status" \
+    FAKE_CURRENT_DOWNSTREAM_SHA="$current_downstream" \
+    FAKE_DOWNSTREAM_COMPARE_STATUS="$downstream_status" \
     FAKE_GH_LOG="$WORK/gh.log" \
     FAKE_CALLER_BLOB="$CALLER_BLOB" \
     FAKE_CALLER_CONTENT="$CALLER_CONTENT" \
@@ -99,8 +118,20 @@ run_case() {
   ready=$(sed -n 's/^ready=//p' "$WORK/output")
   requeues=$(grep -c '^workflow run enforce-repo-settings.yml' "$WORK/gh.log" || true)
   bootstraps=$(grep -c '^workflow run dispatch-downstream.yml' "$WORK/gh.log" || true)
+  if [ "$expected_requeues" -eq 1 ]; then
+    if ! grep -q "^workflow run enforce-repo-settings.yml .*source_sha=${current_source}$" \
+      "$WORK/gh.log"; then
+      exact_requeue=false
+    fi
+    if [ "$downstream_sha" != "$current_downstream" ] &&
+      [ "$downstream_status" = "ahead" ] &&
+      ! grep -q '^workflow run enforce-repo-settings.yml .* --ref main ' "$WORK/gh.log"; then
+      exact_requeue=false
+    fi
+  fi
   if [ "$rc" = "$expected_rc" ] && [ "$ready" = "$expected_ready" ] &&
-    [ "$requeues" = "$expected_requeues" ] && [ "$bootstraps" = "$expected_bootstraps" ]; then
+    [ "$requeues" = "$expected_requeues" ] &&
+    [ "$bootstraps" = "$expected_bootstraps" ] && [ "$exact_requeue" = true ]; then
     echo "[OK] $label"
     PASS=$((PASS + 1))
   else
@@ -110,18 +141,41 @@ run_case() {
   fi
 }
 
-run_case "old receipt applies while old is protected main" "$OLD_SHA" "$OLD_SHA" ahead 0 true 0 0
-run_case "new receipt applies after protected main advances" "$NEW_SHA" "$NEW_SHA" ahead 0 true 0 0
-run_case "old receipt enqueues new main instead of rolling back" "$OLD_SHA" "$NEW_SHA" ahead 0 false 1 0
-run_case "unmerged branch receipt fails provenance" "$BRANCH_SHA" "$NEW_SHA" diverged 1 "" 0 0
+run_case "old receipt applies while old is protected main" \
+  "$OLD_SHA" "$OLD_SHA" ahead \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 0 true 0 0
+run_case "new receipt applies after protected main advances" \
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 0 true 0 0
+run_case "old source receipt enqueues new main instead of rolling back" \
+  "$OLD_SHA" "$NEW_SHA" ahead \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 0 false 1 0
+run_case "unmerged source receipt fails provenance" \
+  "$BRANCH_SHA" "$NEW_SHA" diverged \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 1 "" 0 0
+run_case "historical downstream receipt requeues exact protected main" \
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  "$OLD_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 0 false 1 0
+run_case "unmerged downstream receipt fails provenance" \
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  "$BRANCH_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" diverged main 1 "" 0 0
+run_case "invalid downstream receipt fails closed" \
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  not-a-sha "$CURRENT_DOWNSTREAM_SHA" ahead main 1 "" 0 0
+run_case "non-main default branch fails closed" \
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead trunk 1 "" 0 0
 
 FAKE_DOWNSTREAM_CALLER_BLOB=9999999999999999999999999999999999999999
-run_case "legacy caller enqueues central bootstrap without enforcement" "$NEW_SHA" "$NEW_SHA" ahead 0 false 0 1
+run_case "legacy caller enqueues central bootstrap without enforcement" \
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 0 false 0 1
 unset FAKE_DOWNSTREAM_CALLER_BLOB
 
 FAKE_ROLLOUT_STATE=quiesced
 run_case "quiesced caller refuses reusable enforcement and requests state repair" \
-  "$NEW_SHA" "$NEW_SHA" ahead 0 false 0 1
+  "$NEW_SHA" "$NEW_SHA" ahead \
+  "$CURRENT_DOWNSTREAM_SHA" "$CURRENT_DOWNSTREAM_SHA" ahead main 0 false 0 1
 unset FAKE_ROLLOUT_STATE
 
 echo "=== Summary: ${PASS} passed, ${FAIL} failed ==="

--- a/tests/test-sync-downstream-receipt.sh
+++ b/tests/test-sync-downstream-receipt.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Exercise sync's downstream protected-main guard across job advancement.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SYNC_WORKFLOW="$REPO_ROOT/.github/workflows/sync-managed-files.yml"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin"
+
+extract_function() {
+  local function_name="$1"
+  awk -v signature="          ${function_name}() {" '
+    $0 == signature { found=1 }
+    found {
+      line=$0
+      sub(/^          /, "")
+      print
+      if (line == "          }") exit
+    }
+  ' "$SYNC_WORKFLOW"
+}
+
+for function_name in retry require_sha ensure_current_downstream_main; do
+  extract_function "$function_name" >>"$WORK/helpers.sh"
+done
+# shellcheck source=/dev/null
+source "$WORK/helpers.sh"
+
+cat >"$WORK/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+case "$*" in
+  'api repos/f5-sales-demo/example/commits/main --jq .sha')
+    printf '%s\n' "$FAKE_CURRENT_DOWNSTREAM_SHA"
+    ;;
+  'api repos/f5-sales-demo/example/compare/'*' --jq .status')
+    printf '%s\n' "$FAKE_DOWNSTREAM_STATUS"
+    ;;
+  'workflow run enforce-repo-settings.yml --repo f5-sales-demo/example --ref main -f source_sha='*)
+    exit 0
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+chmod +x "$WORK/bin/gh"
+
+export PATH="$WORK/bin:$PATH"
+export FAKE_GH_LOG="$WORK/gh.log"
+export GITHUB_REPOSITORY=f5-sales-demo/example
+export REPO_SETTINGS_TOKEN=fake-token
+expected_source_sha=1111111111111111111111111111111111111111
+expected_downstream_sha=2222222222222222222222222222222222222222
+NEW_DOWNSTREAM_SHA=3333333333333333333333333333333333333333
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1" expected_rc="$2" expected_dispatches="$3"
+  local rc=0 dispatches
+  : >"$FAKE_GH_LOG"
+  ensure_current_downstream_main >"$WORK/stdout" 2>"$WORK/stderr" || rc=$?
+  dispatches=$(grep -c '^workflow run enforce-repo-settings.yml' "$FAKE_GH_LOG" || true)
+  if [ "$rc" -eq "$expected_rc" ] && [ "$dispatches" -eq "$expected_dispatches" ]; then
+    echo "[OK] $label"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $label (rc=$rc dispatches=$dispatches)"
+    sed 's/^/  /' "$WORK/stderr"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+export FAKE_CURRENT_DOWNSTREAM_SHA="$expected_downstream_sha"
+export FAKE_DOWNSTREAM_STATUS=ahead
+check "exact checked-out receipt remains current before scanning" 0 0
+
+# Simulate main advancing after the first guard and before the post-scan guard.
+export FAKE_CURRENT_DOWNSTREAM_SHA="$NEW_DOWNSTREAM_SHA"
+check "post-scan advancement defers mutation and requeues current main" 78 1
+if grep -q \
+  "^workflow run enforce-repo-settings.yml --repo f5-sales-demo/example --ref main -f source_sha=${expected_source_sha}$" \
+  "$FAKE_GH_LOG"; then
+  echo "[OK] recovery is bound to main and the exact source receipt"
+  PASS=$((PASS + 1))
+else
+  echo "[FAIL] recovery omitted main or the exact source receipt"
+  FAIL=$((FAIL + 1))
+fi
+
+export FAKE_CURRENT_DOWNSTREAM_SHA="$NEW_DOWNSTREAM_SHA"
+export FAKE_DOWNSTREAM_STATUS=diverged
+check "unmerged downstream receipt fails closed" 1 0
+
+export FAKE_CURRENT_DOWNSTREAM_SHA=invalid
+export FAKE_DOWNSTREAM_STATUS=ahead
+check "malformed downstream protected-main receipt fails closed" 1 0
+
+echo "=== Summary: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -386,26 +386,26 @@ if [ -s "$WORK/select-owned-sync-pr.sh" ]; then
   REPO=consumer
   PR_SHA=0123456789abcdef0123456789abcdef01234567
 
-  jq -n --arg sha "$PR_SHA" '
+  jq -n --arg sha "$PR_SHA" --arg repo "$OWNER/$REPO" '
     [[{number: 17,
        head: {ref: "governance/sync-managed-files", sha: $sha,
-              repo: {full_name: "example/consumer"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}}]]
   ' >"$WORK/sync-owned.json"
-  jq -n --arg sha "$PR_SHA" '
+  jq -n --arg sha "$PR_SHA" --arg repo "attacker/$REPO" '
     [[{number: 18,
        head: {ref: "governance/sync-managed-files", sha: $sha,
-              repo: {full_name: "attacker/consumer"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}}]]
   ' >"$WORK/sync-fork.json"
-  jq -n --arg sha "$PR_SHA" '
+  jq -n --arg sha "$PR_SHA" --arg repo "$OWNER/$REPO" '
     [[{number: 19,
        head: {ref: "governance/sync-managed-files", sha: $sha,
-              repo: {full_name: "example/consumer"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}},
       {number: 20,
        head: {ref: "governance/sync-managed-files", sha: $sha,
-              repo: {full_name: "example/consumer"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}}]]
   ' >"$WORK/sync-duplicate.json"
 
@@ -448,26 +448,26 @@ if [ -s "$WORK/select-owned-manifest-pr.sh" ]; then
   BRANCH=sync/manifest
   PR_SHA=89abcdef0123456789abcdef0123456789abcdef
 
-  jq -n --arg sha "$PR_SHA" '
+  jq -n --arg sha "$PR_SHA" --arg repo "$GITHUB_REPOSITORY" '
     [[{number: 21,
        head: {ref: "sync/manifest", sha: $sha,
-              repo: {full_name: "example/docs-control"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}}]]
   ' >"$WORK/manifest-owned.json"
-  jq -n --arg sha "$PR_SHA" '
+  jq -n --arg sha "$PR_SHA" --arg repo "attacker/${GITHUB_REPOSITORY#*/}" '
     [[{number: 22,
        head: {ref: "sync/manifest", sha: $sha,
-              repo: {full_name: "attacker/docs-control"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}}]]
   ' >"$WORK/manifest-fork.json"
-  jq -n --arg sha "$PR_SHA" '
+  jq -n --arg sha "$PR_SHA" --arg repo "$GITHUB_REPOSITORY" '
     [[{number: 23,
        head: {ref: "sync/manifest", sha: $sha,
-              repo: {full_name: "example/docs-control"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}},
       {number: 24,
        head: {ref: "sync/manifest", sha: $sha,
-              repo: {full_name: "example/docs-control"}},
+              repo: {full_name: $repo}},
        base: {ref: "main"}}]]
   ' >"$WORK/manifest-duplicate.json"
 

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -48,10 +48,11 @@ else
     "extraction produced nothing; the assertions below would be vacuous"
 fi
 
-if grep -q 'commit_tree' "$WORK/existing_pr_block.txt"; then
-  pass "1.2 the existing-PR path commits the drifted files"
+if grep -q 'gh pr close' "$WORK/existing_pr_block.txt"; then
+  pass "1.2 the existing-PR path retires the superseded automation PR"
 else
-  fail "1.2 the existing-PR path commits the drifted files" "no commit_tree call found"
+  fail "1.2 the existing-PR path retires the superseded automation PR" \
+    "the shared mutable PR remains in place"
 fi
 
 echo ""
@@ -76,35 +77,34 @@ else
 fi
 
 echo ""
-echo "=== Section 3: rebasing still happens, atomically ==="
+echo "=== Section 3: replacement uses a unique non-destructive branch ==="
 
-# Dropping the rebase is not an acceptable fix: a branch based on an old main
-# produces a diff that reverts unrelated commits. It has to move to main's SHA
-# as part of the same ref update that adds the drift commit.
-# The call is written across backslash-continued lines, so join continuations
-# before matching -- grep is line-based and would miss it.
+# A fixed automation branch requires a destructive force update to rebase an
+# existing PR. Use a unique run-owned branch from current main instead: an
+# unproved pre-existing branch can never be overwritten.
 perl -0pe 's/\\\n\s*/ /g' "$WORK/existing_pr_block.txt" >"$WORK/existing_pr_joined.txt"
 
-if grep -qE 'commit_tree[^|;]*"\$MAIN_SHA"' "$WORK/existing_pr_joined.txt"; then
-  pass "3.1 the existing-PR path rebases via commit_tree's base argument"
+if grep -q 'SYNC_BRANCH=.*GITHUB_RUN_ID.*GITHUB_RUN_ATTEMPT' "$SYNC"; then
+  pass "3.1 each sync transition owns a unique run branch"
 else
-  fail "3.1 the existing-PR path rebases via commit_tree's base argument" \
-    "commit_tree is not given a base commit, so the branch would stay on its old base"
+  fail "3.1 each sync transition owns a unique run branch" \
+    "the workflow still depends on a shared mutable automation branch"
 fi
 
-if grep -qE 'local base_override|base_override="\$3"' "$SYNC"; then
-  pass "3.2 commit_tree accepts a base-commit override"
+if grep -q 'gh pr close "$EXISTING_PR"' "$SYNC" &&
+  grep -q -- '--comment "Superseded by exact managed-file receipt' "$SYNC"; then
+  pass "3.2 a proved prior automation PR is closed before replacement"
 else
-  fail "3.2 commit_tree accepts a base-commit override" \
-    "commit_tree still derives its parent solely from the branch head"
+  fail "3.2 a proved prior automation PR is closed before replacement" \
+    "an existing mutable PR can still be force-rebased in place"
 fi
 
-# A force update is required once the parent is main rather than the branch tip.
-if grep -qE '"force": *(true|\$force)' "$SYNC"; then
-  pass "3.3 commit_tree can force the ref update when rebasing"
+if ! grep -qE '"force": *(true|\$force)|base_override' "$SYNC" &&
+  grep -q -- '--base main' "$SYNC"; then
+  pass "3.3 sync branch updates are non-force and PR base is explicit"
 else
-  fail "3.3 commit_tree can force the ref update when rebasing" \
-    "a non-force PATCH cannot move the branch onto a new base"
+  fail "3.3 sync branch updates are non-force and PR base is explicit" \
+    "force movement or an implicit PR base remains"
 fi
 
 echo ""
@@ -159,7 +159,12 @@ if [ -s "$WORK/tree_payload_helpers.sh" ]; then
       printf '\n\n' >>"$RAW_CONTENT"
     fi
     normalize_tree_content "$RAW_CONTENT" "$NORMALIZED_CONTENT"
-    append_tree_item "$TREE_ITEMS" "fixtures/large-${index}.txt" "$NORMALIZED_CONTENT"
+    if [ $((index % 2)) -eq 0 ]; then
+      FILE_MODE=100755
+    else
+      FILE_MODE=100644
+    fi
+    append_tree_item "$TREE_ITEMS" "fixtures/large-${index}.txt" "$FILE_MODE" "$NORMALIZED_CONTENT"
   done
 
   TREE_REQUEST="$WORK/tree-request.json"
@@ -172,7 +177,8 @@ if [ -s "$WORK/tree_payload_helpers.sh" ]; then
     --argjson expected_length "$((LARGE_BYTES + 1))" \
     '.base_tree == $base_tree and
      (.tree | length) == $expected_count and
-     all(.tree[]; .mode == "100644" and .type == "blob") and
+     all(.tree[]; (.mode == "100644" or .mode == "100755") and .type == "blob") and
+     ([.tree[].mode] == ["100644","100755","100644","100755","100644","100755","100644","100755","100644","100755"]) and
      all(.tree[]; (.content | length) == $expected_length) and
      all(.tree[]; .content | endswith("\n")) and
      (.tree[1].path == "fixtures/large-2.txt")' \
@@ -185,6 +191,392 @@ if [ -s "$WORK/tree_payload_helpers.sh" ]; then
 else
   fail "4.4 production helpers assemble multiple oversized entries exactly" \
     "payload helpers were unavailable for the stress test"
+fi
+
+echo ""
+echo "=== Section 5: exact managed content fails closed ==="
+
+if grep -qE 'fetch_governed.*(\|\| true|\|\| echo)' "$SYNC"; then
+  fail "5.1 governed fetch failures are fatal" \
+    "required canonical content fetches are suppressed"
+else
+  pass "5.1 governed fetch failures are fatal"
+fi
+
+if grep -q 'No cached content.*skipping' "$SYNC"; then
+  fail "5.2 every drifted path must have cached canonical bytes" \
+    "commit_tree silently skips drifted files with missing content"
+else
+  pass "5.2 every drifted path must have cached canonical bytes"
+fi
+
+if grep -qE '(canonical.*git hash-object|git hash-object.*canonical)' "$SYNC" &&
+  grep -q 'Canonical blob mismatch' "$SYNC"; then
+  pass "5.3 fetched managed bytes are checked against the manifest blob"
+else
+  fail "5.3 fetched managed bytes are checked against the manifest blob" \
+    "cached managed content is not verified against its exact manifest entry"
+fi
+
+if grep -q 'Manifest entry missing or inconsistent' "$SYNC" &&
+  ! grep -q 'falling back to per-file' "$SYNC"; then
+  pass "5.4 missing manifest evidence fails closed"
+else
+  fail "5.4 missing manifest evidence fails closed" \
+    "managed content can bypass the manifest receipt"
+fi
+
+if grep -Fq 'git/trees/${expected_source_sha}?recursive=1' "$SYNC" &&
+  grep -Fq 'compare/${MANIFEST_COMMIT}...${expected_source_sha}' "$SYNC" &&
+  grep -q 'truncated == false' "$SYNC" &&
+  grep -q 'Exact source tree does not match the managed manifest' "$SYNC"; then
+  pass "5.5 manifest bytes are proved against the requested commit tree"
+else
+  fail "5.5 manifest bytes are proved against the requested commit tree" \
+    "manifest source_commit shape is accepted without exact-tree evidence"
+fi
+
+if grep -q '\.mode | type == "string"' "$SYNC" &&
+  grep -q 'LOCAL_MODE' "$SYNC" &&
+  grep -q 'CANONICAL_MODE' "$SYNC"; then
+  pass "5.6 executable modes participate in drift detection"
+else
+  fail "5.6 executable modes participate in drift detection" \
+    "blob-equal executable managed files can be silently demoted"
+fi
+
+MANIFEST_BUILDER="$REPO_ROOT/.github/workflows/build-managed-files-manifest.yml"
+if grep -q 'git ls-files -s' "$MANIFEST_BUILDER" &&
+  grep -q 'mode: \$mode' "$MANIFEST_BUILDER"; then
+  pass "5.7 manifest publication records canonical Git modes"
+else
+  fail "5.7 manifest publication records canonical Git modes" \
+    "manifest cannot carry executable-file identity"
+fi
+
+if ! grep -qE 'generated_at|date -u' "$MANIFEST_BUILDER"; then
+  pass "5.8 manifest bytes contain no wall-clock data"
+else
+  fail "5.8 manifest bytes contain no wall-clock data" \
+    "repeating the same source/configuration can publish different canonical bytes"
+fi
+
+echo ""
+echo "=== Section 6: required PR transitions fail closed ==="
+
+if grep -qE 'auto_merge .*\|\| true' "$SYNC"; then
+  fail "6.1 managed-file auto-merge failures are fatal" \
+    "a sync path suppresses the required auto-merge result"
+else
+  pass "6.1 managed-file auto-merge failures are fatal"
+fi
+
+if grep -q 'merge attempted' "$SYNC"; then
+  fail "6.2 sync reports only confirmed auto-merge state" \
+    "the workflow reports an attempt instead of the required confirmed transition"
+else
+  pass "6.2 sync reports only confirmed auto-merge state"
+fi
+
+if grep -qE 'gh pr merge .*\|\| true' "$MANIFEST_BUILDER"; then
+  fail "6.3 manifest auto-merge failures are fatal" \
+    "manifest publication suppresses failure while claiming auto-merge is enabled"
+else
+  pass "6.3 manifest auto-merge failures are fatal"
+fi
+
+perl -0pe 's/\\\n\s*/ /g' "$SYNC" >"$WORK/sync-joined.txt"
+perl -0pe 's/\\\n\s*/ /g' "$MANIFEST_BUILDER" >"$WORK/manifest-joined.txt"
+
+if grep -q 'gh pr list' "$WORK/sync-joined.txt" &&
+  grep -qE -- '--head +"?governance/sync-managed-files' "$WORK/sync-joined.txt"; then
+  fail "6.4 existing sync PR selection inventories ownership" \
+    "gh pr list cannot express or prove same-repository head ownership"
+elif grep -Fq 'pulls?state=open&per_page=100' "$SYNC" &&
+  grep -q -- '--paginate --slurp' "$SYNC" &&
+  grep -q 'head.repo.full_name' "$SYNC" &&
+  grep -q 'base.ref' "$SYNC" &&
+  grep -q 'head.sha' "$SYNC" &&
+  grep -q 'Multiple open sync PRs' "$SYNC"; then
+  pass "6.4 existing sync PR selection inventories ownership"
+else
+  fail "6.4 existing sync PR selection inventories ownership" \
+    "same-name fork, base, exact head, or duplicate ownership is not proved"
+fi
+
+if grep -qE '(EXISTING_PR|STALE_ISSUES)=.*\|\| true|gh issue close .*\|\| true' \
+  "$WORK/sync-joined.txt"; then
+  fail "6.5 sync PR and issue inventory failures are fatal" \
+    "required inventory or close errors are suppressed"
+else
+  pass "6.5 sync PR and issue inventory failures are fatal"
+fi
+
+if grep -q 'assert_sync_pr_head()' "$SYNC" &&
+  [ "$(grep -Ec 'assert_sync_pr_head +"' "$WORK/sync-joined.txt")" -ge 2 ]; then
+  pass "6.6 selected sync PR head is re-proved before auto-merge"
+else
+  fail "6.6 selected sync PR head is re-proved before auto-merge" \
+    "existing and newly-created PR paths do not prove the branch commit"
+fi
+
+if grep -q 'BRANCH_LOOKUP_RC' "$SYNC" &&
+  grep -q 'api_value_or_404.*git/ref/heads/${SYNC_BRANCH}' "$WORK/sync-joined.txt" &&
+  ! grep -qE 'if ! retry_json .*git/refs.*--method POST' "$WORK/sync-joined.txt"; then
+  pass "6.7 branch creation distinguishes absence from API failure"
+else
+  fail "6.7 branch creation distinguishes absence from API failure" \
+    "any create error can still be treated as a proved existing branch"
+fi
+
+if grep -q 'managed_cache_path()' "$SYNC" &&
+  grep -q 'git hash-object --stdin' "$SYNC" &&
+  ! grep -q "tr '/' '__'" "$SYNC"; then
+  pass "6.8 managed drift cache keys cannot collide on slash and underscore"
+else
+  fail "6.8 managed drift cache keys cannot collide on slash and underscore" \
+    "destination paths still use a lossy cache-key encoding"
+fi
+
+if grep -q 'Duplicate managed-file destinations' "$MANIFEST_BUILDER" &&
+  grep -q 'group_by' "$MANIFEST_BUILDER"; then
+  pass "6.9 manifest publication rejects duplicate destinations"
+else
+  fail "6.9 manifest publication rejects duplicate destinations" \
+    "last-writer-wins manifest construction remains possible"
+fi
+
+if grep -Fq 'git show "HEAD:${MANIFEST_PATH}"' "$MANIFEST_BUILDER" &&
+  ! grep -qE "CURRENT_FILES=.*\|\| echo '\{\}'" "$WORK/manifest-joined.txt"; then
+  pass "6.10 current manifest comparison fails closed at the exact checkout"
+else
+  fail "6.10 current manifest comparison fails closed at the exact checkout" \
+    "API, decode, or schema failure can still masquerade as an empty manifest"
+fi
+
+if grep -q 'read_manifest_prs()' "$MANIFEST_BUILDER" &&
+  grep -q 'head.repo.full_name' "$MANIFEST_BUILDER" &&
+  grep -q 'base.ref' "$MANIFEST_BUILDER" &&
+  grep -q 'head.sha' "$MANIFEST_BUILDER" &&
+  grep -q 'Multiple open manifest PRs' "$MANIFEST_BUILDER" &&
+  ! grep -q 'gh pr list --head' "$MANIFEST_BUILDER"; then
+  pass "6.11 manifest PR ownership and exact head fail closed"
+else
+  fail "6.11 manifest PR ownership and exact head fail closed" \
+    "manifest auto-merge can act on an unowned, duplicate, or stale-head PR"
+fi
+
+echo ""
+echo "=== Section 7: hostile and duplicate PR inventories are rejected ==="
+
+awk '
+  /^          select_owned_sync_pr\(\) \{/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$SYNC" >"$WORK/select-owned-sync-pr.sh"
+
+if [ -s "$WORK/select-owned-sync-pr.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$WORK/select-owned-sync-pr.sh"
+  OWNER=example
+  REPO=consumer
+  PR_SHA=0123456789abcdef0123456789abcdef01234567
+
+  jq -n --arg sha "$PR_SHA" '
+    [[{number: 17,
+       head: {ref: "governance/sync-managed-files", sha: $sha,
+              repo: {full_name: "example/consumer"}},
+       base: {ref: "main"}}]]
+  ' >"$WORK/sync-owned.json"
+  jq -n --arg sha "$PR_SHA" '
+    [[{number: 18,
+       head: {ref: "governance/sync-managed-files", sha: $sha,
+              repo: {full_name: "attacker/consumer"}},
+       base: {ref: "main"}}]]
+  ' >"$WORK/sync-fork.json"
+  jq -n --arg sha "$PR_SHA" '
+    [[{number: 19,
+       head: {ref: "governance/sync-managed-files", sha: $sha,
+              repo: {full_name: "example/consumer"}},
+       base: {ref: "main"}},
+      {number: 20,
+       head: {ref: "governance/sync-managed-files", sha: $sha,
+              repo: {full_name: "example/consumer"}},
+       base: {ref: "main"}}]]
+  ' >"$WORK/sync-duplicate.json"
+
+  selected=$(select_owned_sync_pr "$WORK/sync-owned.json")
+  if [ "$selected" = "$(printf '17\tgovernance/sync-managed-files\t%s' "$PR_SHA")" ]; then
+    pass "7.1 exact same-repository sync PR is selected"
+  else
+    fail "7.1 exact same-repository sync PR is selected" "selected $(printf '%q' "$selected")"
+  fi
+  if select_owned_sync_pr "$WORK/sync-fork.json" >/dev/null 2>&1; then
+    fail "7.2 same-name fork sync PR is rejected" "hostile fork returned success"
+  else
+    pass "7.2 same-name fork sync PR is rejected"
+  fi
+  if select_owned_sync_pr "$WORK/sync-duplicate.json" >/dev/null 2>&1; then
+    fail "7.3 duplicate sync PR owners are rejected" "duplicate inventory returned success"
+  else
+    pass "7.3 duplicate sync PR owners are rejected"
+  fi
+else
+  fail "7.1 exact same-repository sync PR is selected" "selection helper is absent"
+  fail "7.2 same-name fork sync PR is rejected" "selection helper is absent"
+  fail "7.3 duplicate sync PR owners are rejected" "selection helper is absent"
+fi
+
+awk '
+  /^          select_owned_manifest_pr\(\) \{/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$MANIFEST_BUILDER" >"$WORK/select-owned-manifest-pr.sh"
+
+if [ -s "$WORK/select-owned-manifest-pr.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$WORK/select-owned-manifest-pr.sh"
+  GITHUB_REPOSITORY=example/docs-control
+  BRANCH=sync/manifest
+  PR_SHA=89abcdef0123456789abcdef0123456789abcdef
+
+  jq -n --arg sha "$PR_SHA" '
+    [[{number: 21,
+       head: {ref: "sync/manifest", sha: $sha,
+              repo: {full_name: "example/docs-control"}},
+       base: {ref: "main"}}]]
+  ' >"$WORK/manifest-owned.json"
+  jq -n --arg sha "$PR_SHA" '
+    [[{number: 22,
+       head: {ref: "sync/manifest", sha: $sha,
+              repo: {full_name: "attacker/docs-control"}},
+       base: {ref: "main"}}]]
+  ' >"$WORK/manifest-fork.json"
+  jq -n --arg sha "$PR_SHA" '
+    [[{number: 23,
+       head: {ref: "sync/manifest", sha: $sha,
+              repo: {full_name: "example/docs-control"}},
+       base: {ref: "main"}},
+      {number: 24,
+       head: {ref: "sync/manifest", sha: $sha,
+              repo: {full_name: "example/docs-control"}},
+       base: {ref: "main"}}]]
+  ' >"$WORK/manifest-duplicate.json"
+
+  selected=$(select_owned_manifest_pr "$WORK/manifest-owned.json")
+  if [ "$selected" = "$(printf '21\t%s' "$PR_SHA")" ]; then
+    pass "7.4 exact same-repository manifest PR is selected"
+  else
+    fail "7.4 exact same-repository manifest PR is selected" "selected $(printf '%q' "$selected")"
+  fi
+  if select_owned_manifest_pr "$WORK/manifest-fork.json" >/dev/null 2>&1; then
+    fail "7.5 same-name fork manifest PR is rejected" "hostile fork returned success"
+  else
+    pass "7.5 same-name fork manifest PR is rejected"
+  fi
+  if select_owned_manifest_pr "$WORK/manifest-duplicate.json" >/dev/null 2>&1; then
+    fail "7.6 duplicate manifest PR owners are rejected" "duplicate inventory returned success"
+  else
+    pass "7.6 duplicate manifest PR owners are rejected"
+  fi
+else
+  fail "7.4 exact same-repository manifest PR is selected" "selection helper is absent"
+  fail "7.5 same-name fork manifest PR is rejected" "selection helper is absent"
+  fail "7.6 duplicate manifest PR owners are rejected" "selection helper is absent"
+fi
+
+echo ""
+echo "=== Section 8: protected-source and exact mutation receipts ==="
+
+if grep -q -- '--match-head-commit "$expected_sha"' "$SYNC" &&
+  grep -q -- '--match-head-commit "$EXPECTED_HEAD"' "$MANIFEST_BUILDER"; then
+  pass "8.1 every sync and manifest merge is bound to its verified head"
+else
+  fail "8.1 every sync and manifest merge is bound to its verified head" \
+    "a delayed auto-merge can merge a head that changed after verification"
+fi
+
+if grep -q 'PROTECTED_MAIN_SHA' "$MANIFEST_BUILDER" &&
+  grep -q '\[ "$SOURCE_COMMIT" != "$PROTECTED_MAIN_SHA" \]' "$MANIFEST_BUILDER" &&
+  grep -q 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' "$MANIFEST_BUILDER"; then
+  pass "8.2 manifest generation requires the exact current protected main"
+else
+  fail "8.2 manifest generation requires the exact current protected main" \
+    "workflow_dispatch can still publish from an unmerged or historical ref"
+fi
+
+if grep -q 'assert_manifest_pr_diff()' "$MANIFEST_BUILDER" &&
+  grep -q 'total_commits == 1' "$MANIFEST_BUILDER" &&
+  grep -q '\.files | length) == 1' "$MANIFEST_BUILDER" &&
+  grep -q '\.files\[0\]\.filename == $manifest_path' "$MANIFEST_BUILDER"; then
+  pass "8.3 manifest PR is an exact one-file commit on protected main"
+else
+  fail "8.3 manifest PR is an exact one-file commit on protected main" \
+    "unrelated branch commits can ride into the manifest PR"
+fi
+
+first_inventory_line=$(grep -n 'read_manifest_prs "$MANIFEST_PR_INVENTORY"' "$MANIFEST_BUILDER" |
+  head -1 | cut -d: -f1)
+push_line=$(grep -n 'git push' "$MANIFEST_BUILDER" | head -1 | cut -d: -f1)
+if [ -n "$first_inventory_line" ] && [ -n "$push_line" ] &&
+  [ "$first_inventory_line" -lt "$push_line" ] &&
+  grep -q -- '--force-with-lease=refs/heads/$BRANCH:$REMOTE_BRANCH_SHA' "$MANIFEST_BUILDER" &&
+  ! grep -q 'git push --force origin' "$MANIFEST_BUILDER"; then
+  pass "8.4 manifest ownership is proved before a lease-protected push"
+else
+  fail "8.4 manifest ownership is proved before a lease-protected push" \
+    "mutation precedes inventory or can overwrite a concurrently changed head"
+fi
+
+if grep -q 'validate_managed_routing()' "$SYNC" &&
+  grep -q 'only_repos' "$SYNC" &&
+  grep -q 'skip_files' "$SYNC"; then
+  pass "8.5 managed routing schema fails closed before drift evaluation"
+else
+  fail "8.5 managed routing schema fails closed before drift evaluation" \
+    "malformed routing can silently skip managed paths"
+fi
+
+if grep -q 'validate_docs_sites()' "$SYNC" &&
+  grep -q '\[ERROR\] No canonical docs-site metadata' "$SYNC" &&
+  ! grep -q '\[SKIP\] README.md -- no canonical docs-site metadata' "$SYNC" &&
+  ! grep -qE 'README_DESC=\$\(gh api|README_(TITLE|DESC|BADGES|CONTENT)=.*\|\| true' \
+    "$WORK/sync-joined.txt"; then
+  pass "8.6 missing canonical README metadata fails closed"
+else
+  fail "8.6 missing canonical README metadata fails closed" \
+    "absence of metadata can still silently opt a repository out of governance"
+fi
+
+if jq -e --slurpfile sites "$REPO_ROOT/.github/config/docs-sites.json" '
+    .managed_files.skip_files as $skip_files |
+    $sites[0] as $sites |
+    all($repos[];
+      . as $repo |
+      (($skip_files[$repo] // []) | index("README.md")) != null or
+      any($sites[]; .url == ("https://f5-sales-demo.github.io/" + $repo + "/llms-full.txt")))
+  ' --argjson repos "$(jq -c '.' "$REPO_ROOT/.github/config/downstream-repos.json")" \
+  "$REPO_ROOT/.github/config/repo-settings.json" >/dev/null; then
+  pass "8.7 every downstream README has canonical metadata or an explicit opt-out"
+else
+  fail "8.7 every downstream README has canonical metadata or an explicit opt-out" \
+    "the canonical fleet configuration contains an implicit README ownership gap"
+fi
+
+if grep -q 'select_owned_stale_issues()' "$SYNC" &&
+  grep -q 'This issue was created automatically by the governance enforcement workflow' "$SYNC"; then
+  pass "8.8 stale issue closure requires an exact automation ownership marker"
+else
+  fail "8.8 stale issue closure requires an exact automation ownership marker" \
+    "free-text search results can still close unrelated issues"
 fi
 
 echo ""

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -263,6 +263,7 @@ jobs:
     uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@db1ad6247a857c7b47e5b2cf6cc1046143041fcc
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
+      downstream_sha: ${{ github.sha }}
     secrets:
       repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -36,6 +36,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REQUESTED_SOURCE_SHA: ${{ inputs.source_sha }}
           DOWNSTREAM_SHA: ${{ github.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           source_sha="$REQUESTED_SOURCE_SHA"
@@ -72,6 +73,41 @@ jobs:
 
           if ! printf '%s' "$DOWNSTREAM_SHA" | grep -qE '^[0-9a-f]{40}$'; then
             echo "::error::Could not resolve the exact downstream caller commit"
+            exit 1
+          fi
+          if [ "$DEFAULT_BRANCH" != "main" ]; then
+            echo "::error::Governance enforcement requires protected main"
+            exit 1
+          fi
+          if ! current_downstream_sha=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha'); then
+            echo "::error::Could not resolve downstream protected main"
+            exit 1
+          fi
+          if ! printf '%s' "$current_downstream_sha" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::Downstream protected main returned an invalid commit"
+            exit 1
+          fi
+          if [ "$DOWNSTREAM_SHA" != "$current_downstream_sha" ]; then
+            if ! downstream_status=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${DOWNSTREAM_SHA}...${current_downstream_sha}" \
+              --jq '.status'); then
+              echo "::error::Could not prove the downstream receipt is on protected main"
+              exit 1
+            fi
+            if [ "$downstream_status" = "ahead" ]; then
+              if ! gh workflow run enforce-repo-settings.yml \
+                --repo "$GITHUB_REPOSITORY" --ref main \
+                -f source_sha="$current_source_sha"; then
+                echo "::error::Could not enqueue current downstream protected main"
+                exit 1
+              fi
+              echo "::notice::Historical downstream receipt deferred to current protected main"
+              echo "source_sha=$current_source_sha" >>"$GITHUB_OUTPUT"
+              echo "ready=false" >>"$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Downstream receipt is not an approved protected-main commit"
             exit 1
           fi
           caller_json=$(mktemp)
@@ -229,3 +265,4 @@ jobs:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
     secrets:
       repo-sync-token: ${{ secrets.REPO_SYNC_TOKEN }}
+      repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}

--- a/workflows/github-pages-deploy.yml
+++ b/workflows/github-pages-deploy.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@db1ad6247a857c7b47e5b2cf6cc1046143041fcc
+    with:
+      content-ref: ${{ github.sha }}
     permissions:
       contents: read # read documentation sources
       packages: read # pull the fleet documentation builder image


### PR DESCRIPTION
Closes #976
Closes #949

Supersedes draft #950 with the coordinated exact-receipt transition.

## What changed

- bind every governed source read, downstream comparison, mutation, retry, and merge to validated protected-main commit receipts;
- require the calling repository commit in reusable managed-file sync and verify the exact checkout;
- replace asynchronous auto-merge with guarded polling that re-proves source, downstream, branch, and pull-request head receipts before the merge mutation;
- allow one hour for measured slow fleet checks without replacing healthy pull requests;
- require exact Pages content commits and deterministic revision metadata;
- make fleet caller bootstrap roll back every partial enablement failure;
- validate canonical README metadata and explicit opt-outs;
- fix the PII scanner crash on computed jq person fields without weakening literal enforcement;
- require every shell test to have exactly one guarded CI step.

No documentation or translation content is changed by this branch.

## Verification

- complete governance shell suite: 32/32 passed on current main;
- managed-file protection: 133/133 passed;
- managed sync: 44/44 passed;
- linter configuration: 149/149 passed;
- source mutation: 5/5 passed;
- downstream receipt: 5/5 passed;
- source ordering: 10/10 passed;
- README generation: 15/15 passed;
- retry and enforcement: 30/30 passed;
- agent guidance: 41/41 passed;
- PII scanner hermetic suite and whole-HEAD enforcement passed;
- Ruff check passed; branch-owned format passed; MyPy passed for both Python files; Pylint 10.00/10;
- Actionlint, branch Yamllint, Zizmor, ShellCheck, Shfmt, gitleaks, diff check, and commit hooks passed.

## Measured external blockers

Unrelated full-tree defects discovered during verification are tracked without modifying their owners in this branch:

- #996: Markdown MD041 baseline;
- #1016: unsafe third-party reviewer/translator trust boundary and YAML defects;
- #1019: translation suspension and English-only publication policy violation.

Merge is not publication proof. After merge, verify exact downstream dispatch receipts, corrected managed bytes, the enriched sync pull request, and published artifacts.