### PR TITLE
fix(pii): accept shell positional placeholders

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -221,7 +221,7 @@ SAFE_BLOCK_PROSE_RE = re.compile(
     re.IGNORECASE,
 )
 TEMPLATE_PLACEHOLDER_RE = re.compile(
-    r"(?:\$[A-Za-z_][A-Za-z0-9_]*|\$\{[^{}\s]+\}|"
+    r"(?:\$(?:[A-Za-z_][A-Za-z0-9_]*|[0-9]+)|\$\{[^{}\s]+\}|"
     r"\{[A-Za-z_][A-Za-z0-9_.-]*\}|<[A-Za-z_][A-Za-z0-9_.-]*>|"
     r"\{\{\s*[^{}\r\n]+?\s*\}\}|\[%\s*[^%\r\n]+?\s*%\])"
 )

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -172,6 +172,22 @@ git -C "$repo" add fixture.yaml
 git -C "$repo" commit -qm synthetic
 assert_clean "reserved synthetic values" "$repo" --scope head --mode enforce
 
+repo=$(new_repo shell-positional-identities)
+cat >"${repo}/fixture.sh" <<'EOF'
+NAMESPACE=$2
+EOF
+git -C "$repo" add fixture.sh
+git -C "$repo" commit -qm shell-positional-identities
+assert_clean "shell positional identity inputs are dynamic" "$repo" --scope head --mode enforce
+
+repo=$(new_repo shell-literal-identity)
+cat >"${repo}/fixture.sh" <<'EOF'
+NAMESPACE=private-customer
+EOF
+git -C "$repo" add fixture.sh
+git -C "$repo" commit -qm shell-literal-identity
+assert_customer_identifier "unquoted shell identity literals remain enforced" "$repo" --scope head --mode enforce
+
 repo=$(new_repo localization-message-labels)
 mkdir -p "${repo}/l10n"
 cat >"${repo}/l10n/bundle.l10n.json" <<'EOF'


### PR DESCRIPTION
## Summary

Treat shell positional parameters such as `$2` as dynamic placeholders without weakening detection of unquoted literal identity values.

## Related Issue

Closes #1015

## Changes

- Extend the placeholder grammar with numeric shell positional parameters.
- Add a clean `$2` regression and a literal `private-customer` negative control.

## Verification evidence

- Red: `bash tests/test-check-pii.sh` reported `shell positional identity inputs are dynamic — expected clean (0), got 1`.
- Green: `bash tests/test-check-pii.sh` → `check-pii tests passed`, exit 0.
- `/Users/r.mordasiewicz/.local/bin/pylint scripts/check_pii.py` → exit 0, 9.92/10.
- `shellcheck tests/test-check-pii.sh` → exit 0.
- `git diff --check` → exit 0.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
