### PR TITLE
fix: stop locale lint from walking dependency trees

### DIFF
--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -19,17 +19,13 @@ PATTERNS=(
   'function\s+langToSlug'
 )
 
-# Directories and files to exclude
-EXCLUDE_DIRS="node_modules|dist|\.git|coverage|\.astro|\.next|out|build"
-EXCLUDE_FILES="locale-lint\.sh|\.test\.|\.spec\."
-
 check_pattern() {
   local pattern="$1"
   local results
-  results=$(grep -rn --include='*.ts' --include='*.js' --include='*.tsx' --include='*.jsx' \
-    -E "$pattern" . 2>/dev/null |
-    grep -vE "($EXCLUDE_DIRS)" |
-    grep -vE "($EXCLUDE_FILES)" |
+  if [ "${#SOURCE_FILES[@]}" -eq 0 ]; then
+    return 0
+  fi
+  results=$(grep -nE "$pattern" -- "${SOURCE_FILES[@]}" 2>/dev/null |
     grep -vE "from\s+['\"]@f5-sales-demo/i18n-core" |
     grep -vE "i18n-core/(src|dist)/" ||
     true)
@@ -49,6 +45,22 @@ if [ -f package.json ] && grep -qE '"name"[[:space:]]*:[[:space:]]*"@f5-sales-de
   echo "Locale lint: this is the i18n-core package itself — its locale definitions are canonical."
   exit 0
 fi
+
+# Search repository files, not the whole working tree. Filtering recursive grep output
+# after the walk still reads every ignored dependency and build artifact first; marketplace
+# measured 98,417 files and more than a minute per pattern that way. `git ls-files` includes
+# tracked edits and staged additions while excluding unrelated untracked files.
+SOURCE_FILES=()
+while IFS= read -r -d '' file; do
+  case "$file" in
+  node_modules/* | */node_modules/* | dist/* | */dist/* | coverage/* | */coverage/* | \
+    .astro/* | */.astro/* | .next/* | */.next/* | out/* | */out/* | build/* | */build/* | \
+    *locale-lint.sh | *.test.* | *.spec.*)
+    continue
+    ;;
+  esac
+  SOURCE_FILES+=("$file")
+done < <(git ls-files -z -- '*.ts' '*.js' '*.tsx' '*.jsx')
 
 echo "Locale lint: checking for hardcoded locale lists..."
 echo ""

--- a/tests/test-locale-lint.sh
+++ b/tests/test-locale-lint.sh
@@ -22,9 +22,20 @@ trap 'rm -rf "$TMPDIR_BASE"' EXIT
 setup_clean_repo() {
   rm -rf "$TMPDIR_BASE/repo"
   mkdir -p "$TMPDIR_BASE/repo/src"
+  git -C "$TMPDIR_BASE/repo" init -q
 }
 
 run_lint() {
+  local dir="$1"
+  local exit_code=0
+  local output
+  git -C "$dir" add -A
+  output=$(cd "$dir" && bash "$LINT_SCRIPT" 2>&1) || exit_code=$?
+  echo "$output"
+  return $exit_code
+}
+
+run_lint_untracked() {
   local dir="$1"
   local exit_code=0
   local output
@@ -154,6 +165,22 @@ if [ "$EXIT_CODE" -eq 0 ]; then
   pass "8. test files excluded"
 else
   fail "8. test files excluded" "exit $EXIT_CODE"
+fi
+
+# Pre-commit should inspect files that are actually in the repository, not an
+# unrelated untracked draft. This also proves the implementation does not walk
+# the working tree before filtering its output.
+setup_clean_repo
+cat >"$TMPDIR_BASE/repo/src/untracked.ts" <<'TS'
+const VALID_LOCALE_SLUGS = new Set(['en', 'fr']);
+TS
+OUTPUT=""
+EXIT_CODE=0
+OUTPUT=$(run_lint_untracked "$TMPDIR_BASE/repo") || EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+  pass "9. untracked source files are not scanned"
+else
+  fail "9. untracked source files are not scanned" "exit $EXIT_CODE: $OUTPUT"
 fi
 
 # The package that owns these definitions cannot import them from itself. Inside


### PR DESCRIPTION
## Summary

- build the locale-lint input list once from repository files
- exclude dependency, build, and test paths before reading file contents
- make untracked-file behavior explicit and contract-tested
- preserve all existing hardcoded-locale detection behavior

## Verification

- test-first regression reproduced the untracked working-tree scan
- 11/11 locale-lint contracts pass
- real marketplace worktree with five installed plugin dependency trees completes in 2.06 seconds
- complete changed-file pre-commit gate passes
- every docs-control test script passes, including bootstrap, PII, sync, managed-source, and workflow-pin suites

Closes #866