### PR TITLE
fix(security): scan every history path association

### DIFF
--- a/.agents/skills/i18n-translate/SKILL.md
+++ b/.agents/skills/i18n-translate/SKILL.md
@@ -29,6 +29,7 @@ This skill guides `agy` in translating English Markdown and MDX documentation (`
 ## Translation Procedure
 
 ### 1. Compute English Source Hash
+
 For every English document (`docs/en/path/to/file.md[x]`), calculate the **SHA-256 hash** of the raw English file contents and take the first **12 hexadecimal characters**:
 
 ```python
@@ -37,18 +38,23 @@ source_hash = hashlib.sha256(english_raw_bytes).hexdigest()[:12]
 ```
 
 ### 2. Identify Stale or Missing Target Translations
+
 Check target files at `docs/<locale>/path/to/file.md[x]`:
+
 - If the target file does **not exist**, it is **MISSING** and requires translation.
 - If the target file exists, check its YAML frontmatter `i18n.sourceHash`:
   - If `i18n.sourceHash != source_hash`, it is **STALE** and requires translation.
   - If `i18n.sourceHash == source_hash`, it is up to date and can be skipped (unless `--force` is specified).
 
 ### 3. Handle Deleted English Documentation
+
 Check for English source files that have been **deleted** from `docs/en/` or `src/content/docs/en/`:
+
 - Locate their corresponding target translation paths:
   - If `docs/en/path/to/file.md[x]` is deleted -> Delete `docs/<locale>/path/to/file.md[x]` for all 12 target locales.
   - If `src/content/docs/en/path/to/file.md[x]` is deleted -> Delete `src/content/docs/<locale>/path/to/file.md[x]` for all 12 target locales.
 - Stage these deletions:
+
   ```bash
   git rm docs/<locale>/path/to/file.md[x]
   ```
@@ -58,6 +64,7 @@ Check for English source files that have been **deleted** from `docs/en/` or `sr
 ## Content & Formatting Guidelines
 
 ### Frontmatter Schema Rules
+
 - Preserve all structural YAML frontmatter keys from the English source.
 - **Translate** human-readable text fields:
   - `title`
@@ -67,6 +74,7 @@ Check for English source files that have been **deleted** from `docs/en/` or `sr
   - `hero.tagline`
   - `hero.actions[].text`
 - **Update or inject** the `i18n` metadata block:
+
   ```yaml
   i18n:
     sourceHash: "<12-character-sha256-hex>"
@@ -74,6 +82,7 @@ Check for English source files that have been **deleted** from `docs/en/` or `sr
   ```
 
 ### Non-Translatable Elements
+
 1. **Code Blocks & Inline Code**: Keep code blocks (fenced with ``` or ~~~) and inline code (`...`) completely untranslated.
 2. **JSX / MDX Elements**: Keep HTML/JSX component tags intact, including attributes, imports (`import ... from '...'`), and exports (`export ...`).
 3. **Brand & Product Names**: Keep technical product names untranslated (e.g., `F5`, `F5 Distributed Cloud`, `XC`, `NGINX`, `Terraform`, `Kubernetes`, `Docker`).
@@ -84,10 +93,12 @@ Check for English source files that have been **deleted** from `docs/en/` or `sr
 ## Workspace Execution via `agy`
 
 When running on GitHub Action runners or in CLI:
+
 1. Identify all changed English documentation files using `git diff` or filesystem scanning.
 2. For each stale/missing locale, generate the localized translation.
 3. Write the result to `docs/<locale>/path/to/file.md[x]`.
 4. Stage and commit the updated target files:
+
    ```bash
    git add docs/<locale>/path/to/file.md[x]
    ```

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -122,31 +122,109 @@ materialize_head() {
 
 materialize_history() {
   local oid object_type commit message object_line type_line path type_oid
-  git rev-list --objects --all >"${WORK}/objects"
-  cut -d ' ' -f 1 "${WORK}/objects" |
-    git cat-file --batch-check='%(objectname) %(objecttype)' >"${WORK}/types"
+  local materialized_count object_count ref target target_type type_count
+  if ! git rev-list --objects --all >"${WORK}/objects"; then
+    echo "PII scan error: cannot enumerate reachable Git objects" >&2
+    exit 2
+  fi
+  if ! cut -d ' ' -f 1 "${WORK}/objects" |
+    git cat-file --batch-check='%(objectname) %(objecttype)' >"${WORK}/types"; then
+    echo "PII scan error: cannot inspect reachable Git objects" >&2
+    exit 2
+  fi
+  object_count=$(wc -l <"${WORK}/objects")
+  type_count=$(wc -l <"${WORK}/types")
+  if [ "$object_count" -ne "$type_count" ]; then
+    echo "PII scan error: Git returned a truncated history inventory" >&2
+    exit 2
+  fi
 
+  : >"${WORK}/commits"
   while IFS= read -r object_line <&3 && IFS= read -r type_line <&4; do
     oid=${object_line%% *}
-    path=${object_line#"$oid"}
-    path=${path# }
     read -r type_oid object_type <<<"$type_line"
     if [ "$type_oid" != "$oid" ]; then
       echo "PII scan error: Git returned a mismatched history inventory" >&2
       exit 2
     fi
-    [ "$object_type" = "blob" ] || continue
-    [ -n "$path" ] || path="<blob:${oid:0:12}>"
-    add_blob "$path" "$oid"
+    if [ "$object_type" = "commit" ]; then
+      printf '%s\n' "$oid" >>"${WORK}/commits"
+    fi
   done 3<"${WORK}/objects" 4<"${WORK}/types"
+
+  if ! git diff-tree --stdin --root -m -r --raw -z --no-renames \
+    --no-commit-id <"${WORK}/commits" >"${WORK}/history-diffs"; then
+    echo "PII scan error: cannot enumerate reachable history changes" >&2
+    exit 2
+  fi
+
+  : >"${WORK}/history-trees"
+  if ! git for-each-ref --format='%(refname)' >"${WORK}/refs"; then
+    echo "PII scan error: cannot enumerate Git refs" >&2
+    exit 2
+  fi
+  while IFS= read -r ref; do
+    if ! target=$(git rev-parse "${ref}^{}"); then
+      echo "PII scan error: cannot resolve a reachable ref" >&2
+      exit 2
+    fi
+    if ! target_type=$(git cat-file -t "$target"); then
+      echo "PII scan error: cannot inspect a reachable ref" >&2
+      exit 2
+    fi
+    case "$target_type" in
+    commit) ;;
+    tree)
+      if ! git ls-tree -r -z --full-tree "$target" >>"${WORK}/history-trees"; then
+        echo "PII scan error: cannot enumerate a reachable tree" >&2
+        exit 2
+      fi
+      ;;
+    blob)
+      printf '100644 blob %s\t<blob:%s>\0' "$target" "${target:0:12}" \
+        >>"${WORK}/history-trees"
+      ;;
+    *)
+      echo "PII scan error: reachable ref has an unsupported object type" >&2
+      exit 2
+      ;;
+    esac
+  done <"${WORK}/refs"
+
+  if ! PYTHONPATH="$SCRIPT_DIR" python3 -c \
+    'import sys; from pathlib import Path; from check_pii import write_history_associations; write_history_associations(Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4]))' \
+    "${WORK}/history-diffs" "${WORK}/history-trees" \
+    "${WORK}/history-associations" "${WORK}/history-requests"; then
+    echo "PII scan error: cannot validate reachable history associations" >&2
+    exit 2
+  fi
+
+  if ! git cat-file --batch <"${WORK}/history-requests" \
+    >"${WORK}/history-batch"; then
+    echo "PII scan error: cannot read reachable history blobs" >&2
+    exit 2
+  fi
+  if ! materialized_count=$(PYTHONPATH="$SCRIPT_DIR" python3 -c \
+    'import sys; from pathlib import Path; from check_pii import materialize_history_associations; print(materialize_history_associations(Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), Path(sys.argv[4]), int(sys.argv[5])))' \
+    "${WORK}/history-associations" "${WORK}/history-requests" \
+    "${WORK}/history-batch" "$WORK" "$COUNT"); then
+    echo "PII scan error: cannot materialize reachable history blobs" >&2
+    exit 2
+  fi
+  COUNT=$materialized_count
 
   # -z terminates each record with NUL; the explicit NUL separates the commit
   # object ID from its possibly-multiline message.
+  if ! git log --no-walk=unsorted --stdin -z --format='%H%x00%B' \
+    <"${WORK}/commits" >"${WORK}/messages"; then
+    echo "PII scan error: cannot enumerate reachable commit messages" >&2
+    exit 2
+  fi
   while IFS= read -r -d '' commit && IFS= read -r -d '' message; do
     COUNT=$((COUNT + 1))
     printf '<commit:%s>' "${commit:0:12}" >"${WORK}/${COUNT}.path"
     printf '%s' "$message" >"${WORK}/${COUNT}.blob"
-  done < <(git log --all -z --format='%H%x00%B')
+  done <"${WORK}/messages"
 }
 
 case "$SCOPE" in

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -36,7 +36,9 @@ if TYPE_CHECKING:
     from typing import BinaryIO
 
 GIT_BATCH_FIELD_COUNT = 3
+GIT_MODE_DIGITS = frozenset(b"01234567")
 GIT_MODE_LENGTH = 6
+GIT_OBJECT_ID_DIGITS = frozenset(b"0123456789abcdef")
 GIT_RAW_FIELD_COUNT = 5
 
 EXCLUDED_PATHS = {
@@ -514,9 +516,63 @@ def nul_records(path: Path) -> Iterator[bytes]:
 
 def valid_object_id(value: bytes) -> bool:
     """Return whether a Git object ID uses a supported hash format."""
-    return len(value) in {40, 64} and all(
-        character in b"0123456789abcdef" for character in value
-    )
+    return len(value) in {40, 64} and set(value) <= GIT_OBJECT_ID_DIGITS
+
+
+def history_diff_associations(
+    diff_inventory: Path,
+) -> Iterator[tuple[bytes, bytes, bytes]]:
+    """Yield validated mode, object, and path tuples from raw Git diffs."""
+    records = iter(nul_records(diff_inventory))
+    while True:
+        try:
+            metadata = next(records)
+        except StopIteration:
+            break
+        try:
+            path = next(records)
+        except StopIteration as error:
+            message = "history diff inventory is incomplete"
+            raise ValueError(message) from error
+        fields = metadata.split()
+        if len(fields) != GIT_RAW_FIELD_COUNT:
+            message = "history diff inventory is malformed"
+            raise ValueError(message)
+        if not fields[0].startswith(b":") or not fields[4].isalpha():
+            message = "history diff inventory is malformed"
+            raise ValueError(message)
+        old_mode = fields[0][1:]
+        new_mode, old_oid, new_oid = fields[1:4]
+        modes_are_octal = set(old_mode + new_mode) <= GIT_MODE_DIGITS
+        if (
+            len(old_mode) != GIT_MODE_LENGTH
+            or len(new_mode) != GIT_MODE_LENGTH
+            or not modes_are_octal
+            or not valid_object_id(old_oid)
+            or not valid_object_id(new_oid)
+        ):
+            message = "history diff inventory metadata is invalid"
+            raise ValueError(message)
+        yield new_mode, new_oid, path
+
+
+def history_tree_associations(
+    tree_inventory: Path,
+) -> Iterator[tuple[bytes, bytes, bytes]]:
+    """Yield validated mode, object, and path tuples from direct tree refs."""
+    for record in nul_records(tree_inventory):
+        try:
+            metadata, path = record.split(b"\t", 1)
+            mode, object_type, oid = metadata.split()
+        except ValueError as error:
+            message = "history tree inventory is malformed"
+            raise ValueError(message) from error
+        if object_type == b"commit" and mode == b"160000":
+            continue
+        if object_type != b"blob":
+            message = "history tree inventory contains a non-blob entry"
+            raise ValueError(message)
+        yield mode, oid, path
 
 
 def write_history_associations(
@@ -554,52 +610,10 @@ def write_history_associations(
             request_stream.write(oid + b"\n")
 
     with output.open("wb") as stream, requests.open("wb") as request_stream:
-        diff_records = iter(nul_records(diff_inventory))
-        while True:
-            try:
-                metadata = next(diff_records)
-            except StopIteration:
-                break
-            try:
-                path = next(diff_records)
-            except StopIteration as error:
-                message = "history diff inventory is incomplete"
-                raise ValueError(message) from error
-            fields = metadata.split()
-            if (
-                len(fields) != GIT_RAW_FIELD_COUNT
-                or not fields[0].startswith(b":")
-                or not fields[4].isalpha()
-            ):
-                message = "history diff inventory is malformed"
-                raise ValueError(message)
-            old_mode = fields[0][1:]
-            new_mode, old_oid, new_oid = fields[1:4]
-            if (
-                len(old_mode) != GIT_MODE_LENGTH
-                or len(new_mode) != GIT_MODE_LENGTH
-                or not all(
-                    character in b"01234567" for character in old_mode + new_mode
-                )
-                or not valid_object_id(old_oid)
-                or not valid_object_id(new_oid)
-            ):
-                message = "history diff inventory metadata is invalid"
-                raise ValueError(message)
+        for new_mode, new_oid, path in history_diff_associations(diff_inventory):
             write_association(stream, request_stream, new_mode, new_oid, path)
 
-        for record in nul_records(tree_inventory):
-            try:
-                metadata, path = record.split(b"\t", 1)
-                mode, object_type, oid = metadata.split()
-            except ValueError as error:
-                message = "history tree inventory is malformed"
-                raise ValueError(message) from error
-            if object_type == b"commit" and mode == b"160000":
-                continue
-            if object_type != b"blob":
-                message = "history tree inventory contains a non-blob entry"
-                raise ValueError(message)
+        for mode, oid, path in history_tree_associations(tree_inventory):
             write_association(stream, request_stream, mode, oid, path)
 
 
@@ -615,15 +629,12 @@ def copy_exact(source: BinaryIO, destination: BinaryIO, size: int) -> None:
         remaining -= len(chunk)
 
 
-def materialize_history_associations(
-    associations: Path,
+def materialize_history_objects(
     requests: Path,
     batch_output: Path,
-    input_dir: Path,
-    start_index: int,
-) -> int:
-    """Materialize one validated input per path/blob association."""
-    object_dir = input_dir / "history-objects"
+    object_dir: Path,
+) -> dict[bytes, Path]:
+    """Validate and materialize each uniquely requested Git blob."""
     object_dir.mkdir()
     objects: dict[bytes, Path] = {}
     requested_oids = requests.read_bytes().splitlines()
@@ -650,6 +661,19 @@ def materialize_history_associations(
         if source.read(1):
             message = "Git returned unexpected trailing blob data"
             raise ValueError(message)
+    return objects
+
+
+def materialize_history_associations(
+    associations: Path,
+    requests: Path,
+    batch_output: Path,
+    input_dir: Path,
+    start_index: int,
+) -> int:
+    """Materialize one validated input per path/blob association."""
+    object_dir = input_dir / "history-objects"
+    objects = materialize_history_objects(requests, batch_output, object_dir)
 
     index = start_index
     association_records = iter(nul_records(associations))

--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -21,6 +21,7 @@ import argparse
 import hashlib
 import ipaddress
 import json
+import os
 import re
 import sys
 import unicodedata
@@ -32,6 +33,11 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
+    from typing import BinaryIO
+
+GIT_BATCH_FIELD_COUNT = 3
+GIT_MODE_LENGTH = 6
+GIT_RAW_FIELD_COUNT = 5
 
 EXCLUDED_PATHS = {
     "scripts/check_pii.py",
@@ -491,6 +497,181 @@ def input_blobs(input_dir: Path) -> Iterator[tuple[str, bytes]]:
             raise OSError(message)
         path = path_file.read_bytes().decode("utf-8", "surrogateescape")
         yield path, blob_file.read_bytes()
+
+
+def nul_records(path: Path) -> Iterator[bytes]:
+    """Yield NUL-delimited records without loading the inventory into memory."""
+    remainder = b""
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            records = (remainder + chunk).split(b"\0")
+            remainder = records.pop()
+            yield from records
+    if remainder:
+        message = "history inventory is not NUL-terminated"
+        raise ValueError(message)
+
+
+def valid_object_id(value: bytes) -> bool:
+    """Return whether a Git object ID uses a supported hash format."""
+    return len(value) in {40, 64} and all(
+        character in b"0123456789abcdef" for character in value
+    )
+
+
+def write_history_associations(
+    diff_inventory: Path,
+    tree_inventory: Path,
+    output: Path,
+    requests: Path,
+) -> None:
+    """Deduplicate reachable Git path/blob associations from trusted plumbing."""
+    seen: set[tuple[bytes, bytes]] = set()
+    seen_oids: set[bytes] = set()
+
+    def write_association(
+        stream: BinaryIO,
+        request_stream: BinaryIO,
+        mode: bytes,
+        oid: bytes,
+        path: bytes,
+    ) -> None:
+        if not path or not valid_object_id(oid):
+            message = "history inventory contains an invalid association"
+            raise ValueError(message)
+        if mode in {b"000000", b"120000", b"160000"}:
+            return
+        if mode not in {b"100644", b"100755"}:
+            message = "history inventory contains an unsupported mode"
+            raise ValueError(message)
+        association = (path, oid)
+        if association in seen:
+            return
+        seen.add(association)
+        stream.write(mode + b" " + oid + b"\0" + path + b"\0")
+        if oid not in seen_oids:
+            seen_oids.add(oid)
+            request_stream.write(oid + b"\n")
+
+    with output.open("wb") as stream, requests.open("wb") as request_stream:
+        diff_records = iter(nul_records(diff_inventory))
+        while True:
+            try:
+                metadata = next(diff_records)
+            except StopIteration:
+                break
+            try:
+                path = next(diff_records)
+            except StopIteration as error:
+                message = "history diff inventory is incomplete"
+                raise ValueError(message) from error
+            fields = metadata.split()
+            if (
+                len(fields) != GIT_RAW_FIELD_COUNT
+                or not fields[0].startswith(b":")
+                or not fields[4].isalpha()
+            ):
+                message = "history diff inventory is malformed"
+                raise ValueError(message)
+            old_mode = fields[0][1:]
+            new_mode, old_oid, new_oid = fields[1:4]
+            if (
+                len(old_mode) != GIT_MODE_LENGTH
+                or len(new_mode) != GIT_MODE_LENGTH
+                or not all(
+                    character in b"01234567" for character in old_mode + new_mode
+                )
+                or not valid_object_id(old_oid)
+                or not valid_object_id(new_oid)
+            ):
+                message = "history diff inventory metadata is invalid"
+                raise ValueError(message)
+            write_association(stream, request_stream, new_mode, new_oid, path)
+
+        for record in nul_records(tree_inventory):
+            try:
+                metadata, path = record.split(b"\t", 1)
+                mode, object_type, oid = metadata.split()
+            except ValueError as error:
+                message = "history tree inventory is malformed"
+                raise ValueError(message) from error
+            if object_type == b"commit" and mode == b"160000":
+                continue
+            if object_type != b"blob":
+                message = "history tree inventory contains a non-blob entry"
+                raise ValueError(message)
+            write_association(stream, request_stream, mode, oid, path)
+
+
+def copy_exact(source: BinaryIO, destination: BinaryIO, size: int) -> None:
+    """Copy exactly one Git batch payload without buffering the full blob."""
+    remaining = size
+    while remaining:
+        chunk = source.read(min(remaining, 1024 * 1024))
+        if not chunk:
+            message = "Git returned a truncated blob payload"
+            raise ValueError(message)
+        destination.write(chunk)
+        remaining -= len(chunk)
+
+
+def materialize_history_associations(
+    associations: Path,
+    requests: Path,
+    batch_output: Path,
+    input_dir: Path,
+    start_index: int,
+) -> int:
+    """Materialize one validated input per path/blob association."""
+    object_dir = input_dir / "history-objects"
+    object_dir.mkdir()
+    objects: dict[bytes, Path] = {}
+    requested_oids = requests.read_bytes().splitlines()
+
+    with batch_output.open("rb") as source:
+        for expected_oid in requested_oids:
+            header = source.readline().rstrip(b"\n")
+            fields = header.split()
+            if (
+                len(fields) != GIT_BATCH_FIELD_COUNT
+                or fields[0] != expected_oid
+                or fields[1] != b"blob"
+                or not fields[2].isdigit()
+            ):
+                message = "Git returned an invalid blob header"
+                raise ValueError(message)
+            object_path = object_dir / expected_oid.decode("ascii")
+            with object_path.open("wb") as destination:
+                copy_exact(source, destination, int(fields[2]))
+            if source.read(1) != b"\n":
+                message = "Git returned an unterminated blob payload"
+                raise ValueError(message)
+            objects[expected_oid] = object_path
+        if source.read(1):
+            message = "Git returned unexpected trailing blob data"
+            raise ValueError(message)
+
+    index = start_index
+    association_records = iter(nul_records(associations))
+    while True:
+        try:
+            metadata = next(association_records)
+        except StopIteration:
+            break
+        try:
+            path = next(association_records)
+            mode, oid = metadata.split()
+            object_path = objects[oid]
+        except (KeyError, StopIteration, ValueError) as error:
+            message = "validated history association is malformed"
+            raise ValueError(message) from error
+        if mode not in {b"100644", b"100755"} or not path:
+            message = "validated history association metadata is invalid"
+            raise ValueError(message)
+        index += 1
+        (input_dir / f"{index}.path").write_bytes(path)
+        os.link(object_path, input_dir / f"{index}.blob")
+    return index
 
 
 def is_legal_attribution_path(path: str) -> bool:

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -2271,6 +2271,30 @@ git -C "$repo" commit -qm remove
 assert_clean "removed PII is absent from HEAD" "$repo" --scope head --mode enforce
 assert_violation "reachable historical blob is scanned" "$repo" --scope history --mode enforce
 
+repo=$(new_repo history-path-alias)
+printf 'synthetic pixels\n' >"${repo}/a-safe.txt"
+cp "${repo}/a-safe.txt" "${repo}/z-review.png"
+git -C "$repo" add a-safe.txt z-review.png
+git -C "$repo" commit -qm aliases
+git -C "$repo" rm -q z-review.png
+git -C "$repo" commit -qm remove-media-alias
+assert_clean \
+  "removed media alias is absent from HEAD" \
+  "$repo" --scope head --mode audit
+assert_single_finding \
+  "history scans removed aliases of still-reachable blobs" \
+  "$repo" media-review review --scope history --mode audit
+
+repo=$(new_repo history-tree-ref)
+printf 'synthetic pixels\n' >"${repo}/a-safe.txt"
+cp "${repo}/a-safe.txt" "${repo}/z-review.png"
+git -C "$repo" add a-safe.txt z-review.png
+tree=$(git -C "$repo" write-tree)
+git -C "$repo" update-ref refs/tags/tree-only "$tree"
+assert_single_finding \
+  "history scans every path in a tree-only ref" \
+  "$repo" media-review review --scope history --mode audit
+
 repo=$(new_repo commit-message)
 printf 'change\n' >>"${repo}/README.md"
 git -C "$repo" add README.md
@@ -2317,12 +2341,18 @@ printf 'email: person@customer.local\n' >"${repo}/- odd name.yaml"
 git -C "$repo" add -- '- odd name.yaml'
 git -C "$repo" commit -qm odd
 assert_violation "option-like filename containing spaces" "$repo" --scope head --mode enforce
+assert_violation \
+  "history preserves option-like filenames containing spaces" \
+  "$repo" --scope history --mode enforce
 
 repo=$(new_repo symlink)
 ln -s "/Users/${SYNTHETIC_USER}/private" "${repo}/linked"
 git -C "$repo" add linked
 git -C "$repo" commit -qm symlink
 assert_clean "scanner does not dereference symlinks" "$repo" --scope head --mode enforce
+assert_clean \
+  "history scanner does not dereference symlinks" \
+  "$repo" --scope history --mode enforce
 
 repo=$(new_repo json-output)
 printf 'email: person@customer.local\n' >"${repo}/fixture.yaml"


### PR DESCRIPTION
## Summary

- inventory every unique reachable path/blob association across commit history
- include direct tree and blob refs while scanning each commit message once
- batch object reads and fail closed on malformed, missing, or mismatched inventories
- cover removed aliases, tree-only refs, unusual filenames, and symlink exclusion
- restore pre-existing YAML, Markdown, and EditorConfig hygiene required by the all-files gate

## Verification

- `tests/test-check-pii.sh`
- complete non-PII shell test suite
- Ruff lint and format checks
- ShellCheck and shell syntax checks
- `pre-commit run --all-files`
- staged PII enforcement: clean
- staged PII audit: three existing category-only manual reviews, with matched values redacted
- `vscode-xcsh` exhaustive history audit: seven expected category-only reviews (six media paths and one display label), including the previously omitted alias; 323.68 seconds

No baseline, allowlist, suppression, skipped gate, compatibility shim, recorded matched value, or timeout increase was introduced.

Closes #1038