### PR TITLE
fix(security): remove fleet Gitleaks allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,3 +1,4 @@
-[allowlist]
-  description = "Allowlist placeholder values in example files"
-  paths = ["examples/"]
+title = "Fleet default Gitleaks rules"
+
+[extend]
+useDefault = true

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1192,6 +1192,20 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 16: managed Gitleaks configuration has no escape hatches
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 16: unsuppressed Gitleaks configuration ==="
+
+EXPECTED_GITLEAKS_CONFIG=$'title = "Fleet default Gitleaks rules"\n\n[extend]\nuseDefault = true'
+if [ "$(cat "$REPO_ROOT/.gitleaks.toml")" = "$EXPECTED_GITLEAKS_CONFIG" ]; then
+  pass "16.1 managed Gitleaks config uses defaults without allowlists or baselines"
+else
+  fail "16.1 managed Gitleaks config uses defaults without allowlists or baselines" \
+    "the config contains an escape hatch or does not enable the default rules"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # Summary
 # ════════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
## Summary

- replace the managed examples-path Gitleaks allowlist with the embedded default rule set
- add a regression requiring the exact unsuppressed managed configuration
- propagate the clean-break configuration to every governed repository through the managed-files workflow

## Verification

- failing-first linter-config regression reproduced
- `tests/test-linter-configs.sh`: 156 passed
- `pre-commit run --all-files`
- staged PII enforcement: clean
- unsuppressed Gitleaks current-tree scan: zero findings
- unsuppressed Gitleaks history scan: zero findings across 542 commits
- no baseline, path allowlist, ignore file, or inline `gitleaks:allow` handling

Closes #1063
Campaign: #878