### PR TITLE
fix(governance): align consumer linked-issue context

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -33,7 +33,7 @@
       "enforce_admins": true,
       "required_status_checks": {
         "strict": true,
-        "contexts": ["check / Check linked issues", "lint / Lint Code Base", "lint / Shell Unit Tests"],
+        "contexts": ["Check linked issues", "lint / Lint Code Base", "lint / Shell Unit Tests"],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
       "required_pull_request_reviews": null,

--- a/tests/test-privileged-pr-workflows.sh
+++ b/tests/test-privileged-pr-workflows.sh
@@ -68,16 +68,23 @@ done
 for file in \
   "$REPO_ROOT/workflows/require-linked-issue.yml" \
   "$REPO_ROOT/.github/workflows/require-linked-issue.yml"; do
-  required_context=$(jq -r '
-    .branch_protection[0].required_status_checks.self_contexts[]
-    | select(endswith("Check linked issues"))
-  ' "$REPO_ROOT/.github/config/repo-settings.json")
   published_context=$(sed -n 's/.*const STATUS_CONTEXT = "\([^"]*\)";.*/\1/p' "$file")
-  if [ -n "$required_context" ] && [ "$published_context" = "$required_context" ]; then
-    pass "${file#"$REPO_ROOT/"} publishes the exact required self-repository context"
-  else
-    fail "${file#"$REPO_ROOT/"} publishes the exact required self-repository context"
-  fi
+  for context_scope in contexts self_contexts; do
+    case "$context_scope" in
+    contexts) context_label="consumer" ;;
+    self_contexts) context_label="self-repository" ;;
+    esac
+    required_context=$(jq -r --arg scope "$context_scope" '
+      .branch_protection[0].required_status_checks[$scope]
+      | map(select(endswith("Check linked issues")))
+      | if length == 1 then .[0] else empty end
+    ' "$REPO_ROOT/.github/config/repo-settings.json")
+    if [ -n "$required_context" ] && [ "$published_context" = "$required_context" ]; then
+      pass "${file#"$REPO_ROOT/"} publishes the exact required $context_label context"
+    else
+      fail "${file#"$REPO_ROOT/"} publishes the exact required $context_label context"
+    fi
+  done
   require_literal "$file" 'const headSha = pull.head.sha;' "${file#"$REPO_ROOT/"} publishes status on the current PR head"
   require_literal "$file" 'github.paginate(github.rest.pulls.list' "${file#"$REPO_ROOT/"} evaluates every open pull request"
   require_literal "$file" 'postStatus("pending"' "${file#"$REPO_ROOT/"} publishes a pending status before evaluation"


### PR DESCRIPTION
## Summary

Align the downstream linked-issue required context with the status actually published by the managed scheduled workflow.

## Related Issue

Closes #1134

## Changes

- Require `Check linked issues` for governed consumers instead of the stale `check / Check linked issues` context.
- Assert both consumer and self-repository settings match both managed workflow publishers.

## Verification evidence

- Red: `bash tests/test-privileged-pr-workflows.sh` failed both new consumer-context assertions before the settings correction.
- Green: `bash tests/test-privileged-pr-workflows.sh` passed after the correction.
- `bash tests/test-linter-configs.sh`: 158 passed, 0 failed.
- Complete `tests/test-*.sh` inventory: 36 scripts passed, 0 failed.
- `bash scripts/agy-pre-push-review.sh`: no blocking or medium findings; one non-blocking documentation-drift nit outside this issue's settings/test scope.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
