### PR TITLE
fix: suspend Antigravity automations

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -28,6 +28,7 @@
     ".github/workflows/workflow-security-audit.yml",
     ".github/workflows/semgrep.yml",
     ".github/workflows/translation-audit.yml",
+    ".github/workflows/antigravity-review.yml",
     ".github/workflows/antigravity-translate.yml",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/ISSUE_TEMPLATE/bug_report.md",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -157,6 +157,14 @@
         "dest": ".github/workflows/translation-audit.yml"
       },
       {
+        "src": "workflows/antigravity-review.yml",
+        "dest": ".github/workflows/antigravity-review.yml"
+      },
+      {
+        "src": "workflows/antigravity-translate.yml",
+        "dest": ".github/workflows/antigravity-translate.yml"
+      },
+      {
         "src": ".github/PULL_REQUEST_TEMPLATE.md",
         "dest": ".github/PULL_REQUEST_TEMPLATE.md"
       },

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -1,3 +1,4 @@
+---
 name: Antigravity Code Review
 
 on:
@@ -15,8 +16,12 @@ permissions:
 
 jobs:
   antigravity-review:
-    # Security: restrict execution to trusted same-repo PR heads (exclude external forks)
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # SUSPENDED: Gemini Antigravity review is opt-in while its quota is exhausted.
+    # Unset, false, or any value other than the literal string "true" stays off.
+    # Security: also restrict execution to trusted same-repo PR heads (exclude external forks).
+    if: >-
+      vars.ANTIGRAVITY_REVIEW_ENABLED == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -50,17 +55,17 @@ jobs:
             export SSH_AUTH_SOCK
             export GNOME_KEYRING_CONTROL
             export GNOME_KEYRING_PID
-            
+
             # 2. Extract clean raw JSON from macOS keychain base64-encoded token
             RAW_TOKEN_JSON=$(echo "$ANTIGRAVITY_TOKEN" | sed "s/^go-keyring-base64:// " | base64 -d)
-            
+
             # 3. Store raw JSON in standard DBus Secret Service
             python3 -c "import keyring; keyring.set_password('\''gemini'\'', '\''antigravity'\'', \"\"\"$RAW_TOKEN_JSON\"\"\")"
-            
+
             # 4. Automate workspace trust with Gemini 3.6 Flash (High) and global endpoint
             mkdir -p ~/.gemini/antigravity-cli
             echo "{\"gcp\": {\"project\": \"$GCP_PROJECT_ID\", \"location\": \"global\"}, \"model\": \"Gemini 3.6 Flash (High)\", \"trustedWorkspaces\": [\"/home/runner/work/$REPOSITORY_NAME/$REPOSITORY_NAME\"]}" > ~/.gemini/antigravity-cli/settings.json
-            
+
             # 5. Run the Antigravity Agentic PR Reviewer. Using --dangerously-skip-permissions to allow execution of git and gh tools in headless mode.
             /home/runner/.local/bin/agy --project "$GCP_PROJECT_ID" --dangerously-skip-permissions --print "You are Antigravity, an elite agentic AI coding assistant. Review this Pull Request. First, run '\''gh pr diff'\'' to retrieve the code modifications. Meticulously inspect the changes for security issues, hardcoded tokens/secrets, PII leakage (such as email addresses, user names, phone numbers), or bad architectural patterns. Finally, use '\''gh pr comment'\'' to post a constructive, high-quality review summary directly on the PR."
           '

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -1,3 +1,4 @@
+---
 name: Antigravity Language Translation
 
 on:
@@ -19,8 +20,13 @@ permissions:
 
 jobs:
   antigravity-translate:
-    # Security: restrict execution to trusted same-repo PR heads (exclude external forks)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+    # SUSPENDED: Gemini Antigravity translation shares the fleet translation
+    # switch while its quota is exhausted. Unset or anything but "true" stays off.
+    # Security: also restrict execution to trusted same-repo PR heads.
+    if: >-
+      vars.TRANSLATIONS_ENABLED == 'true' &&
+      (github.event.pull_request.head.repo.full_name == github.repository ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -40,7 +46,7 @@ jobs:
         run: |
           # Fetch changed files in the branch
           git diff --name-only origin/main...HEAD > changed_files.txt || git diff --name-only HEAD~1 > changed_files.txt || touch changed_files.txt
-          
+
           # Execute the trigger parser script
           bash scripts/parse-translation-trigger.sh "$PR_TITLE" changed_files.txt "$EVENT_NAME"
 
@@ -69,17 +75,17 @@ jobs:
             export SSH_AUTH_SOCK
             export GNOME_KEYRING_CONTROL
             export GNOME_KEYRING_PID
-            
+
             # 2. Extract clean raw JSON from macOS keychain base64-encoded token
             RAW_TOKEN_JSON=$(echo "$ANTIGRAVITY_TOKEN" | sed "s/^go-keyring-base64://" | base64 -d)
-            
+
             # 3. Store raw JSON in standard DBus Secret Service
             python3 -c "import keyring; keyring.set_password('\''gemini'\'', '\''antigravity'\'', \"\"\"$RAW_TOKEN_JSON\"\"\")"
-            
+
             # 4. Automate workspace trust with Gemini 3.6 Flash (High) and global endpoint
             mkdir -p ~/.gemini/antigravity-cli
             echo "{\"gcp\": {\"project\": \"$GCP_PROJECT_ID\", \"location\": \"global\"}, \"model\": \"Gemini 3.6 Flash (High)\", \"trustedWorkspaces\": [\"/home/runner/work/$REPOSITORY_NAME/$REPOSITORY_NAME\"]}" > ~/.gemini/antigravity-cli/settings.json
-            
+
             # 5. Configure git identity for automated translation commits
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -508,6 +508,10 @@ jobs:
         if: hashFiles('tests/test-translation-suspension.sh') != ''
         run: bash tests/test-translation-suspension.sh
 
+      - name: Run Antigravity suspension test
+        if: hashFiles('tests/test-antigravity-suspension.sh') != ''
+        run: bash tests/test-antigravity-suspension.sh
+
       - name: Run locale-lint test
         if: hashFiles('tests/test-locale-lint.sh') != ''
         run: bash tests/test-locale-lint.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended**, and the translation-freshness audit still runs but no longer gates a merge — see CONTRIBUTING.md.
+- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Claude and Antigravity CI reviewers, Antigravity translation, and translation-freshness audit are **suspended** — see CONTRIBUTING.md.
 
 ## Two review layers
 
@@ -27,7 +27,7 @@ Reviewing a **spec or plan** is not reviewing a **pull-request diff**. Pick by w
 
 - **Local, pre-PR — advisory, never a gate.** When installed, use `codex:verified-code-review` before a human reviews a spec or plan (`review-doc --kind spec|plan`, its primary use), before a push that opens or updates a PR (`adversarial-review`), and after each round of fixes. When absent, skip it — never substitute a PR-diff reviewer. Confirm findings here before acting; report those you dismissed.
 - **Never** use a PR-diff reviewer for a spec, plan, or local branch. `.claude/settings.json` denies `code-review:code-review` and `pr-review-toolkit:review-pr`; `code-review-f5:code-review` is marked `disable-model-invocation`. The built-ins `/review` and `/security-review` cannot be denied — not selecting them is on you.
-- **CI** — the `review / claude-review` diff reviewer is **suspended**: not running, not required. Do not wait for it, and do not re-enable it outside REVIEWER-SPEC.md.
+- **CI** — both pull-request diff reviewers are **suspended** and not required. Do not wait for Claude or Antigravity review; follow their separate restoration procedures in CONTRIBUTING.md.
 
 ## Worktrees
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,14 +199,11 @@ Review happens in two layers. They are not interchangeable, and neither substitu
 
 ### CI review (suspended)
 
-> **Suspended.** The self-hosted reviewer could not reliably reach model inference or the VPN, so
-> the check often never went green and blocked pull requests for infrastructure reasons rather than
-> code-quality ones. The `review / claude-review` context has been removed from branch protection
-> (docs-control#833) and the workflow is gated off behind the `REVIEWER_ENABLED` variable
-> (docs-control#838). **No CI job currently reviews pull-request diffs.** Do not wait for it, and do
-> not treat its absence as a fault. Restoring it is described in `REVIEWER-SPEC.md` — set the
-> variable and confirm a real review completes *before* re-adding the required context, because the
-> reverse order deadlocks every open pull request.
+> **Suspended.** No CI job currently reviews pull-request diffs. The self-hosted Claude reviewer is
+> gated behind `REVIEWER_ENABLED` (docs-control#838), and its required context was removed first
+> (docs-control#833). The quota-backed Gemini Antigravity reviewer is disabled in GitHub Actions and
+> fail-closed behind `ANTIGRAVITY_REVIEW_ENABLED` (docs-control#1043). Do not wait for either review
+> or treat its absence as a fault.
 
 The rest of this section describes the reviewer as it behaves when enabled.
 
@@ -227,6 +224,18 @@ until it passes.
   and the linked-issue check — this is for machine-generated PRs only. The authoritative prefix
   list lives in `require-linked-issue.yml` and `code-review.yml`; never adopt such a prefix for
   human or agent work.
+
+#### Restoring Antigravity review
+
+Keep the source gate in place. After quota is available, enable the reusable workflow in
+`docs-control`, enable the caller workflow only in the selected repositories, and only then set
+their `ANTIGRAVITY_REVIEW_ENABLED` Actions variable to the literal string `true`. Exercise a real
+same-repository pull request in every selected repository before relying on the reviewer. The
+Antigravity review is advisory and must not be added to required status contexts.
+
+The Claude review has a separate restoration procedure in `REVIEWER-SPEC.md`: set its variable and
+confirm a real review completes *before* re-adding its required context. Reversing that order
+deadlocks every open pull request.
 
 ### Local pre-PR review (advisory second opinion)
 
@@ -251,26 +260,34 @@ problems while they are still cheap to fix — in a spec or a plan, before any c
 The two layers are complementary: the local layer catches issues before the pull request exists and
 costs nothing when it is wrong, while CI remains the gate that decides whether a change merges.
 
-## Translations (Antigravity `agy` Automated Translation)
+## Translations (suspended)
 
-Language translation for the `f5-sales-demo` ecosystem across 12 target locales (`fr`, `es`, `de`, `pt-br`, `ja`, `ko`, `zh-cn`, `zh-tw`, `ar`, `it`, `hi`, `th`) is powered by **Antigravity (`agy`)** running as an automated GitHub Actions runner workflow (`antigravity-translate.yml`).
+Automated translation is suspended while Gemini Antigravity quota is exhausted. The reusable
+workflow is disabled in GitHub Actions, and both it and every governed caller fail closed unless
+`vars.TRANSLATIONS_ENABLED` is the literal string `true`. Local generation and the freshness audit
+remain suspended under the same switch. Translation files stay in place and can be restored without
+recreating the workflows or credentials.
 
 How the translation pipeline operates:
 
 | Part | Where | How it Works |
 | ---- | ----- | ------------ |
-| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on GitHub Action runner | Triggers on PRs modifying `docs/en/**/*.md[x]`. Uses Gemini 3.6 Flash (High) and `.agents/skills/i18n-translate/SKILL.md` to translate missing/stale files, update `i18n.sourceHash`, and auto-commit back to the PR branch. |
-| Freshness Audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against English source SHA-256 | Verifies that all 12 localized docs exist and match current English hashes. |
-| Required Context | `audit / Translation freshness` in branch protection | Ensures no PR merges with stale or missing translations. |
+| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on a GitHub Actions runner | **Suspended.** When restored, it translates missing or stale files and commits them back to same-repository pull-request branches. |
+| Freshness Audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against English source SHA-256 | **Suspended.** The gated job is retained but may skip while translations intentionally drift. |
+| Required Context | `audit / Translation freshness` in branch protection | **Not required.** Requiring a check while its job can skip would deadlock pull requests. |
 
 ### Restoring translations and activating Antigravity `agy` translator
-
 
 Order matters, and getting it wrong deadlocks every open pull request — the same trap the suspended
 reviewer left behind.
 
-1. Turn on **both** switches. `TRANSLATIONS_ENABLED` is one name for two independent settings, and
-   setting only one half-restores the system:
+1. Restore the workflow states before the switch. First enable the reusable workflow in
+   `docs-control`, then enable the governed caller workflow only in the selected repositories. Do
+   not set `TRANSLATIONS_ENABLED` yet: a positive source gate must remain between an accidentally
+   enabled workflow and quota-backed execution.
+
+2. Turn on **both** switch environments. `TRANSLATIONS_ENABLED` is one name for two independent
+   settings, and setting only one half-restores the system:
 
    ```bash
    # Generation — the pre-commit hook reads your local process environment.
@@ -280,36 +297,38 @@ reviewer left behind.
    ```
 
    Then set the `TRANSLATIONS_ENABLED` **organisation variable** to `true`, which is what the audit
-   workflow reads — an organisation variable is exposed to Actions through the `vars` context only, so
-   it never reaches the hook on your machine.
+   and Antigravity workflows read — an organisation variable is exposed to Actions through the
+   `vars` context only, so it never reaches the hook on your machine.
 
-   Setting just the organisation variable is the trap: the `--force` run in step 2 works, because you
+   Setting just the organisation variable is the trap: the `--force` run in step 3 works, because you
    run it directly, and then every later English edit silently skips generation. Nothing complains
    until the audit is required again, at which point pull requests fail fleet-wide.
    Make sure the organisation variable is visible to **all** governed repositories. An organisation
    variable scoped to a subset leaves the rest with a job that silently never runs.
-2. Regenerate everything with `docs-translate --force` and commit. Expect roughly 4,320 files across
+3. Regenerate everything with `docs-translate --force` and commit. Expect roughly 4,320 files across
    the fleet.
-3. **Un-gate both, and let that sync downstream.** In `workflows/translation-audit.yml`, delete the
+4. **Un-gate the audit and local hook, and let that sync downstream.** In
+   `workflows/translation-audit.yml`, delete the
    `if: vars.TRANSLATIONS_ENABLED == 'true'` line *and* the `SUSPENDED:` comment block, returning the
    job to unconditional. In `.pre-commit-config.yaml`, remove the `TRANSLATIONS_ENABLED` branch from
-   the `docs-translate` hook.
+   the `docs-translate` hook. Keep the Antigravity caller and reusable-workflow gates: quota-backed
+   automation should remain fail-closed even after the audit is unconditional again.
 
    Delete the `if:`, do not merely set the variable. Leaving the condition in place makes organisation
    variable visibility permanently load-bearing for CI: any repository the variable is not visible to
    silently skips the job, and once the context is required again its pull requests wait forever for a
-   check that is never emitted. An unconditional job removes that whole class of failure — after this,
-   `TRANSLATIONS_ENABLED` governs only local generation, which fails visibly and cheaply.
+   check that is never emitted. An unconditional audit removes that whole class of failure — after
+   this, `TRANSLATIONS_ENABLED` gates only quota-backed Antigravity generation.
 
    docs-control's `tests/test-translation-suspension.sh` keys section 1 on the `SUSPENDED:` marker,
    so leaving it in place fails the guard the moment the context comes back.
-4. Confirm the audit actually reports on **every governed repository that receives the workflow**, not
+5. Confirm the audit actually reports on **every governed repository that receives the workflow**, not
    on one pull request. Three traps here, all of them load-bearing:
 
    - **One green PR proves one repo.** During the suspension a five-repository spot check came back
      clean while **9 of 38** still had the old branch protection, because enforcement fans out in
      batches of five. Re-adding the context on that evidence would have deadlocked nine repositories.
-   - **An old run proves nothing.** The last conclusion may predate the un-gating in step 3, or come
+   - **An old run proves nothing.** The last conclusion may predate the un-gating in step 4, or come
      from a repository still running the gated workflow. Confirm the synced file no longer contains the
      `if:` before trusting a run, and only count runs created after that.
    - **Some repos never receive this workflow at all.** Anything listed under `skip_files` for
@@ -319,7 +338,7 @@ reviewer left behind.
      *permanent* deadlock, not a transient one.
 
    ```bash
-   SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)   # capture AFTER step 3 has synced
+   SINCE=$(date -u +%Y-%m-%dT%H:%M:%SZ)   # capture AFTER step 4 has synced
    SKIP=$(jq -r '.skip_files | to_entries[]
                  | select(any(.value[]; test("translation-audit"))) | .key' .claude/governance.json)
    while IFS= read -r r; do
@@ -362,17 +381,17 @@ reviewer left behind.
    Close the probe pull request once the audit reports. Skipping this step is how an operator ends up
    re-adding the required context on the strength of repositories that were never actually exercised.
 
-5. **Only then** re-add `audit / Translation freshness` to
+6. **Only then** re-add `audit / Translation freshness` to
    `branch_protection[0].required_status_checks.contexts` — **and re-add
    `excluded_required_contexts: ["audit / Translation freshness"]` to the `terraform-provider-xcsh`
    and `code-review` overrides**, which were removed with the base context because an exclusion that
    matches no required context silently no-ops. Without them those two repositories would gain a
    check they were deliberately exempt from.
 
-Re-adding the required context before step 4 makes a check that never reports mandatory, which blocks
+Re-adding the required context before step 5 makes a check that never reports mandatory, which blocks
 every pull request until an administrator intervenes. The guard test cannot catch this for you: it
 reads files, and no static check can see whether an organisation variable is set in every repository.
-Step 4 is the only thing standing between a restore and a fleet-wide outage.
+Step 5 is the only thing standing between a restore and a fleet-wide outage.
 
 ## Branch Protection Rules
 
@@ -395,7 +414,8 @@ If you are Claude Code, Copilot, or another AI coding assistant, follow these ru
 6. **Fill out the PR template checklist** completely.
 7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
 8. **Respect CODEOWNERS** — Review the CODEOWNERS file for the default reviewer.
-9. **The automated reviewer is authoritative** — if it blocks, fix and re-push; never bypass, disable, or override it. See [Automated code review](#automated-code-review).
+9. **A restored blocking reviewer is authoritative** — if it blocks, fix and re-push; never bypass,
+   disable, or override it. See [Automated code review](#automated-code-review).
 
 ## Engineering Standards
 

--- a/tests/test-antigravity-suspension.sh
+++ b/tests/test-antigravity-suspension.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Proves quota-backed Antigravity automation is fail-closed and governed.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
+GOVERNANCE="$REPO_ROOT/.claude/governance.json"
+CONTRIBUTING="$REPO_ROOT/CONTRIBUTING.md"
+
+PASS=0
+FAIL=0
+
+pass() {
+  printf '  PASS: %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  FAIL: %s — %s\n' "$1" "$2"
+  FAIL=$((FAIL + 1))
+}
+
+assert_contains() {
+  local file="$1" token="$2" label="$3"
+  if grep -qF "$token" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "$file does not contain: $token"
+  fi
+}
+
+echo "Antigravity suspension guards"
+
+for file in \
+  "$REPO_ROOT/.github/workflows/antigravity-review.yml" \
+  "$REPO_ROOT/workflows/antigravity-review.yml"; do
+  assert_contains "$file" "vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'" \
+    "review workflow $(basename "$file") is positive-gated"
+  assert_contains "$file" "SUSPENDED:" \
+    "review workflow $(basename "$file") records suspension intent"
+done
+
+for file in \
+  "$REPO_ROOT/.github/workflows/antigravity-translate.yml" \
+  "$REPO_ROOT/workflows/antigravity-translate.yml"; do
+  assert_contains "$file" "vars.TRANSLATIONS_ENABLED == 'true'" \
+    "translation workflow $(basename "$file") shares the translation gate"
+  assert_contains "$file" "SUSPENDED:" \
+    "translation workflow $(basename "$file") records suspension intent"
+done
+
+for mapping in \
+  'workflows/antigravity-review.yml|.github/workflows/antigravity-review.yml' \
+  'workflows/antigravity-translate.yml|.github/workflows/antigravity-translate.yml'; do
+  src=${mapping%%|*}
+  dest=${mapping#*|}
+  if jq -e --arg src "$src" --arg dest "$dest" '
+    [.managed_files.files[] | select(.src == $src and .dest == $dest)] | length == 1
+  ' "$REPO_SETTINGS" >/dev/null; then
+    pass "$dest has one canonical managed-file mapping"
+  else
+    fail "$dest has one canonical managed-file mapping" \
+      "missing or duplicated src=$src dest=$dest"
+  fi
+  if jq -e --arg dest "$dest" '
+    [.protected_files[] | select(. == $dest)] | length == 1
+  ' "$GOVERNANCE" >/dev/null; then
+    pass "$dest is protected by docs-control governance"
+  else
+    fail "$dest is protected by docs-control governance" \
+      "missing or duplicated protected_files entry"
+  fi
+done
+
+if jq -e '
+  ((.branch_protection[0].required_status_checks.contexts // []) +
+   ([.repo_overrides // {} | .[] | .additional_contexts // []] | flatten)) |
+  all(.[]; test("antigravity"; "i") | not)
+' "$REPO_SETTINGS" >/dev/null; then
+  pass "no Antigravity workflow is a required status context"
+else
+  fail "no Antigravity workflow is a required status context" \
+    "a gated workflow must never be required"
+fi
+
+assert_contains "$CONTRIBUTING" "ANTIGRAVITY_REVIEW_ENABLED" \
+  "CONTRIBUTING documents the review restore switch"
+assert_contains "$CONTRIBUTING" "Translations (suspended)" \
+  "CONTRIBUTING identifies translations as suspended"
+assert_contains "$CONTRIBUTING" "enable the reusable workflow" \
+  "CONTRIBUTING documents workflow-state restoration order"
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/test-translation-suspension.sh
+++ b/tests/test-translation-suspension.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_SETTINGS="$REPO_ROOT/.github/config/repo-settings.json"
 AUDIT_STUB="$REPO_ROOT/workflows/translation-audit.yml"
+ANTIGRAVITY_REUSABLE="$REPO_ROOT/.github/workflows/antigravity-translate.yml"
+ANTIGRAVITY_STUB="$REPO_ROOT/workflows/antigravity-translate.yml"
 PRE_COMMIT="$REPO_ROOT/.pre-commit-config.yaml"
 CONTRIBUTING="$REPO_ROOT/CONTRIBUTING.md"
 
@@ -110,8 +112,18 @@ fi
 echo ""
 echo "=== Section 2: generation is opt-in, not opt-out ==="
 
+for translation_workflow in "$ANTIGRAVITY_REUSABLE" "$ANTIGRAVITY_STUB"; do
+  if grep -qF "vars.TRANSLATIONS_ENABLED == 'true'" "$translation_workflow" &&
+    grep -q 'SUSPENDED:' "$translation_workflow"; then
+    pass "2.0 Antigravity $(basename "$translation_workflow") shares the positive translation gate"
+  else
+    fail "2.0 Antigravity $(basename "$translation_workflow") shares the positive translation gate" \
+      "quota-backed generation must stay off unless TRANSLATIONS_ENABLED is exactly true"
+  fi
+done
+
 # Assert against the current state rather than assuming suspension forever.
-# Restoration removes this branch from the hook (CONTRIBUTING step 3), so an
+# Restoration removes this branch from the hook (CONTRIBUTING step 4), so an
 # unconditional requirement would fail the moment someone follows the documented
 # procedure — forcing an undocumented test edit in the middle of a recovery.
 #

--- a/workflows/antigravity-review.yml
+++ b/workflows/antigravity-review.yml
@@ -13,9 +13,11 @@ concurrency:
 
 jobs:
   review:
-    # Runs only if the PR head repository is the same as the base repository
-    # and is not triggered on automated branches
+    # SUSPENDED: Gemini Antigravity review is opt-in while its quota is exhausted.
+    # Runs only if explicitly enabled, the PR head repository is the same as the
+    # base repository, and the event is not triggered on an automated branch.
     if: >-
+      vars.ANTIGRAVITY_REVIEW_ENABLED == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !(startsWith(github.head_ref, 'governance/') ||
         startsWith(github.head_ref, 'sync/') ||

--- a/workflows/antigravity-translate.yml
+++ b/workflows/antigravity-translate.yml
@@ -17,9 +17,12 @@ concurrency:
 
 jobs:
   translate:
-    # Runs only if the PR head repository is the same as the base repository
-    # and is not triggered on automated branches
+    # SUSPENDED: Gemini Antigravity translation shares the fleet translation
+    # switch while its quota is exhausted.
+    # Runs only if explicitly enabled, the PR head repository is the same as the
+    # base repository, and the event is not triggered on an automated branch.
     if: >-
+      vars.TRANSLATIONS_ENABLED == 'true' &&
       (github.event_name == 'workflow_dispatch' ||
        github.event.pull_request.head.repo.full_name == github.repository) &&
       !(startsWith(github.head_ref, 'governance/') ||


### PR DESCRIPTION
## Summary

Suspend quota-backed Gemini Antigravity translation and pull-request review automation without deleting the workflows or credentials. The live docs-control workflows were disabled first; source now fails closed unless the corresponding Actions variable is exactly `true`.

## Related Issue

Closes #1043

## Changes

- Gate both reusable workflows and both governed callers.
- Reclaim review and translation callers in the canonical managed-file inventory.
- Document the suspension and safe workflow-state/variable restoration order.
- Add Antigravity suspension coverage and extend the existing translation guard.

## Verification evidence

- `bash tests/test-antigravity-suspension.sh` — 16 passed, 0 failed.
- `bash tests/test-translation-suspension.sh` — 15 passed, 0 failed.
- All 33 `tests/test-*.sh` suites passed, including bounded bootstrap and PII acceptance suites.
- `pre-commit run --from-ref origin/main --to-ref HEAD` — all applicable hooks passed after rebasing onto current main.
- `actionlint ...` passed; `zizmor --config zizmor.yaml .github/workflows/` reported no findings.
- Full-tree pre-commit additionally identified pre-existing markdown spacing failures in the unchanged `.agents/skills/i18n-translate/SKILL.md`; the PR diff itself is lint-clean.
- Required CI passed on final head `56630d9`: linked issue, lint, and shell unit tests.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions
