### PR TITLE
fix: settle governed pin ownership visibility

### DIFF
--- a/scripts/update-governed-workflow-pins.sh
+++ b/scripts/update-governed-workflow-pins.sh
@@ -92,7 +92,10 @@ assert_target_current() {
 
 read_paginated_array() {
   local endpoint="$1" destination="$2" response
-  response=$(mktemp "$work/api-pages.XXXXXX")
+  if ! response=$(mktemp "$work/api-pages.XXXXXX"); then
+    echo "::error::could not allocate governed pin inventory response" >&2
+    return 1
+  fi
   if ! gh api "$endpoint" --paginate --slurp >"$response"; then
     echo "::error::could not inventory governed pin automation state" >&2
     rm -f "$response"
@@ -124,12 +127,16 @@ delete_remote_branch() {
   # monotonic automation. Once a newer run owns the transition, the entire
   # older ref is disposable even if its tip moves after this defensive read;
   # no human or other automation may publish into the reserved namespace.
-  err_file=$(mktemp "$work/ref-error.XXXXXX")
-  set +e
-  actual_oid=$(gh api "repos/${repository}/git/ref/heads/${ref}" --jq '.object.sha' \
-    2>"$err_file")
-  rc=$?
-  set -e
+  if ! err_file=$(mktemp "$work/ref-error.XXXXXX"); then
+    echo "::error::could not allocate governed pin ref error capture" >&2
+    return 1
+  fi
+  if actual_oid=$(gh api "repos/${repository}/git/ref/heads/${ref}" --jq '.object.sha' \
+    2>"$err_file"); then
+    rc=0
+  else
+    rc=$?
+  fi
   if [ "$rc" -ne 0 ]; then
     if grep -qE '\(HTTP 404\)$' "$err_file"; then
       rm -f "$err_file"
@@ -175,10 +182,33 @@ classify_owner() {
 
 reconcile_pin_prs() {
   local prs refs rows number ref head_repo base_ref expected_oid rc current_count
+  local retired_prs retired_refs retired_row full_ref
+  local settle_attempt settle_delay clear_sweeps retired_visible settle_required
   reconciled_pin_pr_number=""
   reconciled_pin_pr_head_oid=""
-  prs=$(mktemp "$work/open-prs.XXXXXX")
-  refs=$(mktemp "$work/open-refs.XXXXXX")
+  prs=""
+  refs=""
+  retired_prs=""
+  retired_refs=""
+  if ! prs=$(mktemp "$work/open-prs.XXXXXX"); then
+    echo "::error::could not allocate governed pin PR inventory" >&2
+    return 1
+  fi
+  if ! refs=$(mktemp "$work/open-refs.XXXXXX"); then
+    echo "::error::could not allocate governed pin ref inventory" >&2
+    rm -f "$prs"
+    return 1
+  fi
+  if ! retired_prs=$(mktemp "$work/retired-prs.XXXXXX"); then
+    echo "::error::could not allocate retired governed pin PR inventory" >&2
+    rm -f "$prs" "$refs"
+    return 1
+  fi
+  if ! retired_refs=$(mktemp "$work/retired-refs.XXXXXX"); then
+    echo "::error::could not allocate retired governed pin ref inventory" >&2
+    rm -f "$prs" "$refs" "$retired_prs"
+    return 1
+  fi
   if ! read_open_pin_prs "$prs" || ! read_pin_refs "$refs"; then
     rm -f "$prs" "$refs"
     return 1
@@ -199,10 +229,14 @@ reconcile_pin_prs() {
     return 1
   fi
 
-  rows=$(jq -r --arg prefix 'sync/governed-workflow-pins-' '
+  if ! rows=$(jq -r --arg prefix 'sync/governed-workflow-pins-' '
     .[] | select(.head.ref | startswith($prefix)) |
     [.number, .head.ref, .head.sha, .head.repo.full_name, .base.ref] | @tsv
-  ' "$prs")
+  ' "$prs"); then
+    echo "::error::could not extract governed pin PR ownership" >&2
+    rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+    return 1
+  fi
   current_count=0
   while IFS=$'\t' read -r number ref expected_oid head_repo base_ref; do
     [ -n "$number" ] || continue
@@ -211,10 +245,11 @@ reconcile_pin_prs() {
       rm -f "$prs" "$refs"
       return 1
     fi
-    set +e
-    classify_owner "$ref"
-    rc=$?
-    set -e
+    if classify_owner "$ref"; then
+      rc=0
+    else
+      rc=$?
+    fi
     if [ "$rc" -ne 0 ]; then
       rm -f "$prs" "$refs"
       return "$rc"
@@ -231,26 +266,35 @@ reconcile_pin_prs() {
     return 1
   fi
 
-  rows=$(jq -r --arg branch "refs/heads/${branch}" \
-    '.[] | select(.ref != $branch) | [.ref, .object.sha] | @tsv' "$refs")
+  if ! rows=$(jq -r --arg branch "refs/heads/${branch}" \
+    '.[] | select(.ref != $branch) | [.ref, .object.sha] | @tsv' "$refs"); then
+    echo "::error::could not extract governed pin ref ownership" >&2
+    rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+    return 1
+  fi
   while IFS=$'\t' read -r ref expected_oid; do
     [ -n "$ref" ] || continue
     ref="${ref#refs/heads/}"
-    set +e
-    classify_owner "$ref"
-    rc=$?
-    set -e
+    if classify_owner "$ref"; then
+      rc=0
+    else
+      rc=$?
+    fi
     if [ "$rc" -ne 0 ]; then
       rm -f "$prs" "$refs"
       return "$rc"
     fi
   done <<<"$rows"
 
-  rows=$(jq -r --arg branch "$branch" --arg prefix 'sync/governed-workflow-pins-' '
+  if ! rows=$(jq -r --arg branch "$branch" --arg prefix 'sync/governed-workflow-pins-' '
     .[] | select(.head.ref | startswith($prefix)) |
-    select(.head.ref != $branch) | [.number, .head.ref] | @tsv
-  ' "$prs")
-  while IFS=$'\t' read -r number ref; do
+    select(.head.ref != $branch) | [.number, .head.ref, .head.sha] | @tsv
+  ' "$prs"); then
+    echo "::error::could not extract superseded governed pin PRs" >&2
+    rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+    return 1
+  fi
+  while IFS=$'\t' read -r number ref expected_oid; do
     [ -n "$number" ] || continue
     if ! gh pr close "$number" --repo "$repository" \
       --comment "Superseded by a newer exact governed-workflow pin."; then
@@ -258,45 +302,173 @@ reconcile_pin_prs() {
       rm -f "$prs" "$refs"
       return 1
     fi
+    if ! printf '%s\t%s\t%s\n' "$number" "$ref" "$expected_oid" >>"$retired_prs"; then
+      echo "::error::could not record retired governed pin PR identity" >&2
+      rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+      return 1
+    fi
   done <<<"$rows"
 
-  rows=$(jq -r --arg branch "refs/heads/${branch}" \
-    '.[] | select(.ref != $branch) | [.ref, .object.sha] | @tsv' "$refs")
+  if ! rows=$(jq -r --arg branch "refs/heads/${branch}" \
+    '.[] | select(.ref != $branch) | [.ref, .object.sha] | @tsv' "$refs"); then
+    echo "::error::could not extract superseded governed pin refs" >&2
+    rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+    return 1
+  fi
   while IFS=$'\t' read -r ref expected_oid; do
     [ -n "$ref" ] || continue
+    full_ref="$ref"
     ref="${ref#refs/heads/}"
     if ! delete_remote_branch "$ref" "$expected_oid"; then
       rm -f "$prs" "$refs"
       return 1
     fi
+    if ! printf '%s\t%s\n' "$full_ref" "$expected_oid" >>"$retired_refs"; then
+      echo "::error::could not record retired governed pin ref identity" >&2
+      rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+      return 1
+    fi
   done <<<"$rows"
 
-  if ! read_open_pin_prs "$prs" || ! read_pin_refs "$refs"; then
-    rm -f "$prs" "$refs"
-    return 1
+  settle_required=false
+  if [ -s "$retired_prs" ] || [ -s "$retired_refs" ]; then
+    settle_required=true
   fi
-  if ! jq -e --arg prefix 'sync/governed-workflow-pins-' '
-    all(.[] | select(.head.ref | startswith($prefix));
-      (.number | type == "number" and . >= 1 and . == floor) and
-      (.head.ref | type == "string") and
-      (.head.sha | type == "string" and test("^[0-9a-f]{40}$")) and
-      (.head.repo.full_name | type == "string") and
-      (.base.ref | type == "string"))
-  ' "$prs" >/dev/null || ! jq -e '
-    all(.[]; (.ref | type == "string") and
-      (.object.sha | type == "string" and test("^[0-9a-f]{40}$")))
-  ' "$refs" >/dev/null; then
-    echo "::error::governed pin ownership changed during reconciliation" >&2
-    rm -f "$prs" "$refs"
-    return 1
-  fi
+  settle_attempt=1
+  settle_delay=1
+  clear_sweeps=0
+  while true; do
+    if ! read_open_pin_prs "$prs" || ! read_pin_refs "$refs"; then
+      rm -f "$prs" "$refs"
+      return 1
+    fi
+    if ! jq -e --arg prefix 'sync/governed-workflow-pins-' '
+      all(.[] | select(.head.ref | startswith($prefix));
+        (.number | type == "number" and . >= 1 and . == floor) and
+        (.head.ref | type == "string") and
+        (.head.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+        (.head.repo.full_name | type == "string") and
+        (.base.ref | type == "string"))
+    ' "$prs" >/dev/null || ! jq -e '
+      all(.[]; (.ref | type == "string") and
+        (.object.sha | type == "string" and test("^[0-9a-f]{40}$")))
+    ' "$refs" >/dev/null; then
+      echo "::error::governed pin ownership changed during reconciliation" >&2
+      rm -f "$prs" "$refs"
+      return 1
+    fi
+
+    retired_visible=false
+    current_count=0
+    if ! rows=$(jq -r --arg prefix 'sync/governed-workflow-pins-' '
+      .[] | select(.head.ref | startswith($prefix)) |
+      [.number, .head.ref, .head.sha, .head.repo.full_name, .base.ref] | @tsv
+    ' "$prs"); then
+      echo "::error::could not extract settling governed pin PR ownership" >&2
+      rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+      return 1
+    fi
+    while IFS=$'\t' read -r number ref expected_oid head_repo base_ref; do
+      [ -n "$number" ] || continue
+      if [ "$head_repo" != "$repository" ] || [ "$base_ref" != main ]; then
+        echo "::error::governed pin PR does not belong to protected main" >&2
+        rm -f "$prs" "$refs"
+        return 1
+      fi
+      if [ "$ref" = "$branch" ]; then
+        current_count=$((current_count + 1))
+        if [ "$current_count" -gt 1 ]; then
+          echo "::error::multiple governed pin PRs claim the current owner" >&2
+          rm -f "$prs" "$refs"
+          return 1
+        fi
+        continue
+      fi
+      printf -v retired_row '%s\t%s\t%s' "$number" "$ref" "$expected_oid"
+      if grep -Fqx -- "$retired_row" "$retired_prs"; then
+        retired_visible=true
+        continue
+      fi
+      if classify_owner "$ref"; then
+        rc=0
+      else
+        rc=$?
+      fi
+      if [ "$rc" -ne 0 ]; then
+        rm -f "$prs" "$refs"
+        return "$rc"
+      fi
+      echo "::error::an unseen governed pin PR appeared during reconciliation" >&2
+      rm -f "$prs" "$refs"
+      return 1
+    done <<<"$rows"
+
+    if ! rows=$(jq -r --arg branch "refs/heads/${branch}" \
+      '.[] | select(.ref != $branch) | [.ref, .object.sha] | @tsv' "$refs"); then
+      echo "::error::could not extract settling governed pin ref ownership" >&2
+      rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+      return 1
+    fi
+    while IFS=$'\t' read -r ref expected_oid; do
+      [ -n "$ref" ] || continue
+      printf -v retired_row '%s\t%s' "$ref" "$expected_oid"
+      if grep -Fqx -- "$retired_row" "$retired_refs"; then
+        retired_visible=true
+        continue
+      fi
+      full_ref="$ref"
+      ref="${ref#refs/heads/}"
+      if classify_owner "$ref"; then
+        rc=0
+      else
+        rc=$?
+      fi
+      if [ "$rc" -ne 0 ]; then
+        rm -f "$prs" "$refs"
+        return "$rc"
+      fi
+      echo "::error::an unseen governed pin ref appeared during reconciliation: $full_ref" >&2
+      rm -f "$prs" "$refs"
+      return 1
+    done <<<"$rows"
+
+    if [ "$settle_required" = false ]; then
+      break
+    fi
+    if [ "$retired_visible" = true ]; then
+      clear_sweeps=0
+    else
+      clear_sweeps=$((clear_sweeps + 1))
+    fi
+    if [ "$clear_sweeps" -ge 2 ]; then
+      break
+    fi
+    if [ "$settle_attempt" -ge 6 ]; then
+      echo "::error::retired governed pin ownership did not settle after six inventories" >&2
+      rm -f "$prs" "$refs"
+      return 1
+    fi
+    echo "[WAIT] governed pin ownership visibility is not confirmed (${settle_attempt}/6)"
+    if ! sleep "$settle_delay"; then
+      echo "::error::governed pin ownership settling delay was interrupted" >&2
+      rm -f "$prs" "$refs"
+      return 1
+    fi
+    settle_attempt=$((settle_attempt + 1))
+    settle_delay=$((settle_delay * 2))
+    if [ "$settle_delay" -gt 4 ]; then settle_delay=4; fi
+  done
   reconciled_pin_pr_number=""
   reconciled_pin_pr_head_oid=""
   current_count=0
-  rows=$(jq -r --arg prefix 'sync/governed-workflow-pins-' '
+  if ! rows=$(jq -r --arg prefix 'sync/governed-workflow-pins-' '
     .[] | select(.head.ref | startswith($prefix)) |
     [.number, .head.ref, .head.sha, .head.repo.full_name, .base.ref] | @tsv
-  ' "$prs")
+  ' "$prs"); then
+    echo "::error::could not extract reconciled governed pin PR ownership" >&2
+    rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+    return 1
+  fi
   while IFS=$'\t' read -r number ref expected_oid head_repo base_ref; do
     [ -n "$number" ] || continue
     if [ "$head_repo" != "$repository" ] || [ "$base_ref" != main ]; then
@@ -323,7 +495,11 @@ reconcile_pin_prs() {
     rm -f "$prs" "$refs"
     return 1
   fi
-  rows=$(jq -r '.[] | [.ref, .object.sha] | @tsv' "$refs")
+  if ! rows=$(jq -r '.[] | [.ref, .object.sha] | @tsv' "$refs"); then
+    echo "::error::could not extract reconciled governed pin ref ownership" >&2
+    rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
+    return 1
+  fi
   while IFS=$'\t' read -r ref expected_oid; do
     [ -n "$ref" ] || continue
     if [ "$ref" != "refs/heads/${branch}" ]; then
@@ -332,7 +508,7 @@ reconcile_pin_prs() {
       return 1
     fi
   done <<<"$rows"
-  rm -f "$prs" "$refs"
+  rm -f "$prs" "$refs" "$retired_prs" "$retired_refs"
 }
 
 assert_local_commit() {
@@ -392,7 +568,10 @@ main() {
     echo "::error::invalid repository or workflow-run identity" >&2
     return 1
   fi
-  work=$(mktemp -d)
+  if ! work=$(mktemp -d); then
+    echo "::error::could not allocate governed pin updater workspace" >&2
+    return 1
+  fi
   trap 'rm -rf "$work"' EXIT
   workflow_list="$work/workflows"
   update_output="$work/update-output"

--- a/tests/test-governed-workflow-pins.sh
+++ b/tests/test-governed-workflow-pins.sh
@@ -126,6 +126,9 @@ check "roll-forward script exists and is executable" test -x "$ROLLOUT_SCRIPT"
 
 BEHAVIOR="$WORK/behavior"
 mkdir -p "$BEHAVIOR/bin" "$BEHAVIOR/state"
+REAL_JQ_COMMAND=$(command -v jq)
+REAL_MKTEMP_COMMAND=$(command -v mktemp)
+export REAL_JQ_COMMAND REAL_MKTEMP_COMMAND
 cat >"$BEHAVIOR/bin/git" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$FAKE_COMMAND_LOG"
@@ -146,6 +149,10 @@ if [[ "$*" == api\ repos/*/pulls\?state=open* ]]; then
   count=$((count + 1))
   printf '%s\n' "$count" >"$count_file"
   if [ "${FAKE_INVENTORY_FAIL_AT:-0}" -eq "$count" ]; then exit 1; fi
+  if [ "${FAKE_INVENTORY_MALFORMED_AT:-0}" -eq "$count" ]; then
+    printf '[[{}]]\n'
+    exit 0
+  fi
   if [ "${FAKE_DUPLICATE_CURRENT:-}" = 1 ]; then
     jq -cn --arg branch "$FAKE_CURRENT_BRANCH" --arg repo "f5-sales-demo/docs-control" \
       '[[{number: 10, head: {ref: $branch, sha: "9999999999999999999999999999999999999999", repo: {full_name: $repo}}, base: {ref: "main"}},
@@ -155,6 +162,29 @@ if [[ "$*" == api\ repos/*/pulls\?state=open* ]]; then
     jq -cn --arg branch "$FAKE_CURRENT_BRANCH" --arg repo "f5-sales-demo-fork/docs-control" \
       '[[{number: 9, head: {ref: $branch, sha: "9999999999999999999999999999999999999999", repo: {full_name: $repo}}, base: {ref: "main"}}]]'
     exit 0
+  elif [ "${FAKE_FORK_CURRENT_AFTER_DELETE:-}" = 1 ] &&
+    [ -f "$FAKE_STATE/old-ref-deleted" ]; then
+    jq -cn --arg branch "$FAKE_CURRENT_BRANCH" --arg repo "f5-sales-demo-fork/docs-control" \
+      '[[{number: 9, head: {ref: $branch, sha: "9999999999999999999999999999999999999999", repo: {full_name: $repo}}, base: {ref: "main"}}]]'
+    exit 0
+  elif [ "${FAKE_OLD_PR:-}" = 1 ] && [ ! -f "$FAKE_STATE/old-pr-closed" ]; then
+    jq -cn --arg repo "f5-sales-demo/docs-control" \
+      '[[{number: 10, head: {ref: "sync/governed-workflow-pins-aaaaaaaaaaaa-1-1", sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", repo: {full_name: $repo}}, base: {ref: "main"}}]]'
+    exit 0
+  elif [ "${FAKE_OLD_PR:-}" = 1 ] && [ -f "$FAKE_STATE/old-pr-closed" ]; then
+    count_file="$FAKE_STATE/post-close-pr-reads"
+    count=0
+    [ ! -f "$count_file" ] || count=$(cat "$count_file")
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$count_file"
+    if [ "${FAKE_PERSIST_OLD_PR:-}" = 1 ] ||
+      [ "$count" -le "${FAKE_PR_VISIBILITY_LAG_READS:-0}" ]; then
+      jq -cn --arg repo "f5-sales-demo/docs-control" \
+        '[[{number: 10, head: {ref: "sync/governed-workflow-pins-aaaaaaaaaaaa-1-1", sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", repo: {full_name: $repo}}, base: {ref: "main"}}]]'
+    else
+      printf '[[]]\n'
+    fi
+    exit 0
   fi
   printf '[[]]\n'
   exit 0
@@ -162,9 +192,33 @@ fi
 if [[ "$*" == api\ repos/*/git/matching-refs/heads/sync/governed-workflow-pins-* ]]; then
   if [ "${FAKE_OLD_REF:-}" = 1 ] && [ ! -f "$FAKE_STATE/old-ref-deleted" ]; then
     printf '[[{"ref":"refs/heads/sync/governed-workflow-pins-aaaaaaaaaaaa-1-1","object":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]]\n'
+  elif [ "${FAKE_OLD_REF:-}" = 1 ] && [ -f "$FAKE_STATE/old-ref-deleted" ]; then
+    count_file="$FAKE_STATE/post-delete-ref-reads"
+    count=0
+    [ ! -f "$count_file" ] || count=$(cat "$count_file")
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$count_file"
+    if [ "${FAKE_NEWER_REF_AFTER_DELETE:-}" = 1 ]; then
+      printf '[[{"ref":"refs/heads/sync/governed-workflow-pins-cccccccccccc-3-1","object":{"sha":"cccccccccccccccccccccccccccccccccccccccc"}}]]\n'
+    elif [ "${FAKE_UNSEEN_OLDER_REF_AFTER_DELETE:-}" = 1 ]; then
+      printf '[[{"ref":"refs/heads/sync/governed-workflow-pins-cccccccccccc-1-1","object":{"sha":"cccccccccccccccccccccccccccccccccccccccc"}}]]\n'
+    elif [ "${FAKE_EMPTY_THEN_STALE_REF:-}" = 1 ] && [ "$count" -eq 1 ]; then
+      printf '[[]]\n'
+    elif [ "${FAKE_EMPTY_THEN_STALE_REF:-}" = 1 ] && [ "$count" -eq 2 ]; then
+      printf '[[{"ref":"refs/heads/sync/governed-workflow-pins-aaaaaaaaaaaa-1-1","object":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]]\n'
+    elif [ "${FAKE_PERSIST_OLD_REF:-}" = 1 ] ||
+      [ "$count" -le "${FAKE_REF_VISIBILITY_LAG_READS:-0}" ]; then
+      printf '[[{"ref":"refs/heads/sync/governed-workflow-pins-aaaaaaaaaaaa-1-1","object":{"sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}]]\n'
+    else
+      printf '[[]]\n'
+    fi
   else
     printf '[[]]\n'
   fi
+  exit 0
+fi
+if [[ "$*" == pr\ close\ 10* ]]; then
+  touch "$FAKE_STATE/old-pr-closed"
   exit 0
 fi
 if [[ "$*" == *'/git/ref/heads/sync/governed-workflow-pins-aaaaaaaaaaaa-1-1'* ]]; then
@@ -181,7 +235,33 @@ if [[ "$*" == *'/branches/main/protection/required_status_checks'* ]]; then
 fi
 exit 64
 EOF
-chmod +x "$BEHAVIOR/bin/git" "$BEHAVIOR/bin/gh"
+cat >"$BEHAVIOR/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+printf 'sleep %s\n' "$*" >>"$FAKE_COMMAND_LOG"
+count_file="$FAKE_STATE/sleep-count"
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+count=$((count + 1))
+printf '%s\n' "$count" >"$count_file"
+if [ "${FAKE_SLEEP_FAIL_AT:-0}" -eq "$count" ]; then exit 1; fi
+EOF
+cat >"$BEHAVIOR/bin/jq" <<'EOF'
+#!/usr/bin/env bash
+if [ "${FAKE_JQ_TSV_FAIL:-}" = 1 ] && [[ "$*" == *'@tsv'* ]]; then exit 42; fi
+exec "$REAL_JQ_COMMAND" "$@"
+EOF
+cat >"$BEHAVIOR/bin/mktemp" <<'EOF'
+#!/usr/bin/env bash
+count_file="$FAKE_STATE/mktemp-count"
+count=0
+[ ! -f "$count_file" ] || count=$(cat "$count_file")
+count=$((count + 1))
+printf '%s\n' "$count" >"$count_file"
+if [ "${FAKE_MKTEMP_FAIL:-}" = 1 ]; then exit 1; fi
+exec "$REAL_MKTEMP_COMMAND" "$@"
+EOF
+chmod +x "$BEHAVIOR/bin/git" "$BEHAVIOR/bin/gh" "$BEHAVIOR/bin/sleep" \
+  "$BEHAVIOR/bin/jq" "$BEHAVIOR/bin/mktemp"
 
 check "failed main fetch cannot pass against a stale local tracking ref" \
   bash -c '
@@ -211,6 +291,33 @@ check "failed second PR inventory read blocks auto-merge ownership proof" \
     repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-test-2-1
     run_id=2; run_attempt=1; work="$2/state"
     ! reconcile_pin_prs && ! grep -Eq "pr close|method DELETE" "$FAKE_COMMAND_LOG"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "ownership row extraction failure cannot erase a hostile owner" \
+  bash -c '
+    expected_branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_FORK_CURRENT=1 FAKE_CURRENT_BRANCH="$expected_branch" FAKE_JQ_TSV_FAIL=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/mktemp-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch="$expected_branch"
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs &&
+      ! grep -Eq "pr (close|create|merge)|method (POST|PUT|PATCH|DELETE)" "$FAKE_COMMAND_LOG"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "ownership reconciliation stops after its first allocation failure" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_MKTEMP_FAIL=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/mktemp-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test "$(cat "$FAKE_STATE/mktemp-count")" -eq 1 &&
+      ! grep -Eq "api |pr " "$FAKE_COMMAND_LOG"
   ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
 
 check "hostile same-ref fork PR blocks governed-pin mutation" \
@@ -258,6 +365,152 @@ check "orphaned older updater refs are deleted after complete paginated inventor
     run_id=2; run_attempt=1; work="$2/state"
     reconcile_pin_prs && test -f "$FAKE_STATE/old-ref-deleted" &&
       grep -q -- "--paginate --slurp" "$FAKE_COMMAND_LOG"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "deleted updater refs may settle after bounded visibility lag" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_REF_VISIBILITY_LAG_READS=2
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    reconcile_pin_prs && test -f "$FAKE_STATE/old-ref-deleted" &&
+      test "$(cat "$FAKE_STATE/post-delete-ref-reads")" -eq 4 &&
+      test "$(grep "^sleep " "$FAKE_COMMAND_LOG" | cut -d " " -f 2 | paste -sd, -)" = "1,2,4"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "persistently published deleted updater refs still fail closed" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_PERSIST_OLD_REF=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test -f "$FAKE_STATE/old-ref-deleted" &&
+      test "$(cat "$FAKE_STATE/post-delete-ref-reads")" -eq 6 &&
+      test "$(grep "^sleep " "$FAKE_COMMAND_LOG" | cut -d " " -f 2 | paste -sd, -)" = "1,2,4,4,4"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "closed PR and deleted ref visibility settle only after two clear inventories" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_PR=1 FAKE_PR_VISIBILITY_LAG_READS=1
+    export FAKE_OLD_REF=1 FAKE_REF_VISIBILITY_LAG_READS=2
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-pr-closed" \
+      "$FAKE_STATE/post-close-pr-reads" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    reconcile_pin_prs && test -f "$FAKE_STATE/old-pr-closed" &&
+      test -f "$FAKE_STATE/old-ref-deleted" &&
+      test "$(cat "$FAKE_STATE/post-close-pr-reads")" -eq 4 &&
+      test "$(cat "$FAKE_STATE/post-delete-ref-reads")" -eq 4 &&
+      test "$(grep "^sleep " "$FAKE_COMMAND_LOG" | cut -d " " -f 2 | paste -sd, -)" = "1,2,4"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "an empty inventory followed by a stale deleted ref cannot pass early" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_EMPTY_THEN_STALE_REF=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    reconcile_pin_prs && test "$(cat "$FAKE_STATE/post-delete-ref-reads")" -eq 4 &&
+      test "$(grep "^sleep " "$FAKE_COMMAND_LOG" | cut -d " " -f 2 | paste -sd, -)" = "1,2,4"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "a newer owner appearing while visibility settles defers immediately" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_NEWER_REF_AFTER_DELETE=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    set +e; reconcile_pin_prs; rc=$?; set -e
+    test "$rc" -eq 75 && test ! -f "$FAKE_STATE/sleep-count"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "a hostile current-branch PR appearing while visibility settles fails immediately" \
+  bash -c '
+    expected_branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_FORK_CURRENT_AFTER_DELETE=1
+    export FAKE_CURRENT_BRANCH="$expected_branch"
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch="$expected_branch"
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test ! -f "$FAKE_STATE/sleep-count" &&
+      ! grep -Eq "pr (close|create|merge) 9|method (POST|PUT|PATCH)" "$FAKE_COMMAND_LOG"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "an unseen older owner appearing while visibility settles fails immediately" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_UNSEEN_OLDER_REF_AFTER_DELETE=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test ! -f "$FAKE_STATE/sleep-count"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "an API failure during visibility settling fails after no further sleeps" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_REF_VISIBILITY_LAG_READS=5 FAKE_INVENTORY_FAIL_AT=3
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test "$(grep "^sleep " "$FAKE_COMMAND_LOG")" = "sleep 1"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "malformed inventory during visibility settling fails after no further sleeps" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_REF_VISIBILITY_LAG_READS=5 FAKE_INVENTORY_MALFORMED_AT=3
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test "$(grep "^sleep " "$FAKE_COMMAND_LOG")" = "sleep 1"
+  ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
+
+check "an interrupted settling delay fails closed immediately" \
+  bash -c '
+    export PATH="$2/bin:$PATH" FAKE_COMMAND_LOG="$2/commands" FAKE_STATE="$2/state"
+    export FAKE_OLD_REF=1 FAKE_REF_VISIBILITY_LAG_READS=5 FAKE_SLEEP_FAIL_AT=1
+    : >"$FAKE_COMMAND_LOG"
+    rm -f "$FAKE_STATE/inventory-count" "$FAKE_STATE/old-ref-deleted" \
+      "$FAKE_STATE/post-delete-ref-reads" "$FAKE_STATE/sleep-count"
+    source "$1"
+    repository=f5-sales-demo/docs-control; branch=sync/governed-workflow-pins-bbbbbbbbbbbb-2-1
+    run_id=2; run_attempt=1; work="$2/state"
+    ! reconcile_pin_prs && test "$(grep "^sleep " "$FAKE_COMMAND_LOG")" = "sleep 1" &&
+      test "$(cat "$FAKE_STATE/post-delete-ref-reads")" -eq 1
   ' _ "$ROLLOUT_SCRIPT" "$BEHAVIOR"
 
 NOOP_ORIGIN="$WORK/noop-origin.git"


### PR DESCRIPTION
Closes #1032

## Summary

- retry only exact retired governed-pin PR/ref identities after GitHub delete visibility lag
- require two consecutive clear inventories with bounded 1,2,4,4,4-second delays
- defer newer owners immediately and reject hostile or unseen owners immediately
- fail closed on inventory, schema, allocation, extraction, identity-recording, and sleep failures
- preserve caller errexit state

## Verification

- complete governance suite: 32 shell test programs passed
- focused governed-pin regression suite passed
- Bash syntax, ShellCheck, shfmt, and diff checks passed
- applicable pre-commit hooks on both changed files passed
- Ruff check/format passed for both Python modules
- MyPy passed for both Python modules
- Pylint: 10.00/10
- Actionlint passed with the repository CI ShellCheck options
- Zizmor: no findings
- gitleaks: no leaks found
- PII HEAD enforce: clean
- PII HEAD audit: three expected manual-review findings, no enforcement finding

The repository-wide hook run also reproduced unrelated protected-main failures and they are tracked rather than hidden: Antigravity workflow whitespace in #1039 and Markdown formatting in #1046. This PR changes only the governed-pin updater and its test.