### PR TITLE
fix(ci): settle manifest PR head propagation

### DIFF
--- a/.github/workflows/build-managed-files-manifest.yml
+++ b/.github/workflows/build-managed-files-manifest.yml
@@ -297,6 +297,85 @@ jobs:
             esac
           }
 
+          assert_exact_remote_manifest_ref() {
+            local expected_sha="$1" framed remote_sha rc
+            if ! printf '%s' "$expected_sha" | grep -qE '^[0-9a-f]{40}$'; then
+              echo "[ERROR] Invalid expected manifest ref receipt" >&2
+              return 1
+            fi
+            set +e
+            framed=$(git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" &&
+              printf '\034')
+            rc=$?
+            set -e
+            if [ "$rc" -ne 0 ]; then
+              echo "[ERROR] Could not re-prove the pushed manifest ref" >&2
+              return 1
+            fi
+            remote_sha=${framed%%$'\t'*}
+            if [[ ! "$remote_sha" =~ ^[0-9a-f]{40}$ ]] ||
+              [ "$framed" != "${remote_sha}"$'\trefs/heads/'"${BRANCH}"$'\n\034' ] ||
+              [ "$remote_sha" != "$expected_sha" ]; then
+              echo "[ERROR] Remote manifest ref changed after the exact push" >&2
+              return 1
+            fi
+          }
+
+          settle_owned_manifest_pr() {
+            local expected_sha="$1" expected_pr_num="$2" stale_sha="$3"
+            local attempt inventory row rc actual_pr_num actual_head
+            if ! printf '%s' "$expected_sha" | grep -qE '^[0-9a-f]{40}$' ||
+              ! printf '%s' "$expected_pr_num" | grep -qE '^[1-9][0-9]*$' ||
+              { [ -n "$stale_sha" ] &&
+                ! printf '%s' "$stale_sha" | grep -qE '^[0-9a-f]{40}$'; }; then
+              echo "[ERROR] Invalid manifest PR settlement receipt" >&2
+              return 1
+            fi
+
+            for attempt in 1 2 3 4 5 6; do
+              if ! assert_exact_remote_manifest_ref "$expected_sha"; then
+                return 1
+              fi
+
+              inventory=$(mktemp)
+              if ! read_manifest_prs "$inventory"; then
+                rm -f "$inventory"
+                return 1
+              fi
+              set +e
+              row=$(select_owned_manifest_pr "$inventory")
+              rc=$?
+              set -e
+              rm -f "$inventory"
+              if [ "$rc" -ne 0 ]; then
+                return "$rc"
+              fi
+              if [ -n "$row" ]; then
+                IFS=$'\t' read -r actual_pr_num actual_head <<<"$row"
+                if [ "$actual_pr_num" != "$expected_pr_num" ]; then
+                  echo "[ERROR] Manifest PR ownership changed after the exact push" >&2
+                  return 1
+                fi
+                if [ "$actual_head" = "$expected_sha" ]; then
+                  if ! assert_exact_remote_manifest_ref "$expected_sha"; then
+                    return 1
+                  fi
+                  printf '%s\n' "$row"
+                  return 0
+                fi
+                if [ -z "$stale_sha" ] || [ "$actual_head" != "$stale_sha" ]; then
+                  echo "[ERROR] Manifest PR reported an unrecognized head after the exact push" >&2
+                  return 1
+                fi
+              fi
+              if [ "$attempt" -lt 6 ]; then
+                sleep 2
+              fi
+            done
+            echo "[ERROR] Manifest PR head did not settle to the exact pushed commit" >&2
+            return 1
+          }
+
           assert_manifest_pr_head() {
             local pr_num="$1" expected_sha="$2" response
             if ! printf '%s' "$pr_num" | grep -qE '^[1-9][0-9]*$' ||
@@ -435,18 +514,17 @@ jobs:
               origin "HEAD:refs/heads/$BRANCH"
           fi
 
-          # Re-inventory after the lease-protected push. A concurrent PR or
-          # head change must be proved before it can be selected.
+          # Re-inventory after the lease-protected push. A concurrent PR must
+          # never be adopted as the workflow's own publication.
           MANIFEST_PR_INVENTORY=$(mktemp)
           read_manifest_prs "$MANIFEST_PR_INVENTORY"
           MANIFEST_PR_ROW=$(select_owned_manifest_pr "$MANIFEST_PR_INVENTORY")
-          if [ -z "$MANIFEST_PR_ROW" ]; then
-            if [ -n "$PR_NUM" ]; then
-              echo "[ERROR] Inventoried manifest PR disappeared after the exact push" >&2
-              rm -f "$MANIFEST_PR_INVENTORY"
+          rm -f "$MANIFEST_PR_INVENTORY"
+          if [ -z "$PR_NUM" ]; then
+            if [ -n "$MANIFEST_PR_ROW" ]; then
+              echo "[ERROR] An unowned manifest PR appeared after the exact push" >&2
               exit 1
             fi
-            rm -f "$MANIFEST_PR_INVENTORY"
             PR_URL=$(gh pr create --repo "$GITHUB_REPOSITORY" \
               --base main --head "$BRANCH" \
               --title "chore(governance): regenerate managed-files-manifest.json" \
@@ -456,23 +534,13 @@ jobs:
               echo "[ERROR] Manifest PR creation returned an invalid URL" >&2
               exit 1
             fi
-            MANIFEST_PR_INVENTORY=$(mktemp)
-            read_manifest_prs "$MANIFEST_PR_INVENTORY"
-            MANIFEST_PR_ROW=$(select_owned_manifest_pr "$MANIFEST_PR_INVENTORY")
-          else
-            IFS=$'\t' read -r ACTUAL_PR_NUM ACTUAL_HEAD <<<"$MANIFEST_PR_ROW"
-            if [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] ||
-              { [ -n "$PR_NUM" ] && [ "$ACTUAL_PR_NUM" != "$PR_NUM" ]; }; then
-              echo "[ERROR] Manifest PR ownership or head changed after the exact push" >&2
-              rm -f "$MANIFEST_PR_INVENTORY"
-              exit 1
-            fi
-            PR_NUM="$ACTUAL_PR_NUM"
           fi
-          rm -f "$MANIFEST_PR_INVENTORY"
-
-          if [ -z "$MANIFEST_PR_ROW" ]; then
-            echo "[ERROR] Manifest PR was not present after creation" >&2
+          set +e
+          MANIFEST_PR_ROW=$(settle_owned_manifest_pr \
+            "$EXPECTED_HEAD" "$PR_NUM" "$INVENTORIED_HEAD")
+          SETTLE_RC=$?
+          set -e
+          if [ "$SETTLE_RC" -ne 0 ]; then
             exit 1
           fi
           IFS=$'\t' read -r FINAL_PR_NUM FINAL_HEAD <<<"$MANIFEST_PR_ROW"

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -518,6 +518,176 @@ else
   fail "7.6 duplicate manifest PR owners are rejected" "selection helper is absent"
 fi
 
+awk '
+  /^          settle_owned_manifest_pr\(\) \{/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$MANIFEST_BUILDER" >"$WORK/settle-owned-manifest-pr.sh"
+
+awk '
+  /^          assert_exact_remote_manifest_ref\(\) \{/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$MANIFEST_BUILDER" >"$WORK/assert-exact-remote-manifest-ref.sh"
+
+cat >"$WORK/manifest-settle-stubs.sh" <<'EOF'
+read_manifest_prs() {
+  local destination="$1" count=0 head_sha="$expected_sha"
+  if [ -f "$count_file" ]; then
+    count=$(cat "$count_file")
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$count_file"
+  case "$mode" in
+  api-failure) return 1 ;;
+  delayed) [ "$count" -gt 1 ] || head_sha="$stale_sha" ;;
+  stale) head_sha="$stale_sha" ;;
+  competing) head_sha="$competing_sha" ;;
+  duplicate)
+    jq -n --arg expected "$expected_sha" --arg stale "$stale_sha" \
+      --arg repo "$GITHUB_REPOSITORY" '
+        [[{number: 21,
+           head: {ref: "sync/manifest", sha: $expected,
+                  repo: {full_name: $repo}},
+           base: {ref: "main"}},
+          {number: 22,
+           head: {ref: "sync/manifest", sha: $stale,
+                  repo: {full_name: $repo}},
+           base: {ref: "main"}}]]
+      ' >"$destination"
+    return 0
+    ;;
+  remote-changed)
+    stub_remote_sha="$competing_sha"
+    ;;
+  esac
+  jq -n --arg sha "$head_sha" --arg repo "$GITHUB_REPOSITORY" '
+    [[{number: 21,
+       head: {ref: "sync/manifest", sha: $sha,
+              repo: {full_name: $repo}},
+       base: {ref: "main"}}]]
+  ' >"$destination"
+}
+git() {
+  if [ "$*" != "ls-remote --exit-code --heads origin refs/heads/$BRANCH" ]; then
+    return 99
+  fi
+  printf '%s\trefs/heads/%s\n' "$stub_remote_sha" "$BRANCH"
+  if [ "$mode" = "remote-malformed" ]; then
+    printf 'unexpected trailing row\n'
+  fi
+}
+sleep() { :; }
+EOF
+
+run_manifest_settle() (
+  local mode="$1" count_file="$2"
+  local expected_sha=abcdef0123456789abcdef0123456789abcdef01
+  local stale_sha=0123456789abcdef0123456789abcdef01234567
+  local competing_sha=1111111111111111111111111111111111111111
+  local stub_remote_sha="$expected_sha"
+  # shellcheck source=/dev/null
+  source "$WORK/select-owned-manifest-pr.sh"
+  # shellcheck source=/dev/null
+  source "$WORK/assert-exact-remote-manifest-ref.sh"
+  # shellcheck source=/dev/null
+  source "$WORK/settle-owned-manifest-pr.sh"
+  # shellcheck source=/dev/null
+  source "$WORK/manifest-settle-stubs.sh"
+  GITHUB_REPOSITORY=example/docs-control
+  BRANCH=sync/manifest
+
+  settle_owned_manifest_pr "$expected_sha" 21 "$stale_sha"
+)
+
+if [ -s "$WORK/settle-owned-manifest-pr.sh" ] &&
+  [ -s "$WORK/assert-exact-remote-manifest-ref.sh" ]; then
+  count_file="$WORK/manifest-settle-delayed.count"
+  if settled=$(run_manifest_settle delayed "$count_file") &&
+    [ "$settled" = $'21\tabcdef0123456789abcdef0123456789abcdef01' ] &&
+    [ "$(cat "$count_file")" -eq 2 ]; then
+    pass "7.7 delayed manifest PR head propagation settles to the exact pushed head"
+  else
+    fail "7.7 delayed manifest PR head propagation settles to the exact pushed head" \
+      "the bounded verifier did not accept one stale receipt followed by the exact head"
+  fi
+
+  count_file="$WORK/manifest-settle-competing.count"
+  if run_manifest_settle competing "$count_file" >/dev/null 2>&1 ||
+    [ "$(cat "$count_file")" -ne 1 ]; then
+    fail "7.8 an unrecognized manifest PR head fails immediately" \
+      "a competing head was retried or accepted as propagation delay"
+  else
+    pass "7.8 an unrecognized manifest PR head fails immediately"
+  fi
+
+  count_file="$WORK/manifest-settle-remote.count"
+  if run_manifest_settle remote-changed "$count_file" >/dev/null 2>&1; then
+    fail "7.9 a changed remote manifest ref fails immediately" \
+      "the verifier accepted a ref outside its lease-protected push"
+  else
+    pass "7.9 a changed remote manifest ref fails immediately"
+  fi
+
+  count_file="$WORK/manifest-settle-malformed.count"
+  if run_manifest_settle remote-malformed "$count_file" >/dev/null 2>&1; then
+    fail "7.9a malformed remote manifest receipts fail immediately" \
+      "the verifier ignored unparsed remote output"
+  else
+    pass "7.9a malformed remote manifest receipts fail immediately"
+  fi
+
+  count_file="$WORK/manifest-settle-api.count"
+  if run_manifest_settle api-failure "$count_file" >/dev/null 2>&1 ||
+    [ "$(cat "$count_file")" -ne 1 ]; then
+    fail "7.10 manifest inventory API failure is not retried as stale data" \
+      "a read failure was retried or accepted"
+  else
+    pass "7.10 manifest inventory API failure is not retried as stale data"
+  fi
+
+  count_file="$WORK/manifest-settle-duplicate.count"
+  if run_manifest_settle duplicate "$count_file" >/dev/null 2>&1 ||
+    [ "$(cat "$count_file")" -ne 1 ]; then
+    fail "7.11 duplicate manifest PR ownership fails immediately during settlement" \
+      "duplicate owners were retried or accepted"
+  else
+    pass "7.11 duplicate manifest PR ownership fails immediately during settlement"
+  fi
+
+  count_file="$WORK/manifest-settle-exhausted.count"
+  if run_manifest_settle stale "$count_file" >/dev/null 2>&1 ||
+    [ "$(cat "$count_file")" -ne 6 ]; then
+    fail "7.12 manifest PR head propagation has a bounded retry budget" \
+      "permanently stale data did not fail after six exact inventories"
+  else
+    pass "7.12 manifest PR head propagation has a bounded retry budget"
+  fi
+else
+  fail "7.7 delayed manifest PR head propagation settles to the exact pushed head" \
+    "settlement helper is absent"
+  fail "7.8 an unrecognized manifest PR head fails immediately" \
+    "settlement helper is absent"
+  fail "7.9 a changed remote manifest ref fails immediately" \
+    "settlement helper is absent"
+  fail "7.9a malformed remote manifest receipts fail immediately" \
+    "settlement helper is absent"
+  fail "7.10 manifest inventory API failure is not retried as stale data" \
+    "settlement helper is absent"
+  fail "7.11 duplicate manifest PR ownership fails immediately during settlement" \
+    "settlement helper is absent"
+  fail "7.12 manifest PR head propagation has a bounded retry budget" \
+    "settlement helper is absent"
+fi
+
 echo ""
 echo "=== Section 8: protected-source and exact mutation receipts ==="
 


### PR DESCRIPTION
## Summary

Tolerate GitHub’s bounded post-push PR-head propagation delay without weakening exact ownership, ref, diff, or matched-head merge guarantees.

## Related Issue

Closes #1160

## Changes

- verify the remote `sync/manifest` ref through an exact framed Git receipt before and after every accepted PR inventory
- retry only a missing row or the previously inventoried head for six bounded reads
- fail immediately on an unrecognized head, changed or malformed remote ref, API failure, duplicate owner, or changed PR number
- refuse to adopt a concurrently appeared PR when this run created the branch
- preserve exact manifest-only diff verification and matched-head auto-merge

## Verification evidence

- production failure reproduced in run 30879129172: pushed exact `c2cbecc`, then received the stale PR-head receipt
- TDD red: `bash tests/test-sync-managed-files.sh` — 62 passed, 6 failed before implementation
- TDD green: `bash tests/test-sync-managed-files.sh` — 69 passed, 0 failed
- `bash tests/test-linter-configs.sh` — 159 passed, 0 failed
- `bash tests/test-agent-guidance.sh` — 41 passed, 0 failed
- `pre-commit run --files .github/workflows/build-managed-files-manifest.yml tests/test-sync-managed-files.sh` — all applicable hooks passed
- `bash scripts/agy-pre-push-review.sh` at `ed89ed6` — PII enforce clean; 69/69 tests passed; zero findings

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue’s acceptance criteria are met
- [x] Verified locally by exercising delayed, hostile, malformed, failed, and exhausted settlement paths
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions