### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,17 +1,17 @@
 {
-  "source_commit": "854a1bc6cecb6144c62d5d9bf93c904ad55add7f",
+  "source_commit": "4b8a030ecececebb2e01a1f30004a19b527c586d",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
       "dest": ".github/workflows/github-pages-deploy.yml",
-      "sha": "79191fdd7c0cf49ab862052a186c1087302903e1",
+      "sha": "4749e0fa37b5fcd6e0ae32af4b80bc8f36cef67f",
       "size": 855,
       "mode": "100644"
     },
     ".github/workflows/enforce-repo-settings.yml": {
       "src": "workflows/enforce-repo-settings.yml",
       "dest": ".github/workflows/enforce-repo-settings.yml",
-      "sha": "85ce32707519770470880116b87069d3f2241b14",
+      "sha": "cf31f03f3ce8af3b5e2f3759e134947ac6962060",
       "size": 11636,
       "mode": "100644"
     },
@@ -25,28 +25,28 @@
     ".github/workflows/super-linter.yml": {
       "src": "workflows/super-linter.yml",
       "dest": ".github/workflows/super-linter.yml",
-      "sha": "101c60c85dc3c6e3ce4f5533fbdde3cf581f77e6",
+      "sha": "69e0862a95a15159fee0a938de6f51ffff303bda",
       "size": 800,
       "mode": "100644"
     },
     ".github/workflows/translation-audit.yml": {
       "src": "workflows/translation-audit.yml",
       "dest": ".github/workflows/translation-audit.yml",
-      "sha": "6ac0a99435526d1d55efa632a90033a02bb4f106",
+      "sha": "dc4c01e76c3079f2360b3f765b0646bdb38b2996",
       "size": 1697,
       "mode": "100644"
     },
     ".github/workflows/antigravity-review.yml": {
       "src": "workflows/antigravity-review.yml",
       "dest": ".github/workflows/antigravity-review.yml",
-      "sha": "4418968c2d408c8ff9dbc5098fe5a10133c3954c",
+      "sha": "1e67ba9712e879a07476a93f6be6e9fde0c1540c",
       "size": 1959,
       "mode": "100644"
     },
     ".github/workflows/antigravity-translate.yml": {
       "src": "workflows/antigravity-translate.yml",
       "dest": ".github/workflows/antigravity-translate.yml",
-      "sha": "b42ede973e445466b0d786fdcb339949403fd084",
+      "sha": "577b7db62bb74a5f9e930a1bd5bf971d8100202d",
       "size": 2164,
       "mode": "100644"
     },
@@ -186,7 +186,7 @@
     ".github/workflows/auto-merge.yml": {
       "src": "workflows/auto-merge.yml",
       "dest": ".github/workflows/auto-merge.yml",
-      "sha": "d9f39a5f924c2ee82d1294a2f2b52a67ab9e299b",
+      "sha": "aa2f140e19a2ef35a21eeaead07b2b176577dbdd",
       "size": 1381,
       "mode": "100644"
     },


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.