### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,38 +1,38 @@
 {
-  "source_commit": "db8d2182c89ad18fd218ed4ddb8092c81b8c5aa4",
+  "source_commit": "9e9f7253604ae000b958842cd23dabd8d6f6b2d5",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
       "dest": ".github/workflows/github-pages-deploy.yml",
-      "sha": "f127a747936a834559ab19a558d1d5b519560d4b",
+      "sha": "e2cb56aa5c84ec6a1bdaded92d376e12cc519260",
       "size": 855,
       "mode": "100644"
     },
     ".github/workflows/enforce-repo-settings.yml": {
       "src": "workflows/enforce-repo-settings.yml",
       "dest": ".github/workflows/enforce-repo-settings.yml",
-      "sha": "911ad6f50ee59ca1fd9cf725e4465a09a080c5e8",
+      "sha": "22120c3f7656a9f5c952eb3395b8bc3abfe4574a",
       "size": 11553,
       "mode": "100644"
     },
     ".github/workflows/require-linked-issue.yml": {
       "src": "workflows/require-linked-issue.yml",
       "dest": ".github/workflows/require-linked-issue.yml",
-      "sha": "9ac8cee3fcaff621f2ecefa90a56d6f2bea99262",
+      "sha": "1ed7a3d869e7ce04ad35d277a679e90183ae32a4",
       "size": 1087,
       "mode": "100644"
     },
     ".github/workflows/super-linter.yml": {
       "src": "workflows/super-linter.yml",
       "dest": ".github/workflows/super-linter.yml",
-      "sha": "7955b3f997ba1d436fb6a7f1a5aafa1198c732d5",
+      "sha": "c89cf1d5efc78a8e6719b49fe51c4f45d7730eac",
       "size": 800,
       "mode": "100644"
     },
     ".github/workflows/translation-audit.yml": {
       "src": "workflows/translation-audit.yml",
       "dest": ".github/workflows/translation-audit.yml",
-      "sha": "c6b59755cf4ccab55f0ebd663da408534d234f54",
+      "sha": "b2663f46e472c509cf906d1bc80ab9bf7e40b1b6",
       "size": 1800,
       "mode": "100644"
     },
@@ -158,14 +158,14 @@
     ".github/workflows/dependabot-auto-merge.yml": {
       "src": "workflows/dependabot-auto-merge.yml",
       "dest": ".github/workflows/dependabot-auto-merge.yml",
-      "sha": "7612391e174f314a6972764e78681c56ceb42d9c",
+      "sha": "ec948487824f1dd1e3bf6951f5cfc23fa33e734b",
       "size": 840,
       "mode": "100644"
     },
     ".github/workflows/auto-merge.yml": {
       "src": "workflows/auto-merge.yml",
       "dest": ".github/workflows/auto-merge.yml",
-      "sha": "720ebcf735f19edec1d65967acfb15b80f0bbc57",
+      "sha": "23ca04fa5173863cbf8fe08de95f00d6aded0b07",
       "size": 1381,
       "mode": "100644"
     },
@@ -368,7 +368,7 @@
     ".github/workflows/code-review.yml": {
       "src": "workflows/code-review.yml",
       "dest": ".github/workflows/code-review.yml",
-      "sha": "f405cfe99aa6f86d197127ec78849899185abe27",
+      "sha": "4f3c16bacef89ead66d19070a856150a5cdb580e",
       "size": 6756,
       "mode": "100644"
     },


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.