### PR TITLE
fix: start generated READMEs with H1

### DIFF
--- a/README.md.tpl
+++ b/README.md.tpl
@@ -1,6 +1,6 @@
-__LANGUAGE_NAV__
-
 # __TITLE__
+
+__LANGUAGE_NAV__
 
 [![GitHub Pages Deploy](https://github.com/__ORG_NAME__/__REPO_NAME__/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/__ORG_NAME__/__REPO_NAME__/actions/workflows/github-pages-deploy.yml)
 [![Repository Settings](https://github.com/__ORG_NAME__/__REPO_NAME__/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/__ORG_NAME__/__REPO_NAME__/actions/workflows/enforce-repo-settings.yml)

--- a/tests/test-readme-generation.sh
+++ b/tests/test-readme-generation.sh
@@ -103,6 +103,25 @@ Some per-repo prose.") ;;
 done
 
 echo ""
+echo "=== Section 1b: generated README starts with one H1 (MD041) ==="
+
+for case_name in "language navigation" "no language navigation"; do
+  case "$case_name" in
+  "language navigation") out=$(render "🌐 English" "" "") ;;
+  "no language navigation") out=$(render "" "" "") ;;
+  esac
+
+  first_content=$(awk 'NF { print; exit }' "$out")
+  h1_count=$(grep -c '^# ' "$out" || true)
+  if [ "$first_content" = "# Example Repo" ] && [ "$h1_count" -eq 1 ]; then
+    pass "1b.x rendered README starts with exactly one H1 ($case_name)"
+  else
+    fail "1b.x rendered README starts with exactly one H1 ($case_name)" \
+      "first content is '$first_content'; H1 count is $h1_count"
+  fi
+done
+
+echo ""
 echo "=== Section 2: the template still renders its required content ==="
 
 out=$(render "🌐 English" "" "")


### PR DESCRIPTION
Closes #1048

## Summary

- move the generated README title before language navigation
- add regression coverage for empty and non-empty navigation
- keep exactly one top-level heading in every rendered README

## Verification

- bash tests/test-readme-generation.sh (17 passed)
- shfmt -d tests/test-readme-generation.sh
- shellcheck tests/test-readme-generation.sh
- rendered README piped through markdownlint-cli 0.49.1