### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-02T22:30:27Z",
-  "source_commit": "4eee15c790fdfc223c47a3f8fd0f6e150645334e",
+  "generated_at": "2026-08-02T22:56:04Z",
+  "source_commit": "0d8a7ea6495bf6aae017fd18181130b5e247e869",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -293,8 +293,8 @@
     ".claude/governance.json": {
       "src": ".claude/governance.json",
       "dest": ".claude/governance.json",
-      "sha": "b29c4d7db44b1a83b14b0fb57e94a2bd949c1652",
-      "size": 5138
+      "sha": "99d77bac8baa2204c605b1a497c4191e6d4314b5",
+      "size": 5122
     },
     ".claude/settings.json": {
       "src": ".claude/settings.json",


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.