### PR TITLE
fix(ci): derive ownership repair workspace

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -39,14 +39,11 @@ jobs:
         run: |
           set -euo pipefail
           workspace="${GITHUB_WORKSPACE:?}"
-          case "$workspace" in
-            /data/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control | \
-              /home/robin/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control) ;; # repo-hygiene:allow
-            *)
-              echo "::error::Refusing to repair unexpected workspace: ${workspace}"
-              exit 1
-              ;;
-          esac
+          expected_workspace="${RUNNER_WORKSPACE:?}/docs-control"
+          if ! [ "$workspace" = "$expected_workspace" ]; then
+            echo "::error::Refusing to repair unexpected workspace: ${workspace}"
+            exit 1
+          fi
           sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"
 
       - name: Checkout
@@ -426,14 +423,11 @@ jobs:
         run: |
           set -euo pipefail
           workspace="${GITHUB_WORKSPACE:?}"
-          case "$workspace" in
-            /data/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control | \
-              /home/robin/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control) ;; # repo-hygiene:allow
-            *)
-              echo "::error::Refusing to repair unexpected workspace: ${workspace}"
-              exit 1
-              ;;
-          esac
+          expected_workspace="${RUNNER_WORKSPACE:?}/docs-control"
+          if ! [ "$workspace" = "$expected_workspace" ]; then
+            echo "::error::Refusing to repair unexpected workspace: ${workspace}"
+            exit 1
+          fi
           sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"
 
       - name: Checkout

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1195,10 +1195,11 @@ expected_condition = (
 )
 required_fragments = (
     'workspace="${GITHUB_WORKSPACE:?}"',
-    "/data/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control",
-    "/home/robin/actions-runners/f5-sales-demo/docs-control/_work/docs-control/docs-control",  # repo-hygiene:allow
+    'expected_workspace="${RUNNER_WORKSPACE:?}/docs-control"',
+    '[ "$workspace" = "$expected_workspace" ]',
     'sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"',
 )
+forbidden_fragments = ("/home/", "/data/actions-runners/")
 
 for job_name in ("lint", "shell-unit-tests"):
     steps = workflow["jobs"][job_name]["steps"]
@@ -1213,6 +1214,8 @@ for job_name in ("lint", "shell-unit-tests"):
         raise SystemExit(1)
     command = repair.get("run", "")
     if any(fragment not in command for fragment in required_fragments):
+        raise SystemExit(1)
+    if any(fragment in command for fragment in forbidden_fragments):
         raise SystemExit(1)
 PY
   pass "17.1 lint and shell jobs repair only the exact docs-control workspace before checkout"


### PR DESCRIPTION
Closes #1114\n\nDerive the only allowed ownership-repair path from GitHub Actions runtime variables and require exact equality before chown. Remove real operator and runner filesystem paths from the workflow and enforce their absence in the regression test.