### PR TITLE
fix: scope MD041 to document structure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
 ## Summary
 
 Brief description of the changes in this PR.

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "MD013": { "line_length": 400 },
   "MD033": false,
+  "MD041": { "front_matter_title": "^\\s*(title|name)\\s*[:=]" },
   "MD060": true
 }

--- a/plugins/f5-review/code-review-f5/commands/code-review.md
+++ b/plugins/f5-review/code-review-f5/commands/code-review.md
@@ -7,6 +7,8 @@ description: F5-extended multi-agent code review of a pull request
 disable-model-invocation: true
 ---
 
+# F5 code review
+
 Provide a code review for the given pull request.
 
 <!-- F5-EXTENSION E3: highest-priority F5 review rubric (from REVIEW.md). These

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -670,6 +670,46 @@ for rule in MD029 MD041 MD025 MD024 MD007; do
   fi
 done
 
+# GitHub issue templates are forms whose platform-supplied title lives in the
+# `name` frontmatter field. Keep MD041 enforced for documents while teaching it
+# that precise form convention; unrelated metadata must not satisfy the rule.
+MD041_TITLE_RE=$(jq -r '.MD041.front_matter_title // ""' "$REPO_ROOT/.markdownlint.json")
+for heading in "title: Documentation" "name: Bug Report"; do
+  if [[ -n "$MD041_TITLE_RE" && "$heading" =~ $MD041_TITLE_RE ]]; then
+    pass "5b.x MD041 accepts form heading '$heading'"
+  else
+    fail "5b.x MD041 accepts form heading '$heading'" "front_matter_title does not match"
+  fi
+done
+if [[ "description: Review a pull request" =~ $MD041_TITLE_RE ]]; then
+  fail "5b.x MD041 rejects unrelated frontmatter" "description unexpectedly supplies a title"
+else
+  pass "5b.x MD041 rejects unrelated frontmatter"
+fi
+
+# Pull-request templates have no frontmatter because GitHub would copy it into
+# every PR body. A single next-line directive scopes the structural exception to
+# the form's opening H2 without exempting any later Markdown rule or file.
+if [ "$(sed -n '1p' "$REPO_ROOT/.github/PULL_REQUEST_TEMPLATE.md")" = \
+  '<!-- markdownlint-disable-next-line MD041 -->' ] &&
+  [ "$(sed -n '2p' "$REPO_ROOT/.github/PULL_REQUEST_TEMPLATE.md")" = "## Summary" ]; then
+  pass "5b.x pull-request form scopes only its opening MD041 exception"
+else
+  fail "5b.x pull-request form scopes only its opening MD041 exception" \
+    "expected an adjacent disable-next-line directive before Summary"
+fi
+
+# The review command is prompt documentation, not a GitHub form, so it keeps a
+# real H1 rather than gaining another exception.
+if awk '
+  /^---$/ { delimiters++; next }
+  delimiters >= 2 && NF { print; exit }
+' "$REPO_ROOT/plugins/f5-review/code-review-f5/commands/code-review.md" | grep -qx '# F5 code review'; then
+  pass "5b.x review command starts with a real H1"
+else
+  fail "5b.x review command starts with a real H1" "first body line is not the expected H1"
+fi
+
 # MD040 (code-fence-language) is ENFORCED, and this asserts it stays that way.
 # It was previously disabled with the rationale "plain fenced code for pseudo-output
 # is valid", which contradicts STYLE_GUIDE.md §"Code and commands": "Tag every fence


### PR DESCRIPTION
Closes #996

Keeps MD041 enforced while accounting for the real structure of non-document Markdown:
- recognizes GitHub issue-template `name` frontmatter as the platform-supplied title;
- scopes a next-line exception to the pull-request form opening;
- adds a real H1 to the review command.

Regression coverage proves unrelated frontmatter does not satisfy MD041 and that the PR-template exception cannot widen.

Verification:
- `bash tests/test-linter-configs.sh` (155 passed)
- `pre-commit run --files .markdownlint.json .github/PULL_REQUEST_TEMPLATE.md plugins/f5-review/code-review-f5/commands/code-review.md tests/test-linter-configs.sh`
- markdownlint on all five files identified in #996