### PR TITLE
fix(governance): align linked-issue status context

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -28,7 +28,7 @@ jobs:
             const EXCLUDE_BRANCHES = "dependabot/**,release/**,changeset-release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*";
             const MARKER = "<!-- require-linked-issue -->";
             const MESSAGE = `${MARKER}\nThis PR must be linked to a GitHub issue. Use 'Closes #123' in the PR description, or link an issue from the sidebar.`;
-            const STATUS_CONTEXT = "check / Check linked issues";
+            const STATUS_CONTEXT = "Check linked issues";
             const { owner, repo } = context.repo;
 
             const globToRegex = (glob) => {

--- a/tests/test-privileged-pr-workflows.sh
+++ b/tests/test-privileged-pr-workflows.sh
@@ -68,7 +68,16 @@ done
 for file in \
   "$REPO_ROOT/workflows/require-linked-issue.yml" \
   "$REPO_ROOT/.github/workflows/require-linked-issue.yml"; do
-  require_literal "$file" 'check / Check linked issues' "${file#"$REPO_ROOT/"} publishes the existing required context"
+  required_context=$(jq -r '
+    .branch_protection[0].required_status_checks.self_contexts[]
+    | select(endswith("Check linked issues"))
+  ' "$REPO_ROOT/.github/config/repo-settings.json")
+  published_context=$(sed -n 's/.*const STATUS_CONTEXT = "\([^"]*\)";.*/\1/p' "$file")
+  if [ -n "$required_context" ] && [ "$published_context" = "$required_context" ]; then
+    pass "${file#"$REPO_ROOT/"} publishes the exact required self-repository context"
+  else
+    fail "${file#"$REPO_ROOT/"} publishes the exact required self-repository context"
+  fi
   require_literal "$file" 'const headSha = pull.head.sha;' "${file#"$REPO_ROOT/"} publishes status on the current PR head"
   require_literal "$file" 'github.paginate(github.rest.pulls.list' "${file#"$REPO_ROOT/"} evaluates every open pull request"
   require_literal "$file" 'postStatus("pending"' "${file#"$REPO_ROOT/"} publishes a pending status before evaluation"

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -28,7 +28,7 @@ jobs:
             const EXCLUDE_BRANCHES = "dependabot/**,release/**,changeset-release/**,openapi-sync/**,plugin-sync/**,deps/**,sync/**,docs/update-*";
             const MARKER = "<!-- require-linked-issue -->";
             const MESSAGE = `${MARKER}\nThis PR must be linked to a GitHub issue. Use 'Closes #123' in the PR description, or link an issue from the sidebar.`;
-            const STATUS_CONTEXT = "check / Check linked issues";
+            const STATUS_CONTEXT = "Check linked issues";
             const { owner, repo } = context.repo;
 
             const globToRegex = (glob) => {


### PR DESCRIPTION
Closes #1105

## Summary

- publish the exact self-repository `Check linked issues` context required by branch protection
- keep the active workflow byte-identical to its managed source
- derive the regression assertion from repo-settings instead of duplicating the context name in the test

## Live evidence

- docs-control#1104 has green lint, shell, auto-merge, and `check / Check linked issues` statuses but remains BLOCKED
- branch protection requires GitHub Actions app context `Check linked issues`
- the mismatch prevents the required context from ever arriving

## Verification

- regression test failed against the pre-fix workflow and passed after the fix
- privileged workflow contracts: pass
- linter-config contracts: 154 passed
- managed-sync contracts: 59 passed
- actionlint, yamllint, and zizmor: pass
- all pre-commit hooks: pass
- unified agy review of 2c0ba20: approve, zero findings