### PR TITLE
fix: keep fleet dispatch within runner budget

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -185,7 +185,9 @@ jobs:
           done
           TOTAL=${#REPOS[@]}
           BATCH_SIZE=5
-          BATCH_DELAY=45
+          # Seven gaps at the current fleet size consume 210 seconds, leaving
+          # 90 seconds of the runner's five-minute budget for API work/retries.
+          BATCH_DELAY=30
           echo "Dispatching enforce-repo-settings to ${TOTAL} repos (batches of ${BATCH_SIZE}, ${BATCH_DELAY}s delay)..."
 
           LOG=$(mktemp)

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -29,6 +29,19 @@ check "no read-config job (consolidated)" "! grep -q '^  read-config:$' '$WF'"
 # Parallelism cap stays at 5 via batched dispatch loop.
 check "BATCH_SIZE=5 for parallelism cap" "grep -q 'BATCH_SIZE=5' '$WF'"
 
+# The repository runner cancels jobs at five minutes. Keep at least 60 seconds
+# for preflight, API calls, and retry backoff instead of spending the entire
+# budget in deterministic inter-batch sleeps.
+BATCH_SIZE_VALUE=$(sed -nE 's/^[[:space:]]*BATCH_SIZE=([0-9]+)$/\1/p' "$WF")
+BATCH_DELAY_VALUE=$(sed -nE 's/^[[:space:]]*BATCH_DELAY=([0-9]+)$/\1/p' "$WF")
+FLEET_SIZE=$(jq 'length' "$CONFIG")
+BATCH_COUNT=$(((FLEET_SIZE + BATCH_SIZE_VALUE - 1) / BATCH_SIZE_VALUE))
+SCHEDULED_SLEEP_SECONDS=$(((BATCH_COUNT - 1) * BATCH_DELAY_VALUE))
+RUNNER_BUDGET_SECONDS=300
+RUNNER_RESERVE_SECONDS=60
+check "inter-batch sleeps leave 60s of the runner budget" \
+  "[ '$SCHEDULED_SLEEP_SECONDS' -le '$((RUNNER_BUDGET_SECONDS - RUNNER_RESERVE_SECONDS))' ]"
+
 # Retry-with-backoff preserved (2s → 4s → 8s).
 check "retry max=3 attempts" "grep -Eq 'max=3' '$WF'"
 check "backoff delay starts at 2s" "grep -Eq 'delay=2' '$WF'"


### PR DESCRIPTION
## Summary

Keep the governed downstream dispatcher inside the repository runner's five-minute execution budget.

## Related Issue

Closes #1095

## Changes

- reduce the inter-batch delay from 45 to 30 seconds while preserving five-repository parallelism
- retain three-attempt exponential retry behavior and failure aggregation
- compute the live fleet sleep budget in the dispatch-matrix test
- require at least 60 seconds of the runner budget to remain for preflight, API calls, and retries

## Verification evidence

- red test before the fix: current schedule computed 315 seconds and failed the 240-second sleep ceiling
- `bash tests/test-dispatch-matrix.sh` — all structural and behavioral checks passed after the fix
- `actionlint .github/workflows/dispatch-downstream.yml` — passed
- `yamllint .github/workflows/dispatch-downstream.yml` — passed
- complete pre-commit suite — passed
- exact-HEAD sandboxed `agy` review of `59bfe1e...a7688d1` — no blocking, medium, or nit findings

Live failure evidence: final-manifest dispatch run 30823369033 was canceled at 4m58s with the old 315-second deterministic sleep schedule.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
