### PR TITLE
fix: defer dispatch when GitHub rate limits

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -81,6 +81,10 @@ jobs:
                 -f revision="$SOURCE_SHA"
               exit 0
               ;;
+            84)
+              echo "[DEFER] GitHub API rate capacity was exhausted; scheduled recovery is active"
+              exit 0
+              ;;
             80|81|82)
               echo "[BOOTSTRAP] propagating the exact managed caller before fan-out"
               set +e

--- a/scripts/preflight-downstream-dispatch.sh
+++ b/scripts/preflight-downstream-dispatch.sh
@@ -9,6 +9,40 @@ rollout_config="${ROLLOUT_CONFIG:-.github/config/governance-rollout.json}"
 repository="${GITHUB_REPOSITORY:-}"
 owner="${repository%%/*}"
 source_sha="${SOURCE_SHA:-}"
+api_not_found=false
+current_main=""
+source_status=""
+pinned_blob=""
+source_blob=""
+expected_caller_blob=""
+downstream_main=""
+actual_caller_blob=""
+workflow_state=""
+
+github_api_into() {
+  local target="$1"
+  local err_file api_output api_rc
+  shift
+  err_file=$(mktemp)
+  set +e
+  api_output=$(gh api "$@" 2>"$err_file")
+  api_rc=$?
+  set -e
+  api_not_found=false
+  if [ "$api_rc" -ne 0 ]; then
+    if grep -qiE 'rate[[:space:]-]*limit|HTTP 429|abuse[ -]?detection' "$err_file"; then
+      rm -f "$err_file"
+      echo "[DEFER] GitHub API rate capacity was exhausted; scheduled recovery is active"
+      exit 84
+    fi
+    grep -qE '\(HTTP 404\)$' "$err_file" && api_not_found=true
+    cat "$err_file" >&2
+    rm -f "$err_file"
+    return "$api_rc"
+  fi
+  rm -f "$err_file"
+  printf -v "$target" '%s' "$api_output"
+}
 
 if ! printf '%s' "$source_sha" | grep -qE '^[0-9a-f]{40}$'; then
   echo "[ERROR] Source receipt must be a full lowercase commit SHA" >&2
@@ -37,7 +71,7 @@ if ! pin_revision=$(jq -er \
   echo "[ERROR] Governed workflow pin is missing or invalid" >&2
   exit 1
 fi
-if ! current_main=$(gh api "repos/${repository}/commits/main" --jq '.sha'); then
+if ! github_api_into current_main "repos/${repository}/commits/main" --jq '.sha'; then
   echo "[ERROR] Could not resolve protected docs-control main" >&2
   exit 1
 fi
@@ -47,8 +81,8 @@ if ! printf '%s' "$current_main" | grep -qE '^[0-9a-f]{40}$'; then
 fi
 
 if [ "$source_sha" != "$current_main" ]; then
-  if ! source_status=$(gh api \
-    "repos/${repository}/compare/${source_sha}...${current_main}" --jq '.status'); then
+  if ! github_api_into source_status \
+    "repos/${repository}/compare/${source_sha}...${current_main}" --jq '.status'; then
     echo "[ERROR] Could not prove the dispatch receipt is on protected main" >&2
     exit 1
   fi
@@ -62,13 +96,13 @@ fi
 
 for workflow in enforce-repo-settings.yml sync-managed-files.yml; do
   path=".github/workflows/${workflow}"
-  if ! pinned_blob=$(gh api \
-    "repos/${repository}/contents/${path}?ref=${pin_revision}" --jq '.sha'); then
+  if ! github_api_into pinned_blob \
+    "repos/${repository}/contents/${path}?ref=${pin_revision}" --jq '.sha'; then
     echo "[ERROR] Could not resolve pinned reusable workflow ${workflow}" >&2
     exit 1
   fi
-  if ! source_blob=$(gh api \
-    "repos/${repository}/contents/${path}?ref=${source_sha}" --jq '.sha'); then
+  if ! github_api_into source_blob \
+    "repos/${repository}/contents/${path}?ref=${source_sha}" --jq '.sha'; then
     echo "[ERROR] Could not resolve source reusable workflow ${workflow}" >&2
     exit 1
   fi
@@ -83,9 +117,9 @@ for workflow in enforce-repo-settings.yml sync-managed-files.yml; do
   fi
 done
 
-if ! expected_caller_blob=$(gh api \
+if ! github_api_into expected_caller_blob \
   "repos/${repository}/contents/workflows/enforce-repo-settings.yml?ref=${source_sha}" \
-  --jq '.sha'); then
+  --jq '.sha'; then
   echo "[ERROR] Could not resolve the exact managed caller" >&2
   exit 1
 fi
@@ -101,34 +135,28 @@ while IFS= read -r name; do
     echo "[ERROR] Invalid downstream repository name" >&2
     exit 1
   fi
-  err_file=$(mktemp)
-  if ! downstream_main=$(gh api "repos/${owner}/${name}/commits/main" \
-    --jq '.sha' 2>"$err_file"); then
+  if ! github_api_into downstream_main "repos/${owner}/${name}/commits/main" \
+    --jq '.sha'; then
     echo "[ERROR] Could not resolve protected main for ${name}" >&2
-    rm -f "$err_file"
     exit 1
   fi
   if ! printf '%s' "$downstream_main" | grep -qE '^[0-9a-f]{40}$'; then
     echo "[ERROR] Invalid protected-main receipt for ${name}" >&2
-    rm -f "$err_file"
     exit 1
   fi
-  if ! actual_caller_blob=$(gh api \
+  if ! github_api_into actual_caller_blob \
     "repos/${owner}/${name}/contents/.github/workflows/enforce-repo-settings.yml?ref=${downstream_main}" \
-    --jq '.sha' 2>"$err_file"); then
-    if grep -qE '\(HTTP 404\)$' "$err_file"; then
+    --jq '.sha'; then
+    if [ "$api_not_found" = true ]; then
       actual_caller_blob=""
     else
       echo "[ERROR] Could not read the live managed caller for ${name}" >&2
-      rm -f "$err_file"
       exit 1
     fi
   elif ! printf '%s' "$actual_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
     echo "[ERROR] Invalid live caller blob receipt for ${name}" >&2
-    rm -f "$err_file"
     exit 1
   fi
-  rm -f "$err_file"
   if [ "$actual_caller_blob" != "$expected_caller_blob" ]; then
     echo "[BOOTSTRAP] ${name} does not contain the exact managed caller"
     stale_callers=$((stale_callers + 1))
@@ -137,9 +165,9 @@ while IFS= read -r name; do
     # required until the exact caller has landed.
     continue
   fi
-  if ! workflow_state=$(gh api \
+  if ! github_api_into workflow_state \
     "repos/${owner}/${name}/actions/workflows/enforce-repo-settings.yml" \
-    --jq '.state'); then
+    --jq '.state'; then
     echo "[ERROR] Could not resolve enforcement workflow state for ${name}" >&2
     exit 1
   fi

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -109,6 +109,9 @@ open(sys.argv[2], "w", encoding="utf-8").write(run)
 PY
 cat >"$WORK/scripts/preflight-downstream-dispatch.sh" <<'EOF'
 #!/usr/bin/env bash
+if [ -n "${FAKE_PREFLIGHT_RC:-}" ]; then
+  exit "$FAKE_PREFLIGHT_RC"
+fi
 count_file=.preflight-count
 count=0
 [ ! -f "$count_file" ] || count=$(cat "$count_file")
@@ -186,6 +189,27 @@ set +e
 recovery_rc=$?
 set -e
 check "bootstrap API rate exhaustion defers to scheduled recovery" \
+  "[ '$recovery_rc' -eq 0 ] && ! grep -q 'workflow run dispatch-downstream.yml' '$WORK/gh.log'"
+
+rm -f "$WORK/.preflight-count"
+: >"$WORK/gh.log"
+set +e
+(
+  cd "$WORK"
+  env \
+    PATH="$WORK/bin:$PATH" \
+    FAKE_GH_LOG="$WORK/gh.log" \
+    FAKE_PREFLIGHT_RC=84 \
+    GITHUB_REPOSITORY=f5-sales-demo/docs-control \
+    GITHUB_REPOSITORY_OWNER=f5-sales-demo \
+    SOURCE_SHA=1111111111111111111111111111111111111111 \
+    REPO_SETTINGS_TOKEN=settings-token \
+    REPO_SYNC_TOKEN=sync-token \
+    bash "$WORK/dispatch.sh"
+)
+recovery_rc=$?
+set -e
+check "preflight API rate exhaustion defers to scheduled recovery" \
   "[ '$recovery_rc' -eq 0 ] && ! grep -q 'workflow run dispatch-downstream.yml' '$WORK/gh.log'"
 
 exit "$FAIL"

--- a/tests/test-dispatch-preflight.sh
+++ b/tests/test-dispatch-preflight.sh
@@ -23,6 +23,10 @@ check_case() {
   cat >"$work/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_LOG"
+if [ -n "${FAKE_API_FAIL_MATCH:-}" ] && [[ "$*" == *"$FAKE_API_FAIL_MATCH"* ]]; then
+  printf '%s\n' "$FAKE_API_FAIL_MESSAGE" >&2
+  exit 1
+fi
 case "$*" in
   *'repos/f5-sales-demo/example/commits/main'*) printf '%s\n' "$FAKE_DOWNSTREAM_MAIN" ;;
   *'/commits/main'*) printf '%s\n' "$FAKE_MAIN_SHA" ;;
@@ -75,6 +79,8 @@ EOF
     FAKE_DOWNSTREAM_MAIN="$FAKE_DOWNSTREAM_MAIN" \
     FAKE_MISSING_CALLER="${FAKE_MISSING_CALLER:-}" \
     FAKE_STATE_READ_FAIL="${FAKE_STATE_READ_FAIL:-}" \
+    FAKE_API_FAIL_MATCH="${FAKE_API_FAIL_MATCH:-}" \
+    FAKE_API_FAIL_MESSAGE="${FAKE_API_FAIL_MESSAGE:-}" \
     "$SOURCE" 2>&1)
   rc=$?
   set -e
@@ -122,6 +128,20 @@ unset FAKE_STATE_READ_FAIL
 FAKE_MISSING_CALLER=1
 check_case "missing workflow reaches exact caller bootstrap" 80 "[BOOTSTRAP]"
 unset FAKE_MISSING_CALLER
+
+FAKE_API_FAIL_MATCH='/commits/main'
+FAKE_API_FAIL_MESSAGE='gh: API rate limit exceeded for user ID 123. (HTTP 403)'
+check_case "primary API rate exhaustion returns recoverable defer" 84 \
+  "[DEFER] GitHub API rate capacity was exhausted"
+
+FAKE_API_FAIL_MESSAGE='gh: secondary rate limit. Please wait a few minutes before you try again. (HTTP 403)'
+check_case "secondary API rate exhaustion returns recoverable defer" 84 \
+  "[DEFER] GitHub API rate capacity was exhausted"
+
+FAKE_API_FAIL_MESSAGE='gh: internal server error (HTTP 500)'
+check_case "non-rate API failure remains fatal" 1 \
+  "[ERROR] Could not resolve protected docs-control main"
+unset FAKE_API_FAIL_MATCH FAKE_API_FAIL_MESSAGE
 
 echo "=== Summary: ${PASS} passed, ${FAIL} failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #1071

Treat GitHub API primary/secondary rate exhaustion as recoverable preflight status 84, while preserving fatal handling for unrelated API failures and the existing missing-caller behavior. The dispatcher now defers status 84 to its scheduled recovery.

Verification:
- `bash tests/test-dispatch-preflight.sh`
- `bash tests/test-dispatch-matrix.sh`
- all `tests/test-*.sh`
- `pre-commit run --all-files`
- ShellCheck, shfmt, actionlint