### PR TITLE
fix(ci): restore runner ownership after lint

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -406,6 +406,26 @@ jobs:
           VALIDATE_GO_MODULES: false
           VALIDATE_GO_REVIVE: false
 
+      # The container recreates github_conf/ and super-linter-output/ as root.
+      # Repairing only before checkout leaves a race: another workflow can start
+      # after this container exits but before the next lint preflight, and its
+      # checkout then cannot clean the shared self-hosted workspace. Always
+      # restore ownership here, including when lint itself fails.
+      - name: Restore self-hosted runner workspace ownership
+        if: always() && runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          workspace="${GITHUB_WORKSPACE:?}"
+          repository="${GITHUB_REPOSITORY:?}"
+          repository_name="${repository##*/}"
+          expected_workspace="${RUNNER_WORKSPACE:?}/${repository_name}"
+          if ! [ "$workspace" = "$expected_workspace" ]; then
+            echo "::error::Refusing to repair unexpected workspace: ${workspace}"
+            exit 1
+          fi
+          sudo -n chown -R -- "$(id -u):$(id -g)" "$workspace"
+
       - name: Spectral OpenAPI lint
         if: hashFiles('.spectral.yaml', '.spectral.yml') != ''
         uses: stoplightio/spectral-action@6416fd018ae38e60136775066eb3e98172143141 # v0.8.13

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1196,7 +1196,8 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════
-# SECTION 17: self-hosted docs-control jobs repair Docker-owned output
+# SECTION 17: self-hosted jobs repair Docker-owned output before and
+#             after Super-Linter runs
 # ════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== Section 17: self-hosted workspace ownership repair ==="
@@ -1236,11 +1237,35 @@ for job_name in ("lint", "shell-unit-tests"):
         raise SystemExit(1)
     if any(fragment in command for fragment in forbidden_fragments):
         raise SystemExit(1)
+
+lint_steps = workflow["jobs"]["lint"]["steps"]
+super_linter_steps = [step for step in lint_steps if step.get("name") == "Run Super-Linter"]
+restores = [
+    step
+    for step in lint_steps
+    if step.get("name") == "Restore self-hosted runner workspace ownership"
+]
+if len(super_linter_steps) != 1 or len(restores) != 1:
+    raise SystemExit(1)
+restore = restores[0]
+if lint_steps.index(restore) <= lint_steps.index(super_linter_steps[0]):
+    raise SystemExit(1)
+if restore.get("if") != "always() && runner.environment == 'self-hosted'":
+    raise SystemExit(1)
+if restore.get("shell") != "bash":
+    raise SystemExit(1)
+restore_command = restore.get("run", "")
+if any(fragment not in restore_command for fragment in required_fragments):
+    raise SystemExit(1)
+if any(fragment in restore_command for fragment in forbidden_fragments):
+    raise SystemExit(1)
+if "rm " in restore_command or "rm\n" in restore_command:
+    raise SystemExit(1)
 PY
-  pass "17.1 lint and shell jobs repair only the exact calling repository workspace before checkout"
+  pass "17.1 jobs repair the exact workspace before checkout and after Super-Linter"
 else
-  fail "17.1 lint and shell jobs repair only the exact calling repository workspace before checkout" \
-    "both jobs need the guarded ownership repair before actions/checkout"
+  fail "17.1 jobs repair the exact workspace before checkout and after Super-Linter" \
+    "the lint job needs guarded pre-checkout repair and unconditional post-lint restoration"
 fi
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Restore self-hosted runner workspace ownership after Super-Linter finishes so concurrent and subsequent workflows cannot race root-owned container output.

## Related Issue

Closes #1154

## Changes

- add an `if: always()` self-hosted ownership restoration after the Super-Linter container
- retain the exact disposable-workspace guard and non-interactive ownership change
- extend the linter configuration contract to enforce ordering, conditions, path bounds, and non-deletion

## Verification evidence

- TDD red: `bash tests/test-linter-configs.sh` — 158 passed, 1 failed before implementation
- TDD green: `bash tests/test-linter-configs.sh` — 159 passed, 0 failed
- `actionlint .github/workflows/super-linter.yml` — pass
- `yamllint -c .yamllint.yaml .github/workflows/super-linter.yml` — pass
- `zizmor --no-config --no-ignores --persona=auditor .github/workflows/super-linter.yml` — no findings
- `pre-commit run --all-files` — all applicable hooks passed
- `bash scripts/agy-pre-push-review.sh` at `fe00336e215a25450dff2a48467b5bd8b7f52770` — no findings; PII enforce clean; 159/159 regression checks passed

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions