### PR TITLE
fix(ci): repair runner workspace ownership

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,6 +28,27 @@ jobs:
       statuses: write # publish the lint status context
       pull-requests: write # annotate pull requests with lint findings
     steps:
+      # Super-Linter's container writes github_conf/ and super-linter-output/ as
+      # root on this self-hosted runner. The next checkout cannot clean those
+      # paths and destroys its partial .git directory before failing. Repair
+      # ownership only inside the exact disposable Actions workspace; checkout
+      # then performs its normal bounded clean.
+      - name: Repair docs-control runner workspace
+        if: github.repository == 'f5-sales-demo/docs-control' && runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          workspace="${GITHUB_WORKSPACE:?}"
+          case "$workspace" in
+            /data/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control | \
+              /home/robin/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control) ;; # repo-hygiene:allow
+            *)
+              echo "::error::Refusing to repair unexpected workspace: ${workspace}"
+              exit 1
+              ;;
+          esac
+          sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -399,6 +420,22 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Repair docs-control runner workspace
+        if: github.repository == 'f5-sales-demo/docs-control' && runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          workspace="${GITHUB_WORKSPACE:?}"
+          case "$workspace" in
+            /data/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control | \
+              /home/robin/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control) ;; # repo-hygiene:allow
+            *)
+              echo "::error::Refusing to repair unexpected workspace: ${workspace}"
+              exit 1
+              ;;
+          esac
+          sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1176,6 +1176,52 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
+# SECTION 17: self-hosted docs-control jobs repair Docker-owned output
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Section 17: self-hosted workspace ownership repair ==="
+
+if python3 - "$SUPER_LINTER_WORKFLOW" <<'PY'; then
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as workflow_file:
+    workflow = yaml.safe_load(workflow_file)
+
+expected_condition = (
+    "github.repository == 'f5-sales-demo/docs-control' && "
+    "runner.environment == 'self-hosted'"
+)
+required_fragments = (
+    'workspace="${GITHUB_WORKSPACE:?}"',
+    "/data/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control",
+    "/home/robin/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control",  # repo-hygiene:allow
+    'sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"',
+)
+
+for job_name in ("lint", "shell-unit-tests"):
+    steps = workflow["jobs"][job_name]["steps"]
+    repairs = [step for step in steps if step.get("name") == "Repair docs-control runner workspace"]
+    checkouts = [step for step in steps if step.get("name") == "Checkout"]
+    if len(repairs) != 1 or len(checkouts) != 1:
+        raise SystemExit(1)
+    repair = repairs[0]
+    if steps.index(repair) >= steps.index(checkouts[0]):
+        raise SystemExit(1)
+    if repair.get("if") != expected_condition or repair.get("shell") != "bash":
+        raise SystemExit(1)
+    command = repair.get("run", "")
+    if any(fragment not in command for fragment in required_fragments):
+        raise SystemExit(1)
+PY
+  pass "17.1 lint and shell jobs repair only the exact docs-control workspace before checkout"
+else
+  fail "17.1 lint and shell jobs repair only the exact docs-control workspace before checkout" \
+    "both jobs need the guarded ownership repair before actions/checkout"
+fi
+
+# ════════════════════════════════════════════════════════════════════
 # Summary
 # ════════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
Closes #1107

Related to #1091; that broader disk-capacity issue remains open for `_diag` and tool-cache monitoring.

## Summary

- repair Docker-owned files in the exact docs-control self-hosted Actions workspace before checkout
- scope the repair to docs-control and self-hosted runners only
- validate the workspace against the two observed disposable runner paths before non-interactive chown
- leave deletion to the normal actions/checkout clean
- cover both lint and shell jobs with a configuration regression test

## Live evidence

- #1106 run 30835229232 attempts 1 and 2 both failed before repository code executed
- checkout reported root-owned github_conf and super-linter-output artifacts, then lost its partial .git directory

## Verification

- regression test failed before the workflow repair and passes after it
- linter-config contracts: 155 passed
- repository hygiene with include-paths: pass
- actionlint, yamllint, and zizmor: pass
- all pre-commit hooks: pass
- unified agy review of 78c7191: approve, zero findings