### PR TITLE
fix: sync pylint config to i18n-core

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -6,7 +6,7 @@
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
-    "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
+    "i18n-core": [".ruff.toml", ".mypy.ini", ".isort.cfg", "README.md"],
     "console": [".ruff.toml", ".mypy.ini", ".isort.cfg"],
     "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
     "apt-repo": ["README.md"],

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -124,7 +124,7 @@
       "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
       "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
-      "i18n-core": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg", "README.md"],
+      "i18n-core": [".ruff.toml", ".mypy.ini", ".isort.cfg", "README.md"],
       "console": [".ruff.toml", ".mypy.ini", ".isort.cfg"],
       "xcsh-chrome-extension": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],
       "apt-repo": ["README.md"],

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -776,13 +776,16 @@ for cfg in .ruff.toml .python-lint .mypy.ini; do
   fi
 done
 
-if jq -e '.managed_files.skip_files.console | index(".python-lint") == null' \
-  "$REPO_SETTINGS" >/dev/null; then
-  pass "7.x console receives .python-lint for the managed PII scanner"
-else
-  fail "7.x console receives .python-lint for the managed PII scanner" \
-    ".python-lint is skipped, so Pylint defaults reject scripts/check_pii.py"
-fi
+for repo in console i18n-core; do
+  if jq -e --arg repo "$repo" \
+    '(.managed_files.skip_files[$repo] // []) | index(".python-lint") == null' \
+    "$REPO_SETTINGS" >/dev/null; then
+    pass "7.x $repo receives .python-lint for the managed PII scanner"
+  else
+    fail "7.x $repo receives .python-lint for the managed PII scanner" \
+      ".python-lint is skipped, so Pylint defaults reject scripts/check_pii.py"
+  fi
+done
 
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5c: .checkov.yaml skips the install-test harness dockerfiles


### PR DESCRIPTION
## Summary

Sync the governed `.python-lint` thresholds to `i18n-core` so its managed PII scanner passes the fleet Pylint gate.

## Related Issue

Closes #1079

## Changes

- Remove only `.python-lint` from the `i18n-core` managed-file opt-out in both authoritative manifests.
- Extend the linter-config regression test to require the governed Pylint configuration for `i18n-core` as well as `console`.
- Leave every downstream governed file untouched; propagation remains owned by docs-control.

## Verification evidence

- TDD baseline before the manifest fix: `tests/test-linter-configs.sh` — 156 passed, 1 failed.
- `tests/test-linter-configs.sh` — 157 passed, 0 failed.
- `tests/test-protect-managed-files.sh` — 133 passed, 0 failed.
- `tests/test-review-layer-routing.sh` — 23 passed, 0 failed.
- `tests/test-agent-guidance.sh` — 41 passed, 0 failed.
- `tests/test-sync-managed-files.sh` — 59 passed, 0 failed.
- `pre-commit run --files .github/config/repo-settings.json .claude/governance.json tests/test-linter-configs.sh` — all applicable hooks passed.
- Required CI passed: https://github.com/f5-sales-demo/docs-control/actions/runs/30794758746

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions