### PR TITLE
fix: resolve latest docs builder at publication

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -13,9 +13,9 @@ on:
         default: 'docs'
         type: string
       builder-image:
-        description: 'Builder Docker image URI'
+        description: 'Approved builder Docker image selector'
         required: false
-        default: 'ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163'
+        default: 'ghcr.io/f5-sales-demo/docs-builder:latest'
         type: string
       docs-title:
         description: 'Documentation site title (overrides frontmatter)'
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout the documentation source
-      packages: read # authenticate the pinned builder image pull from GHCR
+      packages: read # authenticate and resolve the latest builder image from GHCR
     outputs:
       build-status: ${{ job.status }}
     steps:
@@ -49,20 +49,13 @@ jobs:
         id: content
         env:
           REQUESTED_REF: ${{ inputs.content-ref }}
-          REQUESTED_IMAGE: ${{ inputs.builder-image }}
         run: |
           CONTENT_REF="$REQUESTED_REF"
           if [[ ! "$CONTENT_REF" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::content-ref must be a full lowercase 40-character commit SHA"
             exit 1
           fi
-          BUILDER_IMAGE="$REQUESTED_IMAGE"
-          if [[ ! "$BUILDER_IMAGE" =~ ^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::builder-image must use the approved repository and an immutable SHA-256 digest"
-            exit 1
-          fi
           echo "content_ref=$CONTENT_REF" >> "$GITHUB_OUTPUT"
-          echo "builder_image=$BUILDER_IMAGE" >> "$GITHUB_OUTPUT"
 
       - name: Checkout content repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -97,6 +90,27 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve latest documentation builder
+        id: builder
+        env:
+          REQUESTED_IMAGE: ${{ inputs.builder-image }}
+        run: |
+          if [[ ! "$REQUESTED_IMAGE" =~ ^ghcr\.io/f5-sales-demo/docs-builder:latest$ ]]; then
+            echo "::error::builder-image must be ghcr.io/f5-sales-demo/docs-builder:latest"
+            exit 1
+          fi
+
+          docker pull "$REQUESTED_IMAGE"
+          RESOLVED_BUILDER_IMAGE=$(
+            docker image inspect "$REQUESTED_IMAGE" \
+              --format '{{range .RepoDigests}}{{println .}}{{end}}'
+          )
+          if [[ ! "$RESOLVED_BUILDER_IMAGE" =~ ^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::builder-image did not resolve to exactly one approved repository digest"
+            exit 1
+          fi
+          echo "builder_image=$RESOLVED_BUILDER_IMAGE" >> "$GITHUB_OUTPUT"
 
       - name: Stage imported files for documentation
         run: |
@@ -144,7 +158,7 @@ jobs:
             -e DOCS_SITE="${{ inputs.docs-site || format('https://{0}.github.io', github.repository_owner) }}" \
             -e GITHUB_REPOSITORY="${{ github.repository }}" \
             ${{ inputs.docs-title && format('-e DOCS_TITLE="{0}"', inputs.docs-title) || '' }} \
-            ${{ steps.content.outputs.builder_image }}
+            ${{ steps.builder.outputs.builder_image }}
 
           echo "✅ Build completed successfully"
           ls -lah ${{ runner.temp }}/docs-output/
@@ -165,7 +179,7 @@ jobs:
       - name: Stage governance assets for /api/
         env:
           CONTENT_REF: ${{ steps.content.outputs.content_ref }}
-          BUILDER_IMAGE: ${{ steps.content.outputs.builder_image }}
+          BUILDER_IMAGE: ${{ steps.builder.outputs.builder_image }}
         run: |
           OUTPUT_DIR="${{ runner.temp }}/docs-output"
           API_DIR="${OUTPUT_DIR}/api"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1120,7 +1120,7 @@ echo ""
 echo "=== Section 14: reusable workflow immutable inputs ==="
 
 PAGES_WORKFLOW="$REPO_ROOT/.github/workflows/github-pages-deploy.yml"
-EXPECTED_BUILDER='ghcr.io/f5-sales-demo/docs-builder@sha256:905d2398fec15c05e828c881ab0e8b782368c30d70d97a978dc383935d7d0163'
+EXPECTED_BUILDER='ghcr.io/f5-sales-demo/docs-builder:latest'
 
 if [ "$(grep -Ec "^[[:space:]]*version:[[:space:]]*(['\"]?2\\.5\\.6['\"]?)[[:space:]]*$" "$SUPER_LINTER_WORKFLOW")" = "1" ] &&
   ! grep -Eq "^[[:space:]]*version:[[:space:]]*(['\"]?latest['\"]?)([[:space:]]|$)" "$SUPER_LINTER_WORKFLOW"; then
@@ -1137,17 +1137,16 @@ else
     "the group needs a reusable-workflow-specific prefix"
 fi
 
-# One workflow_call default is validated before use; there is no runtime
-# fallback. Callers may select a different immutable digest only in the approved
-# builder repository.
-if [ "$(grep -cF "$EXPECTED_BUILDER" "$PAGES_WORKFLOW")" = "1" ] &&
+# One workflow_call default is resolved to an immutable digest after registry
+# authentication; there is no runtime fallback or historical digest pin.
+if [ "$(grep -cF "default: '$EXPECTED_BUILDER'" "$PAGES_WORKFLOW")" = "1" ] &&
   grep -qF '^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$' "$PAGES_WORKFLOW" &&
-  grep -qF '${{ steps.content.outputs.builder_image }}' "$PAGES_WORKFLOW" &&
-  ! grep -Eq 'docs-builder:latest|inputs\.builder-image \|\|' "$PAGES_WORKFLOW"; then
-  pass "14.3 documentation builder identity is validated and digest-pinned"
+  grep -qF '${{ steps.builder.outputs.builder_image }}' "$PAGES_WORKFLOW" &&
+  ! grep -Eq '905d2398|inputs\.builder-image \|\|' "$PAGES_WORKFLOW"; then
+  pass "14.3 latest documentation builder resolves to an approved immutable identity"
 else
-  fail "14.3 documentation builder identity is validated and digest-pinned" \
-    "expected one measured default, approved digest validation, and no fallback"
+  fail "14.3 latest documentation builder resolves to an approved immutable identity" \
+    "expected latest selection, approved digest validation, and no historical fallback"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-pages-staleness-guard.sh
+++ b/tests/test-pages-staleness-guard.sh
@@ -17,6 +17,7 @@ bad() {
 }
 
 input_block=$(sed -n '/^      content-ref:/,/^        type: string/p' "$DEPLOY_WORKFLOW")
+builder_input_block=$(sed -n '/^      builder-image:/,/^        type: string/p' "$DEPLOY_WORKFLOW")
 checkout_block=$(sed -n '/^      - name: Checkout content repo/,/^      - name: Login to GHCR/p' "$DEPLOY_WORKFLOW")
 validation_block=$(sed -n '/^      - name: Resolve immutable content commit/,/^      - name: Checkout content repo/p' "$DEPLOY_WORKFLOW")
 revision_block=$(sed -n '/^      - name: Stage governance assets for \/api\//,/^      - name: Upload artifact/p' "$DEPLOY_WORKFLOW")
@@ -36,12 +37,114 @@ else
   bad "Pages deploy has a mutable or fallback content identity"
 fi
 
-if grep -qF 'BUILDER_IMAGE="$REQUESTED_IMAGE"' <<<"$validation_block" &&
-  grep -qF '^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$' <<<"$validation_block" &&
-  grep -qF 'builder_image=$BUILDER_IMAGE' <<<"$validation_block"; then
-  ok "Pages deploy accepts only the approved digest-pinned builder"
+if grep -qF "default: 'ghcr.io/f5-sales-demo/docs-builder:latest'" <<<"$builder_input_block" &&
+  ! grep -qF '@sha256:' <<<"$builder_input_block"; then
+  ok "Pages deploy selects the latest approved builder release"
 else
-  bad "Pages deploy permits a mutable or unapproved builder image"
+  bad "Pages deploy does not select the latest approved builder release"
+fi
+
+if python3 - "$DEPLOY_WORKFLOW" <<'PY'; then
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as workflow_file:
+    workflow = yaml.safe_load(workflow_file)
+
+steps = workflow["jobs"]["build"]["steps"]
+names = [step.get("name") for step in steps]
+login = names.index("Login to GHCR")
+resolve = names.index("Resolve latest documentation builder")
+if resolve != login + 1:
+    raise SystemExit(1)
+PY
+  ok "Pages deploy authenticates immediately before resolving latest"
+else
+  bad "Pages deploy can resolve the builder before registry authentication"
+fi
+
+resolver_script=$(mktemp)
+resolver_tmp=$(mktemp -d)
+trap 'rm -f "$resolver_script"; rm -rf "$resolver_tmp"' EXIT
+if python3 - "$DEPLOY_WORKFLOW" "$resolver_script" <<'PY'; then
+import sys
+
+import yaml
+
+workflow_path, script_path = sys.argv[1:]
+with open(workflow_path, encoding="utf-8") as workflow_file:
+    workflow = yaml.safe_load(workflow_file)
+
+matching = [
+    step
+    for step in workflow["jobs"]["build"]["steps"]
+    if step.get("name") == "Resolve latest documentation builder"
+]
+if len(matching) != 1 or not isinstance(matching[0].get("run"), str):
+    raise SystemExit(1)
+with open(script_path, "w", encoding="utf-8") as script_file:
+    script_file.write(matching[0]["run"])
+PY
+  :
+else
+  bad "Pages deploy has no executable latest-builder resolver"
+fi
+
+mkdir -p "$resolver_tmp/bin"
+cat >"$resolver_tmp/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "pull" ]; then
+  printf '%s\n' "$2" >>"$DOCKER_CALLS"
+  exit 0
+fi
+if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
+  printf '%s\n' "$STUB_RESOLVED_IMAGE"
+  exit 0
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 2
+STUB
+chmod +x "$resolver_tmp/bin/docker"
+
+approved_tag='ghcr.io/f5-sales-demo/docs-builder:latest'
+approved_digest='ghcr.io/f5-sales-demo/docs-builder@sha256:1111111111111111111111111111111111111111111111111111111111111111'
+export DOCKER_CALLS="$resolver_tmp/docker-calls"
+export STUB_RESOLVED_IMAGE="$approved_digest"
+
+if PATH="$resolver_tmp/bin:$PATH" \
+  REQUESTED_IMAGE="$approved_tag" \
+  GITHUB_OUTPUT="$resolver_tmp/approved-output" \
+  bash "$resolver_script" >/dev/null 2>&1 &&
+  grep -qxF "$approved_tag" "$DOCKER_CALLS" &&
+  grep -qxF "builder_image=$approved_digest" "$resolver_tmp/approved-output"; then
+  ok "Pages deploy resolves latest to one immutable approved digest"
+else
+  bad "Pages deploy does not resolve latest to the digest it records"
+fi
+
+for rejected_image in \
+  'ghcr.io/unapproved/docs-builder:latest' \
+  'ghcr.io/f5-sales-demo/docs-builder:older'; do
+  if PATH="$resolver_tmp/bin:$PATH" \
+    REQUESTED_IMAGE="$rejected_image" \
+    GITHUB_OUTPUT="$resolver_tmp/rejected-output" \
+    bash "$resolver_script" >/dev/null 2>&1; then
+    bad "Pages deploy accepts unapproved builder selector: $rejected_image"
+  else
+    ok "Pages deploy rejects unapproved builder selector: $rejected_image"
+  fi
+done
+
+export STUB_RESOLVED_IMAGE='ghcr.io/unapproved/docs-builder@sha256:2222222222222222222222222222222222222222222222222222222222222222'
+if PATH="$resolver_tmp/bin:$PATH" \
+  REQUESTED_IMAGE="$approved_tag" \
+  GITHUB_OUTPUT="$resolver_tmp/unapproved-output" \
+  bash "$resolver_script" >/dev/null 2>&1; then
+  bad "Pages deploy accepts a resolved digest from an unapproved repository"
+else
+  ok "Pages deploy rejects a resolved digest from an unapproved repository"
 fi
 
 if grep -qF 'ref: ${{ steps.content.outputs.content_ref }}' <<<"$checkout_block" &&
@@ -60,7 +163,7 @@ else
   bad "manual Pages dispatch can publish an unmerged commit"
 fi
 
-if grep -qF '${{ steps.content.outputs.builder_image }}' "$DEPLOY_WORKFLOW" &&
+if grep -qF '${{ steps.builder.outputs.builder_image }}' "$DEPLOY_WORKFLOW" &&
   ! grep -qF 'inputs.builder-image ||' "$DEPLOY_WORKFLOW"; then
   ok "Pages build uses the validated builder identity without fallback"
 else
@@ -77,7 +180,7 @@ else
 fi
 
 if grep -qF 'CONTENT_REF: ${{ steps.content.outputs.content_ref }}' <<<"$revision_block" &&
-  grep -qF 'BUILDER_IMAGE: ${{ steps.content.outputs.builder_image }}' <<<"$revision_block" &&
+  grep -qF 'BUILDER_IMAGE: ${{ steps.builder.outputs.builder_image }}' <<<"$revision_block" &&
   grep -qF 'CHECKED_OUT_SHA=$(git rev-parse HEAD)' <<<"$revision_block" &&
   grep -qF -- '--arg content_ref "${CONTENT_REF}"' <<<"$revision_block" &&
   grep -qF -- '--arg commit "${CHECKED_OUT_SHA}"' <<<"$revision_block" &&


### PR DESCRIPTION
## Summary

Resolve the approved `docs-builder:latest` selector after GHCR authentication, then build and publish the exact immutable digest selected by that invocation. This removes the historical builder pin without weakening the publication receipt or repository allowlist.

## Related Issue

Closes #1082

## Changes

- default Pages builds to the approved `latest` selector
- reject every other repository and tag before pulling
- resolve the pulled image to exactly one approved SHA-256 repository digest
- use the resolved digest for both `docker run` and `/api/revision.json`
- execute the resolver in regression tests with approved and rejected registry responses

## Verification evidence

- Red phase: `bash tests/test-pages-staleness-guard.sh` failed on the pinned default, missing post-login resolver, invalid selectors, and the old output path.
- Green phase: `bash tests/test-pages-staleness-guard.sh` passed all 23 publication-identity assertions.
- `bash tests/test-linter-configs.sh`: 157 passed, 0 failed.
- `pre-commit run --all-files`: every applicable hook passed.
- Every `tests/test-*.sh` program passed sequentially (29/29).
- Local Docker execution is not claimed: this workstation has no `docker` CLI. The executable resolver test uses a deterministic stub; the GitHub-hosted runner performs the authenticated real pull.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions