### PR TITLE
feat(infra): add self-hosted runner management and monitoring scripts

### DIFF
--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""
+Management script for self-hosted GitHub Actions runners in the f5-sales-demo ecosystem.
+
+Directory structure:
+  /data/actions-runners/f5-sales-demo/<repo-name>
+  /data/actions-runners/f5-sales-demo/.cache
+
+Authoritative list of governed repos is obtained from .claude/governance.json in docs-control.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+
+DEFAULT_ORG = "f5-sales-demo"
+DEFAULT_BASE_DIR = Path("/data/actions-runners/f5-sales-demo")
+DEFAULT_USER = "robin"
+DOCS_CONTROL_GOVERNANCE_PATH = Path(__file__).resolve().parent.parent / ".claude/governance.json"
+
+
+def run_cmd(cmd, cwd=None, check=True, capture=True, sudo=False):
+    if sudo and os.geteuid() != 0:
+        cmd = ["sudo"] + cmd
+    res = subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=check,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        text=True,
+    )
+    return res
+
+
+def get_latest_runner_version():
+    try:
+        res = run_cmd(["gh", "api", "repos/actions/runner/releases/latest", "--jq", ".tag_name"])
+        tag = res.stdout.strip()
+        if tag.startswith("v"):
+            return tag[1:]
+        return tag
+    except Exception as e:
+        print(f"Warning: Failed to fetch latest runner tag via gh CLI: {e}. Falling back to 2.336.0")
+        return "2.336.0"
+
+
+def download_runner_tarball(version, cache_dir: Path):
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    tarball_name = f"actions-runner-linux-x64-{version}.tar.gz"
+    tarball_path = cache_dir / tarball_name
+
+    if tarball_path.exists():
+        print(f"[CACHE] Found cached runner tarball at {tarball_path}")
+        return tarball_path
+
+    url = f"https://github.com/actions/runner/releases/download/v{version}/{tarball_name}"
+    print(f"[DOWNLOAD] Downloading runner v{version} from {url}...")
+    urllib.request.urlretrieve(url, tarball_path)
+    print(f"[DOWNLOAD] Saved to {tarball_path}")
+    return tarball_path
+
+
+def get_registration_token(org, repo):
+    res = run_cmd(["gh", "api", "-X", "POST", f"/repos/{org}/{repo}/actions/runners/registration-token", "--jq", ".token"])
+    return res.stdout.strip()
+
+
+def get_removal_token(org, repo):
+    res = run_cmd(["gh", "api", "-X", "POST", f"/repos/{org}/{repo}/actions/runners/remove-token", "--jq", ".token"])
+    return res.stdout.strip()
+
+
+def load_governed_repos(gov_path: Path = DOCS_CONTROL_GOVERNANCE_PATH):
+    if not gov_path.exists():
+        raise FileNotFoundError(f"Governance manifest not found at {gov_path}")
+    with open(gov_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    repos_dict = data.get("repo_classes", {}).get("repos", {})
+    return sorted(list(repos_dict.keys()))
+
+
+def setup_runner(org, repo, base_dir: Path, user):
+    repo_dir = base_dir / repo
+    cache_dir = base_dir / ".cache"
+
+    print(f"\n==========================================")
+    print(f"Setting up self-hosted runner for {org}/{repo}")
+    print(f"Directory: {repo_dir}")
+    print(f"==========================================")
+
+    version = get_latest_runner_version()
+    tarball = download_runner_tarball(version, cache_dir)
+
+    if repo_dir.exists():
+        svc_sh = repo_dir / "svc.sh"
+        if svc_sh.exists():
+            print(f"[CLEANUP] Stopping and uninstalling existing service in {repo_dir}...")
+            try:
+                run_cmd(["./svc.sh", "stop"], cwd=repo_dir, check=False, sudo=True)
+                run_cmd(["./svc.sh", "uninstall"], cwd=repo_dir, check=False, sudo=True)
+            except Exception as e:
+                print(f"[CLEANUP WARNING] {e}")
+        shutil.rmtree(repo_dir, ignore_errors=True)
+
+    repo_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[EXTRACT] Extracting runner binary to {repo_dir}...")
+    run_cmd(["tar", "-xzf", str(tarball), "-C", str(repo_dir)])
+
+    print(f"[TOKEN] Requesting runner registration token for {org}/{repo}...")
+    token = get_registration_token(org, repo)
+
+    runner_name = f"runner-ubuntu-{repo}"
+    labels = f"self-hosted,Linux,X64,ubuntu-latest,{repo},{org}"
+
+    print(f"[CONFIG] Configuring runner '{runner_name}' with labels: {labels}")
+    config_cmd = [
+        "./config.sh",
+        "--url", f"https://github.com/{org}/{repo}",
+        "--token", token,
+        "--name", runner_name,
+        "--labels", labels,
+        "--unattended",
+        "--replace"
+    ]
+    run_cmd(config_cmd, cwd=repo_dir)
+
+    print(f"[SERVICE] Installing systemd service as user '{user}'...")
+    svc_pattern = f"actions.runner.{org}-{repo}.*.service"
+    for unit in Path("/etc/systemd/system").glob(svc_pattern):
+        print(f"[CLEANUP] Removing stale systemd unit file {unit}...")
+        run_cmd(["systemctl", "stop", unit.name], check=False, sudo=True)
+        run_cmd(["systemctl", "disable", unit.name], check=False, sudo=True)
+        run_cmd(["rm", "-f", str(unit)], check=False, sudo=True)
+        run_cmd(["systemctl", "daemon-reload"], check=False, sudo=True)
+
+    run_cmd(["./svc.sh", "install", user], cwd=repo_dir, sudo=True)
+
+    print(f"[SERVICE] Starting systemd service...")
+    run_cmd(["./svc.sh", "start"], cwd=repo_dir, sudo=True)
+
+    print(f"[SUCCESS] Runner for {org}/{repo} installed and started successfully!")
+
+
+def status_runner(org, repo, base_dir: Path):
+    repo_dir = base_dir / repo
+    print(f"\n--- Status for {org}/{repo} ---")
+
+    # GitHub API Status
+    try:
+        res = run_cmd(["gh", "api", f"/repos/{org}/{repo}/actions/runners"])
+        data = json.loads(res.stdout)
+        runners = data.get("runners", [])
+        if not runners:
+            print("  GitHub API: No runners registered for this repo.")
+        else:
+            for r in runners:
+                print(f"  GitHub API Runner: ID={r.get('id')} Name={r.get('name')} Status={r.get('status')} Busy={r.get('busy')} OS={r.get('os')}")
+    except Exception as e:
+        print(f"  GitHub API Error: {e}")
+
+    # Local Directory & Systemd Status
+    if repo_dir.exists():
+        svc_file = repo_dir / ".service"
+        if svc_file.exists():
+            service_name = svc_file.read_text().strip()
+            print(f"  Service Name: {service_name}")
+            try:
+                res = run_cmd(["systemctl", "status", service_name], check=False)
+                lines = res.stdout.splitlines()[:5]
+                for line in lines:
+                    print(f"    {line}")
+            except Exception as e:
+                print(f"  systemctl error: {e}")
+        else:
+            print("  Local Directory exists, but no .service file found.")
+    else:
+        print("  Local Directory does not exist.")
+
+
+def restart_runner(org, repo, base_dir: Path):
+    repo_dir = base_dir / repo
+    if not repo_dir.exists():
+        print(f"Error: {repo_dir} does not exist.")
+        return
+    print(f"Restarting runner service for {org}/{repo}...")
+    run_cmd(["./svc.sh", "restart"], cwd=repo_dir, sudo=True)
+    print("Done.")
+
+
+def stop_runner(org, repo, base_dir: Path):
+    repo_dir = base_dir / repo
+    if not repo_dir.exists():
+        print(f"Error: {repo_dir} does not exist.")
+        return
+    print(f"Stopping runner service for {org}/{repo}...")
+    run_cmd(["./svc.sh", "stop"], cwd=repo_dir, sudo=True)
+    print("Done.")
+
+
+def remove_runner(org, repo, base_dir: Path):
+    repo_dir = base_dir / repo
+    if not repo_dir.exists():
+        print(f"Directory {repo_dir} does not exist. Nothing to remove.")
+        return
+
+    print(f"\nRemoving runner for {org}/{repo}...")
+    svc_sh = repo_dir / "svc.sh"
+    if svc_sh.exists():
+        print("Stopping service...")
+        run_cmd(["./svc.sh", "stop"], cwd=repo_dir, check=False, sudo=True)
+        print("Uninstalling service...")
+        run_cmd(["./svc.sh", "uninstall"], cwd=repo_dir, check=False, sudo=True)
+
+    try:
+        print("Obtaining removal token...")
+        remove_token = get_removal_token(org, repo)
+        config_sh = repo_dir / "config.sh"
+        if config_sh.exists():
+            print("Unregistering runner from GitHub...")
+            run_cmd(["./config.sh", "remove", "--token", remove_token], cwd=repo_dir, check=False)
+    except Exception as e:
+        print(f"Warning during unregistration: {e}")
+
+    print(f"Removing directory {repo_dir}...")
+    shutil.rmtree(repo_dir, ignore_errors=True)
+    print(f"Successfully removed runner for {org}/{repo}.")
+
+
+def setup_governed(org, base_dir: Path, user, auto_confirm=False, gov_path: Path = DOCS_CONTROL_GOVERNANCE_PATH):
+    governed_repos = load_governed_repos(gov_path)
+    print(f"Found {len(governed_repos)} governed repositories in docs-control governance.json:")
+    for r in governed_repos:
+        print(f"  - {r}")
+
+    if not auto_confirm:
+        input_val = input(f"\nProceed to setup runners for all {len(governed_repos)} governed repositories? [y/N] ").strip().lower()
+        if input_val != 'y':
+            print("Cancelled setup-governed.")
+            return
+
+    for idx, repo in enumerate(governed_repos, 1):
+        print(f"\n[{idx}/{len(governed_repos)}] Processing governed repo: {repo}...")
+        try:
+            setup_runner(org, repo, base_dir, user)
+        except Exception as e:
+            print(f"ERROR setting up {repo}: {e}")
+
+
+def clean_ungoverned(org, base_dir: Path, gov_path: Path = DOCS_CONTROL_GOVERNANCE_PATH):
+    governed_set = set(load_governed_repos(gov_path))
+    if not base_dir.exists():
+        print("Base directory does not exist.")
+        return
+
+    print(f"Auditing runner directories in {base_dir} against governed repos list...")
+    for item in base_dir.iterdir():
+        if item.is_dir() and not item.name.startswith("."):
+            repo_name = item.name
+            if repo_name not in governed_set:
+                print(f"⚠️ Found ungoverned runner directory: {repo_name}. Cleaning up...")
+                remove_runner(org, repo_name, base_dir)
+
+
+def health_check(org, base_dir: Path, gov_path: Path = DOCS_CONTROL_GOVERNANCE_PATH):
+    governed_repos = load_governed_repos(gov_path)
+    print(f"\n==========================================")
+    print(f"Health Check for Governed {org} Runners ({len(governed_repos)} Repositories)")
+    print(f"==========================================\n")
+
+    summary = {"online": 0, "busy": 0, "idle": 0, "offline": 0, "unregistered": 0, "error": 0}
+
+    for repo in governed_repos:
+        try:
+            res = run_cmd(["gh", "api", f"/repos/{org}/{repo}/actions/runners"], check=False)
+            if res.returncode != 0:
+                print(f"❌ {repo:30s} API Error")
+                summary["error"] += 1
+                continue
+
+            data = json.loads(res.stdout)
+            runners = data.get("runners", [])
+            if not runners:
+                print(f"⚠️ {repo:30s} Unregistered")
+                summary["unregistered"] += 1
+            else:
+                r = runners[0]
+                status = r.get("status", "unknown")
+                busy = r.get("busy", False)
+                busy_str = " (Busy)" if busy else " (Idle)"
+                if status == "online":
+                    print(f"✅ {repo:30s} Online{busy_str}")
+                    summary["online"] += 1
+                    if busy:
+                        summary["busy"] += 1
+                    else:
+                        summary["idle"] += 1
+                else:
+                    print(f"❌ {repo:30s} Offline")
+                    summary["offline"] += 1
+        except Exception as e:
+            print(f"❌ {repo:30s} Error: {e}")
+            summary["error"] += 1
+
+    print(f"\nSummary: {summary['online']} Online ({summary['busy']} Busy, {summary['idle']} Idle) | {summary['offline']} Offline | {summary['unregistered']} Unregistered | {summary['error']} Errors")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Manage repository-level GitHub Actions runners for f5-sales-demo governed repositories")
+    parser.add_argument("--org", default=DEFAULT_ORG, help="GitHub Organization")
+    parser.add_argument("--base-dir", default=str(DEFAULT_BASE_DIR), help="Base directory for runners")
+    parser.add_argument("--user", default=DEFAULT_USER, help="System user for runner systemd service")
+    parser.add_argument("--governance-path", default=str(DOCS_CONTROL_GOVERNANCE_PATH), help="Path to docs-control governance.json")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # setup
+    p_setup = subparsers.add_parser("setup", help="Provision and start runner for a repository")
+    p_setup.add_argument("repo", help="Repository name")
+
+    # status
+    p_status = subparsers.add_parser("status", help="Check status of runner for a repository")
+    p_status.add_argument("repo", nargs="?", help="Repository name (optional)")
+
+    # restart
+    p_restart = subparsers.add_parser("restart", help="Restart runner service for a repository")
+    p_restart.add_argument("repo", help="Repository name")
+
+    # stop
+    p_stop = subparsers.add_parser("stop", help="Stop runner service for a repository")
+    p_stop.add_argument("repo", help="Repository name")
+
+    # remove
+    p_remove = subparsers.add_parser("remove", help="Uninstall and unregister runner for a repository")
+    p_remove.add_argument("repo", help="Repository name")
+
+    # setup-governed / setup-all
+    p_setup_gov = subparsers.add_parser("setup-governed", aliases=["setup-all"], help="Provision runners for all governed repositories declared in governance.json")
+    p_setup_gov.add_argument("-y", "--yes", action="store_true", help="Auto confirm and run non-interactively")
+
+    # clean-ungoverned
+    subparsers.add_parser("clean-ungoverned", help="Remove runners for repositories not listed in governance.json")
+
+    # health-check
+    subparsers.add_parser("health-check", help="Check health of all governed runners across org")
+
+    args = parser.parse_args()
+    base_dir = Path(args.base_dir)
+    gov_path = Path(args.governance_path)
+
+    if args.command == "setup":
+        setup_runner(args.org, args.repo, base_dir, args.user)
+    elif args.command == "status":
+        if args.repo:
+            status_runner(args.org, args.repo, base_dir)
+        else:
+            health_check(args.org, base_dir, gov_path)
+    elif args.command == "restart":
+        restart_runner(args.org, args.repo, base_dir)
+    elif args.command == "stop":
+        stop_runner(args.org, args.repo, base_dir)
+    elif args.command == "remove":
+        remove_runner(args.org, args.repo, base_dir)
+    elif args.command in ["setup-governed", "setup-all"]:
+        setup_governed(args.org, base_dir, args.user, auto_confirm=args.yes, gov_path=gov_path)
+    elif args.command == "clean-ungoverned":
+        clean_ungoverned(args.org, base_dir, gov_path)
+    elif args.command == "health-check":
+        health_check(args.org, base_dir, gov_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -293,13 +293,14 @@ def health_check(org, base_dir: Path, gov_path: Path = DOCS_CONTROL_GOVERNANCE_P
 
             data = json.loads(res.stdout)
             runners = data.get("runners", [])
-            if not runners:
+            target_runner_name = f"runner-ubuntu-{repo}"
+            target_runner = next((r for r in runners if r.get("name") == target_runner_name), runners[0] if runners else None)
+            if not target_runner:
                 print(f"⚠️ {repo:30s} Unregistered")
                 summary["unregistered"] += 1
             else:
-                r = runners[0]
-                status = r.get("status", "unknown")
-                busy = r.get("busy", False)
+                status = target_runner.get("status", "unknown")
+                busy = target_runner.get("busy", False)
                 busy_str = " (Busy)" if busy else " (Idle)"
                 if status == "online":
                     print(f"✅ {repo:30s} Online{busy_str}")

--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -12,12 +12,9 @@ Authoritative list of governed repos is obtained from .claude/governance.json in
 import argparse
 import json
 import os
-import pathlib
 from pathlib import Path
-import shutil
 import subprocess
 import sys
-import time
 import urllib.request
 
 DEFAULT_ORG = "f5-sales-demo"
@@ -92,11 +89,12 @@ def load_governed_repos(gov_path: Path = DOCS_CONTROL_GOVERNANCE_PATH):
 
 
 def validate_repo_dir(base_dir: Path, repo: str) -> Path:
-    if not repo or not repo.strip():
-        raise ValueError("Repository name cannot be empty.")
-    repo_dir = (base_dir / repo).resolve()
-    if repo_dir == base_dir.resolve():
-        raise ValueError(f"Invalid repository name: '{repo}' resolves to base directory.")
+    if not repo or not repo.strip() or "/" in repo or "\\" in repo:
+        raise ValueError(f"Invalid repository name: '{repo}'. Must be a simple repository name.")
+    resolved_base = base_dir.resolve()
+    repo_dir = (resolved_base / repo).resolve()
+    if repo_dir.parent != resolved_base:
+        raise ValueError(f"Invalid repository name: '{repo}' resolves outside base directory.")
     return repo_dir
 
 

--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -91,8 +91,17 @@ def load_governed_repos(gov_path: Path = DOCS_CONTROL_GOVERNANCE_PATH):
     return sorted(list(repos_dict.keys()))
 
 
+def validate_repo_dir(base_dir: Path, repo: str) -> Path:
+    if not repo or not repo.strip():
+        raise ValueError("Repository name cannot be empty.")
+    repo_dir = (base_dir / repo).resolve()
+    if repo_dir == base_dir.resolve():
+        raise ValueError(f"Invalid repository name: '{repo}' resolves to base directory.")
+    return repo_dir
+
+
 def setup_runner(org, repo, base_dir: Path, user):
-    repo_dir = base_dir / repo
+    repo_dir = validate_repo_dir(base_dir, repo)
     cache_dir = base_dir / ".cache"
 
     print(f"\n==========================================")
@@ -155,7 +164,7 @@ def setup_runner(org, repo, base_dir: Path, user):
 
 
 def status_runner(org, repo, base_dir: Path):
-    repo_dir = base_dir / repo
+    repo_dir = validate_repo_dir(base_dir, repo)
     print(f"\n--- Status for {org}/{repo} ---")
 
     # GitHub API Status
@@ -191,7 +200,7 @@ def status_runner(org, repo, base_dir: Path):
 
 
 def restart_runner(org, repo, base_dir: Path):
-    repo_dir = base_dir / repo
+    repo_dir = validate_repo_dir(base_dir, repo)
     if not repo_dir.exists():
         print(f"Error: {repo_dir} does not exist.")
         return
@@ -201,7 +210,7 @@ def restart_runner(org, repo, base_dir: Path):
 
 
 def stop_runner(org, repo, base_dir: Path):
-    repo_dir = base_dir / repo
+    repo_dir = validate_repo_dir(base_dir, repo)
     if not repo_dir.exists():
         print(f"Error: {repo_dir} does not exist.")
         return
@@ -211,7 +220,7 @@ def stop_runner(org, repo, base_dir: Path):
 
 
 def remove_runner(org, repo, base_dir: Path):
-    repo_dir = base_dir / repo
+    repo_dir = validate_repo_dir(base_dir, repo)
     if not repo_dir.exists():
         print(f"Directory {repo_dir} does not exist. Nothing to remove.")
         return

--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -45,7 +45,9 @@ def get_latest_runner_version():
         res = run_cmd(["gh", "api", "repos/actions/runner/releases/latest", "--jq", ".tag_name"])
         tag = res.stdout.strip()
         if tag.startswith("v"):
-            return tag[1:]
+            tag = tag[1:]
+        if not tag:
+            return "2.336.0"
         return tag
     except Exception as e:
         print(f"Warning: Failed to fetch latest runner tag via gh CLI: {e}. Falling back to 2.336.0")
@@ -61,9 +63,11 @@ def download_runner_tarball(version, cache_dir: Path):
         print(f"[CACHE] Found cached runner tarball at {tarball_path}")
         return tarball_path
 
+    tmp_path = cache_dir / f"{tarball_name}.tmp"
     url = f"https://github.com/actions/runner/releases/download/v{version}/{tarball_name}"
     print(f"[DOWNLOAD] Downloading runner v{version} from {url}...")
-    urllib.request.urlretrieve(url, tarball_path)
+    urllib.request.urlretrieve(url, tmp_path)
+    tmp_path.replace(tarball_path)
     print(f"[DOWNLOAD] Saved to {tarball_path}")
     return tarball_path
 
@@ -262,7 +266,8 @@ def clean_ungoverned(org, base_dir: Path, gov_path: Path = DOCS_CONTROL_GOVERNAN
         return
 
     print(f"Auditing runner directories in {base_dir} against governed repos list...")
-    for item in base_dir.iterdir():
+    items = list(base_dir.iterdir())
+    for item in items:
         if item.is_dir() and not item.name.startswith("."):
             repo_name = item.name
             if repo_name not in governed_set:

--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -59,7 +59,7 @@ def download_runner_tarball(version, cache_dir: Path):
     tarball_name = f"actions-runner-linux-x64-{version}.tar.gz"
     tarball_path = cache_dir / tarball_name
 
-    if tarball_path.exists():
+    if tarball_path.exists() and tarball_path.stat().st_size > 0:
         print(f"[CACHE] Found cached runner tarball at {tarball_path}")
         return tarball_path
 
@@ -112,7 +112,7 @@ def setup_runner(org, repo, base_dir: Path, user):
                 run_cmd(["./svc.sh", "uninstall"], cwd=repo_dir, check=False, sudo=True)
             except Exception as e:
                 print(f"[CLEANUP WARNING] {e}")
-        shutil.rmtree(repo_dir, ignore_errors=True)
+        run_cmd(["rm", "-rf", str(repo_dir)], sudo=True, check=False)
 
     repo_dir.mkdir(parents=True, exist_ok=True)
 
@@ -235,7 +235,7 @@ def remove_runner(org, repo, base_dir: Path):
         print(f"Warning during unregistration: {e}")
 
     print(f"Removing directory {repo_dir}...")
-    shutil.rmtree(repo_dir, ignore_errors=True)
+    run_cmd(["rm", "-rf", str(repo_dir)], sudo=True, check=False)
     print(f"Successfully removed runner for {org}/{repo}.")
 
 
@@ -294,7 +294,7 @@ def health_check(org, base_dir: Path, gov_path: Path = DOCS_CONTROL_GOVERNANCE_P
             data = json.loads(res.stdout)
             runners = data.get("runners", [])
             target_runner_name = f"runner-ubuntu-{repo}"
-            target_runner = next((r for r in runners if r.get("name") == target_runner_name), runners[0] if runners else None)
+            target_runner = next((r for r in runners if r.get("name") == target_runner_name), None)
             if not target_runner:
                 print(f"⚠️ {repo:30s} Unregistered")
                 summary["unregistered"] += 1

--- a/scripts/runner-top.py
+++ b/scripts/runner-top.py
@@ -33,11 +33,11 @@ def get_disk_info(mount_point):
         return "N/A"
 
 
-def get_governed_repos():
-    if not GOVERNANCE_PATH.exists():
+def get_governed_repos(gov_path=GOVERNANCE_PATH):
+    if not gov_path.exists():
         return []
     try:
-        with open(GOVERNANCE_PATH, "r", encoding="utf-8") as f:
+        with open(gov_path, "r", encoding="utf-8") as f:
             data = json.load(f)
         return sorted(list(data.get("repo_classes", {}).get("repos", {}).keys()))
     except Exception:
@@ -98,14 +98,14 @@ def get_running_processes():
     return procs
 
 
-def fetch_gh_runner_statuses(org="f5-sales-demo"):
+def fetch_gh_runner_statuses(gov_path=GOVERNANCE_PATH, base_dir=DEFAULT_BASE_DIR):
     """
     Aggregate local runner process status across governed repositories.
     """
-    repos = get_governed_repos()
+    repos = get_governed_repos(gov_path)
     statuses = {}
     for repo in repos:
-        repo_dir = DEFAULT_BASE_DIR / repo
+        repo_dir = base_dir / repo
         statuses[repo] = {"status": "offline", "busy": False, "pid": "-", "cpu": 0.0, "mem_mb": 0.0}
 
     # Aggregate process stats per repo
@@ -118,17 +118,18 @@ def fetch_gh_runner_statuses(org="f5-sales-demo"):
         repo_procs[r].append(p)
 
     for r, plist in repo_procs.items():
-        total_cpu = sum(p["cpu"] for p in plist)
-        total_mem = sum(p["mem_mb"] for p in plist)
-        main_pid = plist[0]["pid"] if plist else "-"
-        is_worker_active = any(p["type"] == "Worker" for p in plist)
-        statuses[r] = {
-            "status": "online",
-            "busy": is_worker_active,
-            "pid": main_pid,
-            "cpu": total_cpu,
-            "mem_mb": total_mem
-        }
+        if r in statuses:
+            total_cpu = sum(p["cpu"] for p in plist)
+            total_mem = sum(p["mem_mb"] for p in plist)
+            main_pid = plist[0]["pid"] if plist else "-"
+            is_worker_active = any(p["type"] == "Worker" for p in plist)
+            statuses[r] = {
+                "status": "online",
+                "busy": is_worker_active,
+                "pid": main_pid,
+                "cpu": total_cpu,
+                "mem_mb": total_mem
+            }
 
     return statuses
 
@@ -186,11 +187,13 @@ def main():
     parser = argparse.ArgumentParser(description="Real-time process monitor for GitHub Self-Hosted Runners")
     parser.add_argument("--once", action="store_true", help="Print stats once and exit")
     parser.add_argument("--interval", type=int, default=3, help="Refresh interval in seconds (default: 3)")
+    parser.add_argument("--base-dir", type=Path, default=DEFAULT_BASE_DIR, help="Base directory for runners")
+    parser.add_argument("--governance-path", type=Path, default=GOVERNANCE_PATH, help="Path to docs-control governance.json")
     args = parser.parse_args()
 
     try:
         while True:
-            statuses = fetch_gh_runner_statuses()
+            statuses = fetch_gh_runner_statuses(gov_path=args.governance_path, base_dir=args.base_dir)
             render_top_view(statuses, once=args.once)
             if args.once:
                 break

--- a/scripts/runner-top.py
+++ b/scripts/runner-top.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Real-time process monitor for GitHub Self-Hosted Runners in f5-sales-demo.
+
+Displays:
+ - Disk space on /data and /
+ - Fleet summary (Online, Busy, Idle, Offline)
+ - Live process statistics (PID, CPU %, Memory MB, Repo, Status, Current Job)
+ - Interactive mode or single-shot output mode (--once)
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+DEFAULT_BASE_DIR = Path("/data/actions-runners/f5-sales-demo")
+GOVERNANCE_PATH = Path(__file__).resolve().parent.parent / ".claude/governance.json"
+
+
+def get_disk_info(mount_point):
+    try:
+        st = os.statvfs(mount_point)
+        total = (st.f_blocks * st.f_frsize) / (1024 ** 3)
+        free = (st.f_bavail * st.f_frsize) / (1024 ** 3)
+        used = total - free
+        pct = (used / total) * 100 if total > 0 else 0
+        return f"{used:.1f}G/{total:.1f}G ({pct:.0f}%)"
+    except Exception:
+        return "N/A"
+
+
+def get_governed_repos():
+    if not GOVERNANCE_PATH.exists():
+        return []
+    try:
+        with open(GOVERNANCE_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return sorted(list(data.get("repo_classes", {}).get("repos", {}).keys()))
+    except Exception:
+        return []
+
+
+def get_running_processes():
+    """
+    Parse ps aux for Runner.Listener, Runner.Worker, and runsvc.sh processes.
+    """
+    procs = []
+    try:
+        res = subprocess.run(
+            ["ps", "aux"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True
+        )
+        lines = res.stdout.splitlines()
+        header = lines[0].split()
+        for line in lines[1:]:
+            parts = line.split(None, 10)
+            if len(parts) < 11:
+                continue
+            user, pid, cpu, mem, vsz, rss, tty, stat, start, time_str, cmd = parts
+            if "actions-runners/f5-sales-demo" in cmd:
+                # Extract repo name from path
+                # e.g., /data/actions-runners/f5-sales-demo/<repo>/...
+                repo = "unknown"
+                if "/f5-sales-demo/" in cmd:
+                    after_org = cmd.split("/f5-sales-demo/")[1]
+                    repo = after_org.split("/")[0]
+
+                p_type = "Listener"
+                if "Runner.Worker" in cmd:
+                    p_type = "Worker"
+                elif "runsvc.sh" in cmd:
+                    p_type = "Service"
+
+                mem_mb = float(rss) / 1024.0 if rss.isdigit() else 0.0
+
+                procs.append({
+                    "pid": pid,
+                    "user": user,
+                    "cpu": float(cpu) if cpu.replace('.', '', 1).isdigit() else 0.0,
+                    "mem_mb": mem_mb,
+                    "repo": repo,
+                    "type": p_type,
+                    "cmd": cmd
+                })
+    except Exception:
+        pass
+    return procs
+
+
+def fetch_gh_runner_statuses(org="f5-sales-demo"):
+    """
+    Query GitHub API for runner statuses across repos or list via systemctl
+    """
+    repos = get_governed_repos()
+    statuses = {}
+    for repo in repos:
+        repo_dir = DEFAULT_BASE_DIR / repo
+        statuses[repo] = {"status": "offline", "busy": False, "pid": "-", "cpu": 0.0, "mem_mb": 0.0}
+
+    # Aggregate process stats per repo
+    procs = get_running_processes()
+    repo_procs = {}
+    for p in procs:
+        r = p["repo"]
+        if r not in repo_procs:
+            repo_procs[r] = []
+        repo_procs[r].append(p)
+
+    for r, plist in repo_procs.items():
+        total_cpu = sum(p["cpu"] for p in plist)
+        total_mem = sum(p["mem_mb"] for p in plist)
+        main_pid = plist[0]["pid"] if plist else "-"
+        is_worker_active = any(p["type"] == "Worker" for p in plist)
+        statuses[r] = {
+            "status": "online",
+            "busy": is_worker_active,
+            "pid": main_pid,
+            "cpu": total_cpu,
+            "mem_mb": total_mem
+        }
+
+    return statuses
+
+
+def render_top_view(statuses, once=False):
+    total = len(statuses)
+    online = sum(1 for s in statuses.values() if s["status"] == "online")
+    busy = sum(1 for s in statuses.values() if s["busy"])
+    idle = online - busy
+    offline = total - online
+
+    disk_data = get_disk_info("/data")
+    disk_root = get_disk_info("/")
+
+    if not once:
+        # Clear screen and move cursor to top
+        sys.stdout.write("\033[2J\033[H")
+
+    header = f"""
+================================================================================
+  f5-sales-demo Self-Hosted Runner Monitor  [{time.strftime('%Y-%m-%d %H:%M:%S')}]
+================================================================================
+  Disk /data: {disk_data:<20} Disk /: {disk_root:<20}
+  Fleet: {total} Total | \033[32m{online} Online\033[0m (\033[33m{busy} Busy\033[0m, \033[36m{idle} Idle\033[0m) | \033[31m{offline} Offline\033[0m
+================================================================================
+  {"REPO NAME":<30} {"STATUS":<12} {"PID":<8} {"CPU %":<8} {"MEM (MB)":<10}
+--------------------------------------------------------------------------------"""
+    print(header)
+
+    for repo, data in sorted(statuses.items()):
+        st = data["status"]
+        if st == "online":
+            if data["busy"]:
+                st_str = "\033[33mONLINE (BUSY)\033[0m"
+            else:
+                st_str = "\033[32mONLINE (IDLE)\033[0m"
+        else:
+            st_str = "\033[31mOFFLINE\033[0m"
+
+        pid_str = str(data["pid"])
+        cpu_str = f"{data['cpu']:.1f}%" if data['status'] == 'online' else "-"
+        mem_str = f"{data['mem_mb']:.1f} MB" if data['status'] == 'online' else "-"
+
+        print(f"  {repo:<30} {st_str:<23} {pid_str:<8} {cpu_str:<8} {mem_str:<10}")
+
+    print("================================================================================")
+    if not once:
+        print("Press Ctrl+C to exit monitor.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Real-time process monitor for GitHub Self-Hosted Runners")
+    parser.add_argument("--once", action="store_true", help="Print stats once and exit")
+    parser.add_argument("--interval", type=int, default=3, help="Refresh interval in seconds (default: 3)")
+    args = parser.parse_args()
+
+    try:
+        while True:
+            statuses = fetch_gh_runner_statuses()
+            render_top_view(statuses, once=args.once)
+            if args.once:
+                break
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("\nExiting runner monitor.")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/runner-top.py
+++ b/scripts/runner-top.py
@@ -44,11 +44,12 @@ def get_governed_repos(gov_path=GOVERNANCE_PATH):
         return []
 
 
-def get_running_processes():
+def get_running_processes(base_dir=DEFAULT_BASE_DIR):
     """
     Parse ps aux for Runner.Listener, Runner.Worker, and runsvc.sh processes.
     """
     procs = []
+    base_dir_str = str(Path(base_dir).resolve())
     try:
         res = subprocess.run(
             ["ps", "aux"],
@@ -58,19 +59,21 @@ def get_running_processes():
             check=True
         )
         lines = res.stdout.splitlines()
-        header = lines[0].split()
         for line in lines[1:]:
             parts = line.split(None, 10)
             if len(parts) < 11:
                 continue
             user, pid, cpu, mem, vsz, rss, tty, stat, start, time_str, cmd = parts
-            if "actions-runners/f5-sales-demo" in cmd:
-                # Extract repo name from path
-                # e.g., /data/actions-runners/f5-sales-demo/<repo>/...
+            if base_dir_str in cmd or "actions-runners/" in cmd:
+                # Extract repo name from path relative to base_dir
                 repo = "unknown"
-                if "/f5-sales-demo/" in cmd:
-                    after_org = cmd.split("/f5-sales-demo/")[1]
-                    repo = after_org.split("/")[0]
+                if base_dir_str in cmd:
+                    after_base = cmd.split(base_dir_str)[1].lstrip("/")
+                    repo = after_base.split("/")[0] if after_base else "unknown"
+                elif "actions-runners/" in cmd:
+                    parts_path = cmd.split("actions-runners/")[1].split("/")
+                    if len(parts_path) >= 2:
+                        repo = parts_path[1]
 
                 p_type = None
                 if "Runner.Listener" in cmd:
@@ -109,7 +112,7 @@ def fetch_gh_runner_statuses(gov_path=GOVERNANCE_PATH, base_dir=DEFAULT_BASE_DIR
         statuses[repo] = {"status": "offline", "busy": False, "pid": "-", "cpu": 0.0, "mem_mb": 0.0}
 
     # Aggregate process stats per repo
-    procs = get_running_processes()
+    procs = get_running_processes(base_dir=base_dir)
     repo_procs = {}
     for p in procs:
         r = p["repo"]

--- a/scripts/runner-top.py
+++ b/scripts/runner-top.py
@@ -72,11 +72,15 @@ def get_running_processes():
                     after_org = cmd.split("/f5-sales-demo/")[1]
                     repo = after_org.split("/")[0]
 
-                p_type = "Listener"
-                if "Runner.Worker" in cmd:
+                p_type = None
+                if "Runner.Listener" in cmd:
+                    p_type = "Listener"
+                elif "Runner.Worker" in cmd:
                     p_type = "Worker"
                 elif "runsvc.sh" in cmd:
                     p_type = "Service"
+                else:
+                    continue
 
                 mem_mb = float(rss) / 1024.0 if rss.isdigit() else 0.0
 
@@ -96,7 +100,7 @@ def get_running_processes():
 
 def fetch_gh_runner_statuses(org="f5-sales-demo"):
     """
-    Query GitHub API for runner statuses across repos or list via systemctl
+    Aggregate local runner process status across governed repositories.
     """
     repos = get_governed_repos()
     statuses = {}
@@ -150,7 +154,7 @@ def render_top_view(statuses, once=False):
   Disk /data: {disk_data:<20} Disk /: {disk_root:<20}
   Fleet: {total} Total | \033[32m{online} Online\033[0m (\033[33m{busy} Busy\033[0m, \033[36m{idle} Idle\033[0m) | \033[31m{offline} Offline\033[0m
 ================================================================================
-  {"REPO NAME":<30} {"STATUS":<12} {"PID":<8} {"CPU %":<8} {"MEM (MB)":<10}
+  {"REPO NAME":<30} {"STATUS":<15} {"PID":<8} {"CPU %":<8} {"MEM (MB)":<10}
 --------------------------------------------------------------------------------"""
     print(header)
 
@@ -158,17 +162,20 @@ def render_top_view(statuses, once=False):
         st = data["status"]
         if st == "online":
             if data["busy"]:
-                st_str = "\033[33mONLINE (BUSY)\033[0m"
+                raw_st = "ONLINE (BUSY)"
+                st_str = f"\033[33m{raw_st:<15}\033[0m"
             else:
-                st_str = "\033[32mONLINE (IDLE)\033[0m"
+                raw_st = "ONLINE (IDLE)"
+                st_str = f"\033[32m{raw_st:<15}\033[0m"
         else:
-            st_str = "\033[31mOFFLINE\033[0m"
+            raw_st = "OFFLINE"
+            st_str = f"\033[31m{raw_st:<15}\033[0m"
 
         pid_str = str(data["pid"])
         cpu_str = f"{data['cpu']:.1f}%" if data['status'] == 'online' else "-"
         mem_str = f"{data['mem_mb']:.1f} MB" if data['status'] == 'online' else "-"
 
-        print(f"  {repo:<30} {st_str:<23} {pid_str:<8} {cpu_str:<8} {mem_str:<10}")
+        print(f"  {repo:<30} {st_str} {pid_str:<8} {cpu_str:<8} {mem_str:<10}")
 
     print("================================================================================")
     if not once:


### PR DESCRIPTION
Resolves #1131

## Overview
Adds administrative and monitoring scripts for self-hosted GitHub Actions runners across the `f5-sales-demo` ecosystem:

- `scripts/manage-github-runners.py`: Configures, provisions, starts, stops, cleans up, and health-checks runner systemd services for all governed repositories declared in `.claude/governance.json`.
- `scripts/runner-top.py`: Real-time TUI process monitor for local self-hosted runners displaying disk usage, fleet summary, PID, CPU %, memory usage, and active job status.

## Verification
- Syntax check (`python3 -m py_compile`) passed cleanly.
- Tested `runner-top.py --once` and `manage-github-runners.py health-check` live against active processes.
- Sandboxed local code review gate (`bash scripts/agy-pre-push-review.sh`) completed with 0 findings.