### PR TITLE
fix: accept multilingual README policy

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -460,6 +460,16 @@ jobs:
             ' >/dev/null
           }
 
+          readme_english_only() {
+            jq -er '
+              if has("readme_english_only") | not then "false"
+              elif (.readme_english_only | type) == "boolean"
+              then (.readme_english_only | tostring)
+              else error("readme_english_only must be a boolean")
+              end
+            '
+          }
+
           select_owned_stale_issues() {
             jq -r '
               if type != "array" or
@@ -979,7 +989,7 @@ jobs:
                       end')
 
                   README_ENGLISH_ONLY=$(printf '%s' "$DOCS_SITE_ENTRY" |
-                    jq -er '.readme_english_only // false')
+                    readme_english_only)
                 case "$README_ENGLISH_ONLY" in
                   true)
                     printf '%s\n' '🌐 English' > /tmp/language_nav.tmp

--- a/tests/test-readme-generation.sh
+++ b/tests/test-readme-generation.sh
@@ -213,6 +213,29 @@ else
     "dispatch-downstream.yml omits a dynamic README input"
 fi
 
+awk '
+  /^          readme_english_only\(\) \{/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$SYNC_WORKFLOW" >"$WORK/readme-english-only.sh"
+if [ -s "$WORK/readme-english-only.sh" ] && (
+  # shellcheck source=/dev/null
+  source "$WORK/readme-english-only.sh"
+  [ "$(printf '%s' '{}' | readme_english_only)" = false ] &&
+    [ "$(printf '%s' '{"readme_english_only":false}' | readme_english_only)" = false ] &&
+    [ "$(printf '%s' '{"readme_english_only":true}' | readme_english_only)" = true ] &&
+    ! printf '%s' '{"readme_english_only":"false"}' | readme_english_only >/dev/null 2>&1
+); then
+  pass "4.7 README language policy accepts both booleans and defaults to multilingual"
+else
+  fail "4.7 README language policy accepts both booleans and defaults to multilingual" \
+    "the production extractor must return false successfully and reject non-booleans"
+fi
+
 echo ""
 echo "=== Section 3: the workflow performs the same normalisation ==="
 


### PR DESCRIPTION
Closes #1073

Return the default and explicit multilingual policy as the string `false` so `jq -e` no longer interprets the valid boolean as command failure. The production extractor rejects non-boolean overrides, and the regression test executes the exact embedded helper.

Verification:
- `bash tests/test-readme-generation.sh`
- `bash tests/test-sync-managed-files.sh`
- `bash tests/test-linter-configs.sh`
- `pre-commit run --all-files`
- actionlint and ShellCheck