### PR TITLE
fix(governance): bootstrap working lint callers

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -33,13 +33,15 @@ jobs:
       # paths and destroys its partial .git directory before failing. Repair
       # ownership only inside the exact disposable Actions workspace; checkout
       # then performs its normal bounded clean.
-      - name: Repair docs-control runner workspace
-        if: github.repository == 'f5-sales-demo/docs-control' && runner.environment == 'self-hosted'
+      - name: Repair self-hosted runner workspace
+        if: runner.environment == 'self-hosted'
         shell: bash
         run: |
           set -euo pipefail
           workspace="${GITHUB_WORKSPACE:?}"
-          expected_workspace="${RUNNER_WORKSPACE:?}/docs-control"
+          repository="${GITHUB_REPOSITORY:?}"
+          repository_name="${repository##*/}"
+          expected_workspace="${RUNNER_WORKSPACE:?}/${repository_name}"
           if ! [ "$workspace" = "$expected_workspace" ]; then
             echo "::error::Refusing to repair unexpected workspace: ${workspace}"
             exit 1
@@ -417,13 +419,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Repair docs-control runner workspace
-        if: github.repository == 'f5-sales-demo/docs-control' && runner.environment == 'self-hosted'
+      - name: Repair self-hosted runner workspace
+        if: runner.environment == 'self-hosted'
         shell: bash
         run: |
           set -euo pipefail
           workspace="${GITHUB_WORKSPACE:?}"
-          expected_workspace="${RUNNER_WORKSPACE:?}/docs-control"
+          repository="${GITHUB_REPOSITORY:?}"
+          repository_name="${repository##*/}"
+          expected_workspace="${RUNNER_WORKSPACE:?}/${repository_name}"
           if ! [ "$workspace" = "$expected_workspace" ]; then
             echo "::error::Refusing to repair unexpected workspace: ${workspace}"
             exit 1

--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Deliver only the exact managed enforcement caller, through one-file,
-# monotonic PRs, before any reusable governance implementation is invoked.
+# Deliver the exact enforcement and Super-Linter callers through bounded,
+# monotonic PRs before any reusable governance implementation is invoked.
 set -euo pipefail
 
 repository="${GITHUB_REPOSITORY:-}"
@@ -11,6 +11,7 @@ run_attempt="${GITHUB_RUN_ATTEMPT:-}"
 downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
 rollout_config="${ROLLOUT_CONFIG:-.github/config/governance-rollout.json}"
 caller_path=".github/workflows/enforce-repo-settings.yml"
+lint_caller_path=".github/workflows/super-linter.yml"
 wait_seconds="${BOOTSTRAP_WAIT_SECONDS:-1800}"
 poll_seconds="${BOOTSTRAP_POLL_SECONDS:-30}"
 
@@ -508,7 +509,38 @@ if [ "$(git hash-object "$work/caller.yml")" != "$expected_blob" ]; then
   echo "[ERROR] Managed caller bytes do not match the GitHub blob receipt" >&2
   exit 1
 fi
-branch="sync/exact-caller-${expected_blob:0:12}-${run_id}-${run_attempt}"
+set +e
+gh api \
+  "repos/${repository}/contents/workflows/super-linter.yml?ref=${source_sha}" \
+  >"$work/lint-caller.json"
+rc=$?
+set -e
+if [ "$rc" -eq 84 ]; then
+  exit 84
+fi
+if [ "$rc" -ne 0 ]; then
+  echo "[ERROR] Could not fetch the exact Super-Linter caller" >&2
+  exit 1
+fi
+if ! jq -e '
+  .type == "file" and .encoding == "base64" and
+  (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+  (.content | type == "string" and length > 0)
+' "$work/lint-caller.json" >/dev/null; then
+  echo "[ERROR] Super-Linter caller response is malformed" >&2
+  exit 1
+fi
+expected_lint_blob=$(jq -r '.sha' "$work/lint-caller.json")
+jq -r '.content' "$work/lint-caller.json" | tr -d '\n' >"$work/lint-caller.b64"
+if ! base64 -d <"$work/lint-caller.b64" >"$work/lint-caller.yml"; then
+  echo "[ERROR] Super-Linter caller response contains invalid base64" >&2
+  exit 1
+fi
+if [ "$(git hash-object "$work/lint-caller.yml")" != "$expected_lint_blob" ]; then
+  echo "[ERROR] Super-Linter caller bytes do not match the GitHub blob receipt" >&2
+  exit 1
+fi
+branch="sync/exact-caller-${expected_blob:0:6}${expected_lint_blob:0:6}-${run_id}-${run_attempt}"
 
 set +e
 assert_source_current
@@ -531,8 +563,10 @@ fi
 echo "[OK] Downstream enforcement workflows are disabled with no active runs"
 
 bootstrap_one() {
-  local name="$1" slug default_branch base_sha main_sha actual_blob rc branch_head branch_blob
+  local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob rc
+  local branch_head branch_blob branch_lint_blob expected_change_count
   local pr_number pr_url created_pr_number compare_file pr_file verified_head verified_blob
+  local verified_lint_blob
   slug="${owner}/${name}"
 
   assert_source_current
@@ -553,12 +587,34 @@ bootstrap_one() {
       echo "[ERROR] Invalid live caller blob for ${name}" >&2
       return 1
     fi
-    [ "$actual_blob" != "$expected_blob" ] || return 0
     ;;
   44) ;;
   84) return 84 ;;
   *) return 1 ;;
   esac
+  set +e
+  actual_lint_blob=$(api_value_or_404 \
+    "repos/${slug}/contents/${lint_caller_path}?ref=${main_sha}" '.sha')
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    if ! printf '%s' "$actual_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
+      echo "[ERROR] Invalid live Super-Linter caller blob for ${name}" >&2
+      return 1
+    fi
+    ;;
+  44) actual_lint_blob="" ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
+  if [ "$actual_blob" = "$expected_blob" ] &&
+    [ "$actual_lint_blob" = "$expected_lint_blob" ]; then
+    return 0
+  fi
+  expected_change_count=0
+  [ "$actual_blob" = "$expected_blob" ] || expected_change_count=$((expected_change_count + 1))
+  [ "$actual_lint_blob" = "$expected_lint_blob" ] || expected_change_count=$((expected_change_count + 1))
 
   default_branch=$(gh api "repos/${slug}" --jq '.default_branch')
   if [ "$default_branch" != "main" ]; then
@@ -612,11 +668,30 @@ bootstrap_one() {
   *) return 1 ;;
   esac
 
-  if [ "$branch_blob" != "$expected_blob" ]; then
-    if [ "$branch_head" != "$base_sha" ]; then
-      echo "[ERROR] Refusing to append to a non-exact bootstrap branch for ${name}" >&2
+  set +e
+  branch_lint_blob=$(api_value_or_404 \
+    "repos/${slug}/contents/${lint_caller_path}?ref=${branch_head}" '.sha')
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    if ! printf '%s' "$branch_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
+      echo "[ERROR] Invalid bootstrap Super-Linter caller blob for ${name}" >&2
       return 1
     fi
+    ;;
+  44) branch_lint_blob="" ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
+
+  if { [ "$branch_blob" != "$expected_blob" ] ||
+    [ "$branch_lint_blob" != "$expected_lint_blob" ]; } &&
+    [ "$branch_head" != "$base_sha" ]; then
+    echo "[ERROR] Refusing to append to a non-exact bootstrap branch for ${name}" >&2
+    return 1
+  fi
+  if [ "$branch_blob" != "$expected_blob" ]; then
     jq -n \
       --arg message "chore(governance): bootstrap exact managed caller" \
       --arg branch "$branch" \
@@ -628,6 +703,18 @@ bootstrap_one() {
       --method PUT --input "$work/update-${name}.json" >/dev/null
     branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
   fi
+  if [ "$branch_lint_blob" != "$expected_lint_blob" ]; then
+    jq -n \
+      --arg message "chore(governance): bootstrap exact Super-Linter caller" \
+      --arg branch "$branch" \
+      --arg sha "$branch_lint_blob" \
+      --rawfile content "$work/lint-caller.b64" \
+      '{message: $message, content: $content, branch: $branch, sha: $sha} |
+       if .sha == "" then del(.sha) else . end' >"$work/update-lint-${name}.json"
+    gh api "repos/${slug}/contents/${lint_caller_path}" \
+      --method PUT --input "$work/update-lint-${name}.json" >/dev/null
+    branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
+  fi
   if ! printf '%s' "$branch_head" | grep -qE '^[0-9a-f]{40}$'; then
     echo "[ERROR] Invalid exact bootstrap head for ${name}" >&2
     return 1
@@ -635,13 +722,18 @@ bootstrap_one() {
 
   compare_file="$work/compare-${name}.json"
   gh api "repos/${slug}/compare/${base_sha}...${branch_head}" >"$compare_file"
-  if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" '
-    .status == "ahead" and .ahead_by == 1 and .total_commits == 1 and
-    (.commits | length) == 1 and (.files | length) == 1 and
-    .files[0].filename == $path and .files[0].sha == $blob and
-    (.files[0].status == "added" or .files[0].status == "modified")
+  if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" \
+    --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
+    --argjson change_count "$expected_change_count" '
+    .status == "ahead" and .ahead_by == $change_count and
+    .total_commits == $change_count and (.commits | length) == $change_count and
+    (.files | length) == $change_count and
+    all(.files[];
+      ((.filename == $path and .sha == $blob) or
+       (.filename == $lint_path and .sha == $lint_blob)) and
+      (.status == "added" or .status == "modified"))
   ' "$compare_file" >/dev/null; then
-    echo "[ERROR] Bootstrap branch for ${name} is not an exact one-file commit" >&2
+    echo "[ERROR] Bootstrap branch for ${name} is not an exact caller update" >&2
     return 1
   fi
 
@@ -652,8 +744,8 @@ bootstrap_one() {
       --repo "$slug" \
       --base "$default_branch" \
       --head "$branch" \
-      --title "chore(governance): bootstrap exact managed caller" \
-      --body "Installs one exact managed caller before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
+      --title "chore(governance): bootstrap exact managed callers" \
+      --body "Installs the exact enforcement and Super-Linter callers before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
     pr_number=${pr_url##*/}
     created_pr_number="$pr_number"
     if ! printf '%s' "$created_pr_number" | grep -qE '^[1-9][0-9]*$'; then
@@ -671,11 +763,12 @@ bootstrap_one() {
   pr_file="$work/pr-${name}.json"
   gh pr view "$pr_number" --repo "$slug" \
     --json baseRefName,headRefName,headRefOid,files,commits >"$pr_file"
-  if ! jq -e --arg path "$caller_path" --arg base "$default_branch" \
-    --arg head "$branch" --arg oid "$branch_head" '
+  if ! jq -e --arg path "$caller_path" --arg lint_path "$lint_caller_path" \
+    --arg base "$default_branch" --arg head "$branch" --arg oid "$branch_head" \
+    --argjson change_count "$expected_change_count" '
     .baseRefName == $base and .headRefName == $head and .headRefOid == $oid and
-    (.commits | length) == 1 and (.files | length) == 1 and
-    .files[0].path == $path
+    (.commits | length) == $change_count and (.files | length) == $change_count and
+    all(.files[]; .path == $path or .path == $lint_path)
   ' "$pr_file" >/dev/null; then
     echo "[ERROR] Bootstrap PR for ${name} contains an unexpected diff" >&2
     return 1
@@ -697,6 +790,12 @@ bootstrap_one() {
     "repos/${slug}/contents/${caller_path}?ref=${verified_head}" --jq '.sha')
   if [ "$verified_blob" != "$expected_blob" ]; then
     echo "[ERROR] Bootstrap caller changed after exact PR verification for ${name}" >&2
+    return 1
+  fi
+  verified_lint_blob=$(gh api \
+    "repos/${slug}/contents/${lint_caller_path}?ref=${verified_head}" --jq '.sha')
+  if [ "$verified_lint_blob" != "$expected_lint_blob" ]; then
+    echo "[ERROR] Super-Linter caller changed after exact PR verification for ${name}" >&2
     return 1
   fi
   gh pr merge "$pr_number" --repo "$slug" --auto --squash --delete-branch \
@@ -768,14 +867,32 @@ while true; do
     84) exit 84 ;;
     *) exit 1 ;;
     esac
+
+    set +e
+    live_lint_blob=$(api_value_or_404 \
+      "repos/${slug}/contents/${lint_caller_path}?ref=${main_sha}" '.sha')
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      if ! printf '%s' "$live_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "[ERROR] Invalid live Super-Linter caller receipt while verifying ${name}" >&2
+        exit 1
+      fi
+      [ "$live_lint_blob" = "$expected_lint_blob" ] || pending=$((pending + 1))
+      ;;
+    44) pending=$((pending + 1)) ;;
+    84) exit 84 ;;
+    *) exit 1 ;;
+    esac
   done < <(jq -r '.[]' "$downstream_config")
 
   if [ "$pending" -eq 0 ]; then
-    echo "[OK] Every downstream protected main contains the exact managed caller"
+    echo "[OK] Every downstream protected main contains both exact managed callers"
     break
   fi
   if [ "$SECONDS" -ge "$deadline" ]; then
-    echo "[DEFER] ${pending} exact-caller merge(s) remain pending; scheduled dispatch will resume verification"
+    echo "[DEFER] ${pending} exact-caller blob(s) remain pending; scheduled dispatch will resume verification"
     exit 83
   fi
   sleep "$poll_seconds"

--- a/scripts/preflight-downstream-dispatch.sh
+++ b/scripts/preflight-downstream-dispatch.sh
@@ -15,8 +15,10 @@ source_status=""
 pinned_blob=""
 source_blob=""
 expected_caller_blob=""
+expected_lint_caller_blob=""
 downstream_main=""
 actual_caller_blob=""
+actual_lint_caller_blob=""
 workflow_state=""
 
 github_api_into() {
@@ -127,6 +129,16 @@ if ! printf '%s' "$expected_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
   echo "[ERROR] GitHub returned an invalid managed caller blob receipt" >&2
   exit 1
 fi
+if ! github_api_into expected_lint_caller_blob \
+  "repos/${repository}/contents/workflows/super-linter.yml?ref=${source_sha}" \
+  --jq '.sha'; then
+  echo "[ERROR] Could not resolve the exact Super-Linter caller" >&2
+  exit 1
+fi
+if ! printf '%s' "$expected_lint_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "[ERROR] GitHub returned an invalid Super-Linter caller blob receipt" >&2
+  exit 1
+fi
 
 stale_callers=0
 state_mismatches=0
@@ -163,6 +175,24 @@ while IFS= read -r name; do
     # Legacy or malformed caller bytes need replacement regardless of their
     # Actions state. They may not parse as a workflow, so no state endpoint is
     # required until the exact caller has landed.
+    continue
+  fi
+  if ! github_api_into actual_lint_caller_blob \
+    "repos/${owner}/${name}/contents/.github/workflows/super-linter.yml?ref=${downstream_main}" \
+    --jq '.sha'; then
+    if [ "$api_not_found" = true ]; then
+      actual_lint_caller_blob=""
+    else
+      echo "[ERROR] Could not read the live Super-Linter caller for ${name}" >&2
+      exit 1
+    fi
+  elif ! printf '%s' "$actual_lint_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
+    echo "[ERROR] Invalid live Super-Linter caller blob receipt for ${name}" >&2
+    exit 1
+  fi
+  if [ "$actual_lint_caller_blob" != "$expected_lint_caller_blob" ]; then
+    echo "[BOOTSTRAP] ${name} does not contain the exact Super-Linter caller"
+    stale_callers=$((stale_callers + 1))
     continue
   fi
   if ! github_api_into workflow_state \

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -18,6 +18,9 @@ BRANCH_HEAD=7777777777777777777777777777777777777777
 CALLER_TEXT='name: Enforce Repository Settings'
 CALLER_CONTENT=$(printf '%s\n' "$CALLER_TEXT" | base64 | tr -d '\n')
 CALLER_BLOB=$(printf '%s\n' "$CALLER_TEXT" | git hash-object --stdin)
+LINT_CALLER_TEXT='name: Super-Linter'
+LINT_CALLER_CONTENT=$(printf '%s\n' "$LINT_CALLER_TEXT" | base64 | tr -d '\n')
+LINT_CALLER_BLOB=$(printf '%s\n' "$LINT_CALLER_TEXT" | git hash-object --stdin)
 printf '["example"]\n' >"$WORK/repos.json"
 printf '{"revision":"%s"}\n' "$PIN_SHA" >"$WORK/pin.json"
 printf '{"state":"active"}\n' >"$WORK/rollout.json"
@@ -54,6 +57,13 @@ if ! grep -q 'quiesce_fleet' <<<"$enable_failure_block"; then
 fi
 echo "[OK] merge and enable transitions retain exact safe ownership"
 
+if ! grep -Fq 'contents/workflows/super-linter.yml?ref=${source_sha}' "$SOURCE" ||
+  ! grep -Fq '.github/workflows/super-linter.yml' "$SOURCE"; then
+  echo "[FAIL] exact-caller bootstrap does not carry the current Super-Linter caller"
+  exit 1
+fi
+echo "[OK] bootstrap carries the lint caller that validates its own PR"
+
 cat >"$WORK/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$FAKE_LOG"
@@ -87,6 +97,14 @@ case "$1 $endpoint" in
     else
       printf '{"type":"file","encoding":"base64","sha":"%s","content":"%s"}\n' \
         "$CALLER_BLOB" "$CALLER_CONTENT"
+    fi
+    ;;
+  'api repos/f5-sales-demo/docs-control/contents/workflows/super-linter.yml?ref='*)
+    if [[ "$*" == *'--jq .sha'* ]]; then
+      printf '%s\n' "$LINT_CALLER_BLOB"
+    else
+      printf '{"type":"file","encoding":"base64","sha":"%s","content":"%s"}\n' \
+        "$LINT_CALLER_BLOB" "$LINT_CALLER_CONTENT"
     fi
     ;;
   'api repos/f5-sales-demo/example/commits/main') printf '%s\n' "$BASE_SHA" ;;
@@ -126,6 +144,9 @@ case "$1 $endpoint" in
   'api repos/f5-sales-demo/example-two/actions/runs?status='*) printf '\n' ;;
   'api repos/f5-sales-demo/example-two/contents/.github/workflows/enforce-repo-settings.yml?ref='*)
     printf '%s\n' "$DOWNSTREAM_BLOB"
+    ;;
+  'api repos/f5-sales-demo/example-two/contents/.github/workflows/super-linter.yml?ref='*)
+    printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
     ;;
   'api repos/f5-sales-demo/example/actions/runs?status='*)
     if [ -n "${FAKE_RATE_LIMIT_STATUS:-}" ] &&
@@ -223,11 +244,23 @@ case "$1 $endpoint" in
     elif [ "$ref" = "$BRANCH_HEAD" ] && [ -f "$FAKE_STATE/updated" ]; then
       printf '%s\n' "$CALLER_BLOB"
     elif [ "$ref" = "$BRANCH_HEAD" ]; then
-      printf '%s\n' "$OLD_BLOB"
+      printf '%s\n' "$DOWNSTREAM_BLOB"
     elif [ -f "$FAKE_STATE/merged" ]; then
       printf '%s\n' "$CALLER_BLOB"
     else
       printf '%s\n' "$DOWNSTREAM_BLOB"
+    fi
+    ;;
+  'api repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml?ref='*)
+    ref=${endpoint##*ref=}
+    if [ "$ref" = "$BRANCH_HEAD" ] && [ -f "$FAKE_STATE/lint-updated" ]; then
+      printf '%s\n' "$LINT_CALLER_BLOB"
+    elif [ "$ref" = "$BRANCH_HEAD" ]; then
+      printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
+    elif [ -f "$FAKE_STATE/merged" ]; then
+      printf '%s\n' "$LINT_CALLER_BLOB"
+    else
+      printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
     fi
     ;;
   'api repos/f5-sales-demo/example') printf 'main\n' ;;
@@ -236,7 +269,7 @@ case "$1 $endpoint" in
     if [ -f "$FAKE_STATE/branch" ]; then
       if [ -f "$FAKE_STATE/corrupt" ]; then
         printf '%s\n' '8888888888888888888888888888888888888888'
-      elif [ -f "$FAKE_STATE/updated" ]; then
+      elif [ -f "$FAKE_STATE/updated" ] || [ -f "$FAKE_STATE/lint-updated" ]; then
         printf '%s\n' "$BRANCH_HEAD"
       else
         printf '%s\n' "$BASE_SHA"
@@ -250,8 +283,24 @@ case "$1 $endpoint" in
   'api repos/f5-sales-demo/example/contents/.github/workflows/enforce-repo-settings.yml')
     touch "$FAKE_STATE/updated"
     ;;
+  'api repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml')
+    touch "$FAKE_STATE/lint-updated"
+    ;;
   'api repos/f5-sales-demo/example/compare/'*)
-    printf '{"status":"ahead","ahead_by":1,"total_commits":1,"commits":[{}],"files":[{"filename":".github/workflows/enforce-repo-settings.yml","sha":"%s","status":"modified"}]}\n' "$CALLER_BLOB"
+    files='[]'
+    count=0
+    if [ "$DOWNSTREAM_BLOB" != "$CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" --arg sha "$CALLER_BLOB" \
+        '$files + [{filename:".github/workflows/enforce-repo-settings.yml",sha:$sha,status:"modified"}]')
+      count=$((count + 1))
+    fi
+    if [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" --arg sha "$LINT_CALLER_BLOB" \
+        '$files + [{filename:".github/workflows/super-linter.yml",sha:$sha,status:"modified"}]')
+      count=$((count + 1))
+    fi
+    jq -cn --argjson count "$count" --argjson files "$files" \
+      '{status:"ahead",ahead_by:$count,total_commits:$count,commits:[range(0;$count)|{}],files:$files}'
     ;;
   'api repos/f5-sales-demo/example/pulls?state=open&per_page=100')
     if [ -f "$FAKE_STATE/duplicate-current-open" ]; then
@@ -296,8 +345,19 @@ case "$1 $endpoint" in
     printf 'https://github.com/f5-sales-demo/example/pull/42\n'
     ;;
   'pr view')
-    printf '{"baseRefName":"main","headRefName":"%s","headRefOid":"%s","commits":[{}],"files":[{"path":".github/workflows/enforce-repo-settings.yml"}]}\n' \
-      "$EXPECTED_BRANCH" "$BRANCH_HEAD"
+    files='[]'
+    count=0
+    if [ "$DOWNSTREAM_BLOB" != "$CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" '$files + [{path:".github/workflows/enforce-repo-settings.yml"}]')
+      count=$((count + 1))
+    fi
+    if [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" '$files + [{path:".github/workflows/super-linter.yml"}]')
+      count=$((count + 1))
+    fi
+    jq -cn --arg branch "$EXPECTED_BRANCH" --arg sha "$BRANCH_HEAD" \
+      --argjson count "$count" --argjson files "$files" \
+      '{baseRefName:"main",headRefName:$branch,headRefOid:$sha,commits:[range(0;$count)|{}],files:$files}'
     ;;
   'pr merge')
     if [ -f "$FAKE_STATE/fail-merge" ]; then
@@ -336,10 +396,13 @@ run_bootstrap() {
     ENFORCE_BLOB="$ENFORCE_BLOB" \
     SYNC_BLOB="$SYNC_BLOB" \
     BRANCH_HEAD="$BRANCH_HEAD" \
-    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB:0:12}-12345-1" \
+    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB:0:6}${LINT_CALLER_BLOB:0:6}-12345-1" \
     CALLER_BLOB="$CALLER_BLOB" \
     CALLER_CONTENT="$CALLER_CONTENT" \
+    LINT_CALLER_BLOB="$LINT_CALLER_BLOB" \
+    LINT_CALLER_CONTENT="$LINT_CALLER_CONTENT" \
     DOWNSTREAM_BLOB="$DOWNSTREAM_BLOB" \
+    DOWNSTREAM_LINT_BLOB="${DOWNSTREAM_LINT_BLOB:-$LINT_CALLER_BLOB}" \
     FAKE_READ_ERROR="${FAKE_READ_ERROR:-}" \
     FAKE_MAIN_ADVANCE_AT="${FAKE_MAIN_ADVANCE_AT:-}" \
     FAKE_MALFORMED_CALLER="${FAKE_MALFORMED_CALLER:-}" \
@@ -389,7 +452,28 @@ if grep -qE '(^|[[:space:]])--force([[:space:]]|$)|"force"[[:space:]]*:[[:space:
   echo "[FAIL] bootstrap used a non-monotonic force update"
   exit 1
 fi
-echo "[OK] stale caller closes older PRs and queues one exact one-file PR"
+echo "[OK] stale callers close older PRs and queue one exact bounded PR"
+
+state="$WORK/state-stale-lint-only"
+mkdir -p "$state"
+touch "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+set +e
+run_bootstrap "$state" >"$WORK/stale-lint-only.out" 2>"$WORK/stale-lint-only.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINT_BLOB
+if [ "$rc" != 83 ] ||
+  grep -q 'contents/.github/workflows/enforce-repo-settings.yml --method PUT' "$WORK/gh.log" ||
+  ! grep -q 'contents/.github/workflows/super-linter.yml --method PUT' "$WORK/gh.log" ||
+  grep -q 'actions/workflows/enforce-repo-settings.yml/enable --method PUT' "$WORK/gh.log"; then
+  echo "[FAIL] stale lint-only caller was not kept quiesced behind its exact bounded PR"
+  cat "$WORK/stale-lint-only.err"
+  exit 1
+fi
+echo "[OK] exact enforcement with stale lint updates only lint and remains quiesced"
 
 state="$WORK/state-exact"
 mkdir -p "$state"

--- a/tests/test-dispatch-preflight.sh
+++ b/tests/test-dispatch-preflight.sh
@@ -9,6 +9,7 @@ PIN_SHA=2222222222222222222222222222222222222222
 OTHER_SHA=3333333333333333333333333333333333333333
 ENFORCE_BLOB=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 SYNC_BLOB=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+LINT_CALLER_BLOB=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 PASS=0
 FAIL=0
 
@@ -36,6 +37,9 @@ case "$*" in
   *"contents/workflows/enforce-repo-settings.yml?ref=$FAKE_SOURCE_SHA"*)
     printf '%s\n' "$FAKE_SOURCE_CALLER_BLOB"
     ;;
+  *"contents/workflows/super-linter.yml?ref=$FAKE_SOURCE_SHA"*)
+    printf '%s\n' "$FAKE_SOURCE_LINT_CALLER_BLOB"
+    ;;
   *"enforce-repo-settings.yml?ref=$FAKE_SOURCE_SHA"*) printf '%s\n' "$FAKE_SOURCE_ENFORCE_BLOB" ;;
   *"sync-managed-files.yml?ref=$FAKE_SOURCE_SHA"*) printf '%s\n' "$FAKE_SOURCE_SYNC_BLOB" ;;
   *"repos/f5-sales-demo/example/contents/.github/workflows/enforce-repo-settings.yml?ref=$FAKE_DOWNSTREAM_MAIN"*)
@@ -44,6 +48,13 @@ case "$*" in
       exit 1
     fi
     printf '%s\n' "$FAKE_DOWNSTREAM_CALLER_BLOB"
+    ;;
+  *"repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml?ref=$FAKE_DOWNSTREAM_MAIN"*)
+    if [ "${FAKE_MISSING_CALLER:-}" = 1 ]; then
+      echo 'gh: Not Found (HTTP 404)' >&2
+      exit 1
+    fi
+    printf '%s\n' "$FAKE_DOWNSTREAM_LINT_CALLER_BLOB"
     ;;
   *'repos/f5-sales-demo/example/actions/workflows/enforce-repo-settings.yml'*)
     if [ "${FAKE_MISSING_CALLER:-}" = 1 ] || [ "${FAKE_STATE_READ_FAIL:-}" = 1 ]; then
@@ -75,7 +86,9 @@ EOF
     FAKE_SOURCE_ENFORCE_BLOB="$FAKE_SOURCE_ENFORCE_BLOB" \
     FAKE_SOURCE_SYNC_BLOB="$FAKE_SOURCE_SYNC_BLOB" \
     FAKE_SOURCE_CALLER_BLOB="$FAKE_SOURCE_CALLER_BLOB" \
+    FAKE_SOURCE_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB" \
     FAKE_DOWNSTREAM_CALLER_BLOB="$FAKE_DOWNSTREAM_CALLER_BLOB" \
+    FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_DOWNSTREAM_LINT_CALLER_BLOB" \
     FAKE_DOWNSTREAM_MAIN="$FAKE_DOWNSTREAM_MAIN" \
     FAKE_MISSING_CALLER="${FAKE_MISSING_CALLER:-}" \
     FAKE_STATE_READ_FAIL="${FAKE_STATE_READ_FAIL:-}" \
@@ -101,7 +114,9 @@ FAKE_PIN_SYNC_BLOB="$SYNC_BLOB"
 FAKE_SOURCE_ENFORCE_BLOB="$ENFORCE_BLOB"
 FAKE_SOURCE_SYNC_BLOB="$SYNC_BLOB"
 FAKE_SOURCE_CALLER_BLOB=cccccccccccccccccccccccccccccccccccccccc
+FAKE_SOURCE_LINT_CALLER_BLOB="$LINT_CALLER_BLOB"
 FAKE_DOWNSTREAM_CALLER_BLOB="$FAKE_SOURCE_CALLER_BLOB"
+FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB"
 FAKE_DOWNSTREAM_MAIN=dddddddddddddddddddddddddddddddddddddddd
 check_case "exact main receipt and exact caller pin permit fan-out" 0 "[OK]"
 
@@ -124,6 +139,14 @@ FAKE_STATE_READ_FAIL=1
 check_case "stale caller bootstraps without requiring legacy workflow state" 80 \
   "[BOOTSTRAP]"
 unset FAKE_STATE_READ_FAIL
+
+FAKE_DOWNSTREAM_CALLER_BLOB="$FAKE_SOURCE_CALLER_BLOB"
+FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$OTHER_SHA"
+FAKE_STATE_READ_FAIL=1
+check_case "stale Super-Linter caller requires bootstrap" 80 \
+  "[BOOTSTRAP] example does not contain the exact Super-Linter caller"
+unset FAKE_STATE_READ_FAIL
+FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB"
 
 FAKE_MISSING_CALLER=1
 check_case "missing workflow reaches exact caller bootstrap" 80 "[BOOTSTRAP]"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1220,13 +1220,12 @@ import yaml
 with open(sys.argv[1], encoding="utf-8") as workflow_file:
     workflow = yaml.safe_load(workflow_file)
 
-expected_condition = (
-    "github.repository == 'f5-sales-demo/docs-control' && "
-    "runner.environment == 'self-hosted'"
-)
+expected_condition = "runner.environment == 'self-hosted'"
 required_fragments = (
     'workspace="${GITHUB_WORKSPACE:?}"',
-    'expected_workspace="${RUNNER_WORKSPACE:?}/docs-control"',
+    'repository="${GITHUB_REPOSITORY:?}"',
+    'repository_name="${repository##*/}"',
+    'expected_workspace="${RUNNER_WORKSPACE:?}/${repository_name}"',
     '[ "$workspace" = "$expected_workspace" ]',
     'sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"',
 )
@@ -1234,7 +1233,7 @@ forbidden_fragments = ("/home/", "/data/actions-runners/")
 
 for job_name in ("lint", "shell-unit-tests"):
     steps = workflow["jobs"][job_name]["steps"]
-    repairs = [step for step in steps if step.get("name") == "Repair docs-control runner workspace"]
+    repairs = [step for step in steps if step.get("name") == "Repair self-hosted runner workspace"]
     checkouts = [step for step in steps if step.get("name") == "Checkout"]
     if len(repairs) != 1 or len(checkouts) != 1:
         raise SystemExit(1)
@@ -1249,9 +1248,9 @@ for job_name in ("lint", "shell-unit-tests"):
     if any(fragment in command for fragment in forbidden_fragments):
         raise SystemExit(1)
 PY
-  pass "17.1 lint and shell jobs repair only the exact docs-control workspace before checkout"
+  pass "17.1 lint and shell jobs repair only the exact calling repository workspace before checkout"
 else
-  fail "17.1 lint and shell jobs repair only the exact docs-control workspace before checkout" \
+  fail "17.1 lint and shell jobs repair only the exact calling repository workspace before checkout" \
     "both jobs need the guarded ownership repair before actions/checkout"
 fi
 


### PR DESCRIPTION
Closes #1121

## What changed

- derive the guarded self-hosted repair workspace from the calling repository
- bootstrap exact enforcement and Super-Linter callers in one bounded PR
- keep enforcement quiesced until both exact blobs are present on protected `main`
- add hermetic coverage for stale lint-only callers and protected-main verification

## Verification

- `bash tests/test-linter-configs.sh` (157 passed)
- `bash tests/test-dispatch-preflight.sh` (10 passed)
- `bash tests/test-bootstrap-downstream-callers.sh`
- ShellCheck and shfmt
- actionlint and zizmor
- staged PII scan and gitleaks
- `pre-commit run --all-files`