### PR TITLE
fix(governance): stage linked evaluator transitions

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -5,6 +5,15 @@ on:
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Exact pull request to evaluate, including a just-merged bootstrap PR
+        required: false
+        type: string
+      expected_head_sha:
+        description: Full head SHA that the targeted pull request must still reference
+        required: false
+        type: string
 
 permissions: {}
 
@@ -43,12 +52,31 @@ jobs:
               globToRegex(pattern.trim()),
             );
 
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner,
-              repo,
-              state: "open",
-              per_page: 100,
-            });
+            const inputs = context.eventName === "workflow_dispatch" ? context.payload.inputs ?? {} : {};
+            const requestedNumber = inputs.pull_request_number ?? "";
+            const requestedHead = inputs.expected_head_sha ?? "";
+            let pulls;
+            if (requestedNumber !== "" || requestedHead !== "") {
+              if (!/^[1-9][0-9]*$/.test(requestedNumber) || !/^[0-9a-f]{40}$/.test(requestedHead)) {
+                throw new Error("Targeted linked-issue evaluation requires an exact PR number and head SHA");
+              }
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: Number(requestedNumber),
+              });
+              if (pull.head.sha !== requestedHead) {
+                throw new Error(`PR #${requestedNumber} head changed before linked-issue evaluation`);
+              }
+              pulls = [pull];
+            } else {
+              pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100,
+              });
+            }
             const evaluationErrors = [];
 
             for (const pull of pulls) {

--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Deliver the exact enforcement and Super-Linter callers through bounded,
-# monotonic PRs before any reusable governance implementation is invoked.
+# Deliver the exact enforcement, Super-Linter, and linked-issue workflows
+# through bounded, monotonic PRs before reusable governance is invoked.
 set -euo pipefail
 
 repository="${GITHUB_REPOSITORY:-}"
@@ -13,8 +13,12 @@ rollout_config="${ROLLOUT_CONFIG:-.github/config/governance-rollout.json}"
 repo_settings_config="${REPO_SETTINGS_CONFIG:-.github/config/repo-settings.json}"
 caller_path=".github/workflows/enforce-repo-settings.yml"
 lint_caller_path=".github/workflows/super-linter.yml"
+linked_caller_path=".github/workflows/require-linked-issue.yml"
+linked_context="Check linked issues"
+legacy_linked_context="check / Check linked issues"
 wait_seconds="${BOOTSTRAP_WAIT_SECONDS:-1800}"
 poll_seconds="${BOOTSTRAP_POLL_SECONDS:-30}"
+linked_wait_seconds="${BOOTSTRAP_LINKED_WAIT_SECONDS:-300}"
 
 if ! printf '%s' "$source_sha" | grep -qE '^[0-9a-f]{40}$'; then
   echo "[ERROR] Source receipt must be a full lowercase commit SHA" >&2
@@ -30,7 +34,8 @@ if ! printf '%s' "$run_id" | grep -qE '^[1-9][0-9]*$' ||
   exit 1
 fi
 if ! printf '%s' "$wait_seconds" | grep -qE '^[0-9]+$' ||
-  ! printf '%s' "$poll_seconds" | grep -qE '^[1-9][0-9]*$'; then
+  ! printf '%s' "$poll_seconds" | grep -qE '^[1-9][0-9]*$' ||
+  ! printf '%s' "$linked_wait_seconds" | grep -qE '^[0-9]+$'; then
   echo "[ERROR] Bootstrap wait configuration is invalid" >&2
   exit 1
 fi
@@ -88,11 +93,16 @@ gh() {
   else
     rc=$?
   fi
-  cat "$err_file" >&2
   if grep -qiE 'rate limit|\(HTTP 429\)$' "$err_file"; then
+    cat "$err_file" >&2
     rm -f "$err_file"
     return 84
   fi
+  if grep -qE '\(HTTP 422\)$' "$err_file"; then
+    rm -f "$err_file"
+    return 85
+  fi
+  cat "$err_file" >&2
   rm -f "$err_file"
   return "$rc"
 }
@@ -139,7 +149,7 @@ retry() {
     )
     rc=$?
     if [ "$rc" -eq 0 ] || [ "$rc" -eq 74 ] || [ "$rc" -eq 75 ] ||
-      [ "$rc" -eq 84 ]; then
+      [ "$rc" -eq 76 ] || [ "$rc" -eq 84 ] || [ "$rc" -eq 85 ]; then
       return "$rc"
     fi
     if [ "$attempt" -ge "$max" ]; then
@@ -215,11 +225,23 @@ normalize_required_checks() {
   jq -c '{strict: .strict, contexts: (.contexts | unique | sort)}'
 }
 
-reconcile_required_checks() {
-  local name="$1" slug endpoint desired current current_state verified rc payload
+transition_required_checks_for_repo() {
+  local name="$1" desired
+  desired=$(required_checks_for_repo "$name")
+  printf '%s' "$desired" | jq -ce \
+    --arg current "$linked_context" --arg legacy "$legacy_linked_context" '
+    if ([.contexts[] | select(. == $current)] | length) != 1 then
+      error("authoritative linked-issue context is not unique")
+    else
+      .contexts = ([.contexts[] | select(. != $current)] + [$legacy] | unique | sort)
+    end
+  '
+}
+
+reconcile_required_checks_to() {
+  local name="$1" desired="$2" slug endpoint current current_state verified rc payload
   slug="${owner}/${name}"
   endpoint="repos/${slug}/branches/main/protection/required_status_checks"
-  desired=$(required_checks_for_repo "$name")
   if ! printf '%s' "$desired" | jq -e '
     .strict | type == "boolean"
   ' >/dev/null || ! printf '%s' "$desired" | jq -e '
@@ -288,6 +310,270 @@ reconcile_required_checks() {
     return 1
   fi
   echo "[OK] Required checks reconciled for ${slug}"
+}
+
+reconcile_required_checks() {
+  local name="$1" desired
+  desired=$(required_checks_for_repo "$name")
+  reconcile_required_checks_to "$name" "$desired"
+}
+
+required_checks_are_desired() {
+  local name="$1" slug endpoint desired current rc
+  slug="${owner}/${name}"
+  endpoint="repos/${slug}/branches/main/protection/required_status_checks"
+  desired=$(required_checks_for_repo "$name")
+  set +e
+  current=$(api_value_or_404 "$endpoint" '.' "$REPO_SETTINGS_TOKEN")
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || return "$rc"
+  if ! printf '%s' "$current" | jq -e '
+    type == "object" and
+    (.strict | type == "boolean") and
+    (.contexts | type == "array" and all(.[]; type == "string" and length > 0))
+  ' >/dev/null; then
+    echo "[ERROR] Required-status-checks response is malformed for ${slug}" >&2
+    return 1
+  fi
+  if [ "$(printf '%s' "$current" | normalize_required_checks)" = "$desired" ]; then
+    return 0
+  fi
+  return 77
+}
+
+legacy_linked_check_is_successful() {
+  local slug="$1" head="$2" response run_response run_ids run_id rc
+  response=$(mktemp "$work/legacy-linked-check.XXXXXX")
+  set +e
+  gh api "repos/${slug}/commits/${head}/check-runs" >"$response"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$response"
+    return "$rc"
+  fi
+  if ! jq -e '
+    type == "object" and (.check_runs | type == "array") and
+    all(.check_runs[];
+      (.name | type == "string") and (.head_sha | type == "string") and
+      (.status | type == "string") and
+      (.conclusion == null or (.conclusion | type == "string")) and
+      (.details_url | type == "string") and
+      (.app.id | type == "number" and . >= 1 and . == floor) and
+      (.app.slug | type == "string"))
+  ' "$response" >/dev/null; then
+    echo "[ERROR] Legacy linked-issue check response is malformed for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  run_ids=$(jq -r --arg head "$head" --arg context "$legacy_linked_context" \
+    --arg prefix "https://github.com/${slug}/actions/runs/" '
+    .check_runs[] |
+    select(.name == $context and .head_sha == $head and .status == "completed" and
+      .conclusion == "success" and .app.id == 15368 and .app.slug == "github-actions" and
+      (.details_url | startswith($prefix))) |
+    .details_url | capture("/actions/runs/(?<run>[1-9][0-9]*)/job/[1-9][0-9]*$").run
+  ' "$response")
+  rm -f "$response"
+  while IFS= read -r run_id; do
+    [ -n "$run_id" ] || continue
+    run_response=$(mktemp "$work/legacy-linked-run.XXXXXX")
+    set +e
+    gh api "repos/${slug}/actions/runs/${run_id}" >"$run_response"
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      rm -f "$run_response"
+      return "$rc"
+    fi
+    if jq -e --arg head "$head" '
+      type == "object" and .path == ".github/workflows/require-linked-issue.yml" and
+      .event == "pull_request_target" and .head_sha == $head and
+      .status == "completed" and .conclusion == "success"
+    ' "$run_response" >/dev/null; then
+      rm -f "$run_response"
+      return 0
+    fi
+    rm -f "$run_response"
+  done <<<"$run_ids"
+  return 76
+}
+
+canonical_linked_status_ids() {
+  local slug="$1" head="$2" destination="$3" response rc
+  response=$(mktemp "$work/canonical-linked-status.XXXXXX")
+  set +e
+  gh api "repos/${slug}/commits/${head}/statuses" >"$response"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$response"
+    return "$rc"
+  fi
+  if ! jq -e '
+    type == "array" and
+    all(.[];
+      (.id | type == "number" and . >= 1 and . == floor) and
+      (.context | type == "string") and (.state | type == "string") and
+      (.creator.id | type == "number" and . >= 1 and . == floor) and
+      (.creator.login | type == "string") and (.creator.type | type == "string"))
+  ' "$response" >/dev/null || ! jq -c --arg context "$linked_context" '
+    [.[] |
+      select(.context == $context and .creator.id == 41898282 and
+        .creator.login == "github-actions[bot]" and .creator.type == "Bot") |
+      .id] | unique | sort
+  ' "$response" >"$destination"; then
+    echo "[ERROR] Commit-status response is malformed for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  rm -f "$response"
+}
+
+dispatch_and_verify_linked_status() {
+  local slug="$1" pr_number="$2" head="$3" targeted="${4:-true}"
+  local before_ids after_file payload rc deadline
+  before_ids=$(mktemp "$work/linked-before.XXXXXX")
+  after_file=$(mktemp "$work/linked-after.XXXXXX")
+  canonical_linked_status_ids "$slug" "$head" "$before_ids" || {
+    rc=$?
+    rm -f "$before_ids" "$after_file"
+    return "$rc"
+  }
+  payload=$(mktemp "$work/linked-dispatch.XXXXXX")
+  if [ "$targeted" = true ]; then
+    jq -n --arg ref main --arg pr "$pr_number" --arg head "$head" \
+      '{ref: $ref, inputs: {pull_request_number: $pr, expected_head_sha: $head}}' >"$payload"
+  elif [ "$targeted" = false ]; then
+    jq -n --arg ref main '{ref: $ref}' >"$payload"
+  else
+    echo "[ERROR] Linked-issue dispatch mode is invalid for ${slug}" >&2
+    rm -f "$before_ids" "$after_file" "$payload"
+    return 1
+  fi
+  set +e
+  GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+    "repos/${slug}/actions/workflows/require-linked-issue.yml/dispatches" \
+    --method POST --input "$payload" >/dev/null
+  rc=$?
+  set -e
+  rm -f "$payload"
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$before_ids" "$after_file"
+    return "$rc"
+  fi
+
+  deadline=$((SECONDS + linked_wait_seconds))
+  while true; do
+    set +e
+    gh api "repos/${slug}/commits/${head}/statuses" >"$after_file"
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      rm -f "$before_ids" "$after_file"
+      return "$rc"
+    fi
+    if ! jq -e --slurpfile before "$before_ids" --arg context "$linked_context" '
+      type == "array" and
+      any(.[];
+        (.id | type == "number" and . >= 1 and . == floor) and
+        .context == $context and .state == "success" and .creator.id == 41898282 and
+        .creator.login == "github-actions[bot]" and .creator.type == "Bot" and
+        (.id as $id | ($before[0] | index($id)) == null))
+    ' "$after_file" >/dev/null; then
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        rm -f "$before_ids" "$after_file"
+        return 76
+      fi
+      sleep "$poll_seconds"
+      continue
+    fi
+    rm -f "$before_ids" "$after_file"
+    return 0
+  done
+}
+
+recover_linked_transition_receipt() {
+  local name="$1" slug prefix response candidate pr_number head actual
+  slug="${owner}/${name}"
+  prefix="sync/exact-caller-${expected_blob:0:6}${expected_lint_blob:0:6}${expected_linked_blob:0:6}-"
+  response=$(mktemp "$work/merged-bootstrap-prs.XXXXXX")
+  gh api "repos/${slug}/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
+    >"$response"
+  if ! jq -e '
+    type == "array" and all(.[];
+      (.number | type == "number" and . >= 1 and . == floor) and
+      (.head.ref | type == "string") and
+      (.head.sha | type == "string") and
+      (.head.repo.full_name | type == "string") and
+      (.base.ref | type == "string") and
+      (.merged_at == null or (.merged_at | type == "string")))
+  ' "$response" >/dev/null; then
+    echo "[ERROR] Closed bootstrap PR inventory is malformed for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  candidate=$(jq -c --arg prefix "$prefix" --arg slug "$slug" '
+    [.[] | select(
+      .merged_at != null and .base.ref == "main" and .head.repo.full_name == $slug and
+      (.head.ref | startswith($prefix)))] |
+    sort_by(.merged_at) | reverse | first // empty
+  ' "$response")
+  rm -f "$response"
+  if [ -z "$candidate" ]; then
+    echo "[ERROR] No exact merged bootstrap receipt can restore protection for ${slug}" >&2
+    return 1
+  fi
+  pr_number=$(printf '%s' "$candidate" | jq -r '.number')
+  head=$(printf '%s' "$candidate" | jq -r '.head.sha')
+  if ! [[ "$head" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "[ERROR] Merged bootstrap receipt has an invalid head for ${slug}" >&2
+    return 1
+  fi
+  actual=$(gh api "repos/${slug}/contents/${caller_path}?ref=${head}" --jq '.sha')
+  [ "$actual" = "$expected_blob" ] || return 1
+  actual=$(gh api "repos/${slug}/contents/${lint_caller_path}?ref=${head}" --jq '.sha')
+  [ "$actual" = "$expected_lint_blob" ] || return 1
+  actual=$(gh api "repos/${slug}/contents/${linked_caller_path}?ref=${head}" --jq '.sha')
+  [ "$actual" = "$expected_linked_blob" ] || return 1
+  jq -n --argjson pr "$pr_number" --arg head "$head" \
+    '{pull_request: $pr, head: $head}' >"$work/linked-transition-${name}.json"
+}
+
+finalize_linked_transition() {
+  local name="$1" slug receipt pr_number head rc
+  slug="${owner}/${name}"
+  if required_checks_are_desired "$name"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+  [ "$rc" -eq 77 ] || return "$rc"
+  receipt="$work/linked-transition-${name}.json"
+  if [ ! -f "$receipt" ]; then
+    recover_linked_transition_receipt "$name"
+  fi
+  if ! pr_number=$(jq -er '.pull_request | select(type == "number" and . >= 1 and . == floor)' \
+    "$receipt") || ! head=$(jq -er \
+      '.head | select(type == "string" and test("^[0-9a-f]{40}$"))' "$receipt"); then
+    echo "[ERROR] Linked-issue transition receipt is malformed for ${name}" >&2
+    return 1
+  fi
+  if dispatch_and_verify_linked_status "$slug" "$pr_number" "$head"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [ "$rc" -eq 76 ]; then
+    echo "[DEFER] Canonical linked-issue status remains pending for ${name} PR #${pr_number}"
+    return 76
+  fi
+  [ "$rc" -eq 0 ] || return "$rc"
+  reconcile_required_checks "$name"
 }
 
 decimal_greater_than() {
@@ -361,7 +647,7 @@ reconcile_bootstrap_prs() {
       rm -f "$open_prs"
       return 1
     fi
-    if [[ ! "$head_ref" =~ ^sync/exact-caller-[0-9a-f]{12}-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
+    if [[ ! "$head_ref" =~ ^sync/exact-caller-[0-9a-f]{18}-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
       echo "[ERROR] Unrecognized exact-caller automation branch for ${slug}" >&2
       rm -f "$open_prs"
       return 1
@@ -438,7 +724,7 @@ reconcile_bootstrap_prs() {
       rm -f "$open_prs"
       return 1
     fi
-    if [[ ! "$head_ref" =~ ^sync/exact-caller-[0-9a-f]{12}-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
+    if [[ ! "$head_ref" =~ ^sync/exact-caller-[0-9a-f]{18}-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
       echo "[ERROR] Unrecognized exact-caller automation branch for ${slug}" >&2
       rm -f "$open_prs"
       return 1
@@ -578,19 +864,18 @@ enable_one() {
   [ "$state" = "active" ]
 }
 
-# The mutating path independently repeats the dispatch safety proof. Exit 80
-# is the only admissible result: current source and pins are exact, while at
-# least one downstream caller still needs bootstrap.
+# The mutating path independently repeats the dispatch safety proof.
+callers_exact=false
 set +e
 GH_TOKEN="$REPO_SETTINGS_TOKEN" scripts/preflight-downstream-dispatch.sh
 preflight_rc=$?
 set -e
 case "$preflight_rc" in
 0)
-  echo "[OK] Every downstream caller is already exact"
-  exit 0
+  callers_exact=true
   ;;
-80 | 81 | 82) ;;
+80) ;;
+81 | 82) callers_exact=true ;;
 78) exit 78 ;;
 *)
   echo "[ERROR] Mutating bootstrap preflight rejected this run" >&2
@@ -660,7 +945,66 @@ if [ "$(git hash-object "$work/lint-caller.yml")" != "$expected_lint_blob" ]; th
   echo "[ERROR] Super-Linter caller bytes do not match the GitHub blob receipt" >&2
   exit 1
 fi
-branch="sync/exact-caller-${expected_blob:0:6}${expected_lint_blob:0:6}-${run_id}-${run_attempt}"
+set +e
+gh api \
+  "repos/${repository}/contents/workflows/require-linked-issue.yml?ref=${source_sha}" \
+  >"$work/linked-caller.json"
+rc=$?
+set -e
+if [ "$rc" -eq 84 ]; then
+  exit 84
+fi
+if [ "$rc" -ne 0 ]; then
+  echo "[ERROR] Could not fetch the exact linked-issue evaluator" >&2
+  exit 1
+fi
+if ! jq -e '
+  .type == "file" and .encoding == "base64" and
+  (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+  (.content | type == "string" and length > 0)
+' "$work/linked-caller.json" >/dev/null; then
+  echo "[ERROR] Linked-issue evaluator response is malformed" >&2
+  exit 1
+fi
+expected_linked_blob=$(jq -r '.sha' "$work/linked-caller.json")
+jq -r '.content' "$work/linked-caller.json" | tr -d '\n' >"$work/linked-caller.b64"
+if ! base64 -d <"$work/linked-caller.b64" >"$work/linked-caller.yml"; then
+  echo "[ERROR] Linked-issue evaluator response contains invalid base64" >&2
+  exit 1
+fi
+if [ "$(git hash-object "$work/linked-caller.yml")" != "$expected_linked_blob" ]; then
+  echo "[ERROR] Linked-issue evaluator bytes do not match the GitHub blob receipt" >&2
+  exit 1
+fi
+branch="sync/exact-caller-${expected_blob:0:6}${expected_lint_blob:0:6}${expected_linked_blob:0:6}-${run_id}-${run_attempt}"
+
+if [ "$callers_exact" = true ]; then
+  finalization_pending=false
+  while IFS= read -r name; do
+    set +e
+    finalize_linked_transition "$name"
+    rc=$?
+    set -e
+    if [ "$rc" -eq 76 ]; then
+      finalization_pending=true
+      continue
+    fi
+    if [ "$rc" -eq 84 ]; then
+      exit 84
+    fi
+    if [ "$rc" -ne 0 ]; then
+      echo "[ERROR] Could not finalize linked-issue protection for ${name}" >&2
+      exit 1
+    fi
+  done < <(jq -r '.[]' "$downstream_config")
+  if [ "$finalization_pending" = true ]; then
+    exit 83
+  fi
+  if [ "$preflight_rc" -eq 0 ]; then
+    echo "[OK] Every downstream managed workflow and required context is exact"
+    exit 0
+  fi
+fi
 
 set +e
 assert_source_current
@@ -683,24 +1027,14 @@ fi
 echo "[OK] Downstream enforcement workflows are disabled with no active runs"
 
 bootstrap_one() {
-  local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob rc
-  local branch_head branch_blob branch_lint_blob expected_change_count
+  local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob
+  local actual_linked_blob rc branch_head branch_blob branch_lint_blob branch_linked_blob
+  local expected_change_count
   local pr_number pr_url created_pr_number compare_file pr_file verified_head verified_blob
-  local verified_lint_blob
+  local verified_lint_blob verified_linked_blob transition_checks
   slug="${owner}/${name}"
 
   assert_source_current
-  set +e
-  (
-    set -e
-    reconcile_required_checks "$name"
-  )
-  rc=$?
-  set -e
-  if [ "$rc" -ne 0 ]; then
-    return "$rc"
-  fi
-
   main_sha=$(gh api "repos/${slug}/commits/main" --jq '.sha')
   if ! printf '%s' "$main_sha" | grep -qE '^[0-9a-f]{40}$'; then
     echo "[ERROR] Invalid protected-main receipt for ${name}" >&2
@@ -738,13 +1072,31 @@ bootstrap_one() {
   84) return 84 ;;
   *) return 1 ;;
   esac
+  set +e
+  actual_linked_blob=$(api_value_or_404 \
+    "repos/${slug}/contents/${linked_caller_path}?ref=${main_sha}" '.sha')
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    if ! printf '%s' "$actual_linked_blob" | grep -qE '^[0-9a-f]{40}$'; then
+      echo "[ERROR] Invalid live linked-issue evaluator blob for ${name}" >&2
+      return 1
+    fi
+    ;;
+  44) actual_linked_blob="" ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
   if [ "$actual_blob" = "$expected_blob" ] &&
-    [ "$actual_lint_blob" = "$expected_lint_blob" ]; then
+    [ "$actual_lint_blob" = "$expected_lint_blob" ] &&
+    [ "$actual_linked_blob" = "$expected_linked_blob" ]; then
     return 0
   fi
   expected_change_count=0
   [ "$actual_blob" = "$expected_blob" ] || expected_change_count=$((expected_change_count + 1))
   [ "$actual_lint_blob" = "$expected_lint_blob" ] || expected_change_count=$((expected_change_count + 1))
+  [ "$actual_linked_blob" = "$expected_linked_blob" ] || expected_change_count=$((expected_change_count + 1))
 
   default_branch=$(gh api "repos/${slug}" --jq '.default_branch')
   if [ "$default_branch" != "main" ]; then
@@ -815,8 +1167,26 @@ bootstrap_one() {
   *) return 1 ;;
   esac
 
+  set +e
+  branch_linked_blob=$(api_value_or_404 \
+    "repos/${slug}/contents/${linked_caller_path}?ref=${branch_head}" '.sha')
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    if ! printf '%s' "$branch_linked_blob" | grep -qE '^[0-9a-f]{40}$'; then
+      echo "[ERROR] Invalid bootstrap linked-issue evaluator blob for ${name}" >&2
+      return 1
+    fi
+    ;;
+  44) branch_linked_blob="" ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
+
   if { [ "$branch_blob" != "$expected_blob" ] ||
-    [ "$branch_lint_blob" != "$expected_lint_blob" ]; } &&
+    [ "$branch_lint_blob" != "$expected_lint_blob" ] ||
+    [ "$branch_linked_blob" != "$expected_linked_blob" ]; } &&
     [ "$branch_head" != "$base_sha" ]; then
     echo "[ERROR] Refusing to append to a non-exact bootstrap branch for ${name}" >&2
     return 1
@@ -845,6 +1215,18 @@ bootstrap_one() {
       --method PUT --input "$work/update-lint-${name}.json" >/dev/null
     branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
   fi
+  if [ "$branch_linked_blob" != "$expected_linked_blob" ]; then
+    jq -n \
+      --arg message "chore(governance): bootstrap exact linked-issue evaluator" \
+      --arg branch "$branch" \
+      --arg sha "$branch_linked_blob" \
+      --rawfile content "$work/linked-caller.b64" \
+      '{message: $message, content: $content, branch: $branch, sha: $sha} |
+       if .sha == "" then del(.sha) else . end' >"$work/update-linked-${name}.json"
+    gh api "repos/${slug}/contents/${linked_caller_path}" \
+      --method PUT --input "$work/update-linked-${name}.json" >/dev/null
+    branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
+  fi
   if ! printf '%s' "$branch_head" | grep -qE '^[0-9a-f]{40}$'; then
     echo "[ERROR] Invalid exact bootstrap head for ${name}" >&2
     return 1
@@ -854,13 +1236,15 @@ bootstrap_one() {
   gh api "repos/${slug}/compare/${base_sha}...${branch_head}" >"$compare_file"
   if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" \
     --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
+    --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
     --argjson change_count "$expected_change_count" '
     .status == "ahead" and .ahead_by == $change_count and
     .total_commits == $change_count and (.commits | length) == $change_count and
     (.files | length) == $change_count and
     all(.files[];
       ((.filename == $path and .sha == $blob) or
-       (.filename == $lint_path and .sha == $lint_blob)) and
+       (.filename == $lint_path and .sha == $lint_blob) or
+       (.filename == $linked_path and .sha == $linked_blob)) and
       (.status == "added" or .status == "modified"))
   ' "$compare_file" >/dev/null; then
     echo "[ERROR] Bootstrap branch for ${name} is not an exact caller update" >&2
@@ -875,7 +1259,7 @@ bootstrap_one() {
       --base "$default_branch" \
       --head "$branch" \
       --title "chore(governance): bootstrap exact managed callers" \
-      --body "Installs the exact enforcement and Super-Linter callers before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
+      --body "Installs the exact enforcement, Super-Linter, and linked-issue workflows before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
     pr_number=${pr_url##*/}
     created_pr_number="$pr_number"
     if ! printf '%s' "$created_pr_number" | grep -qE '^[1-9][0-9]*$'; then
@@ -894,11 +1278,12 @@ bootstrap_one() {
   gh pr view "$pr_number" --repo "$slug" \
     --json baseRefName,headRefName,headRefOid,files,commits >"$pr_file"
   if ! jq -e --arg path "$caller_path" --arg lint_path "$lint_caller_path" \
+    --arg linked_path "$linked_caller_path" \
     --arg base "$default_branch" --arg head "$branch" --arg oid "$branch_head" \
     --argjson change_count "$expected_change_count" '
     .baseRefName == $base and .headRefName == $head and .headRefOid == $oid and
     (.commits | length) == $change_count and (.files | length) == $change_count and
-    all(.files[]; .path == $path or .path == $lint_path)
+    all(.files[]; .path == $path or .path == $lint_path or .path == $linked_path)
   ' "$pr_file" >/dev/null; then
     echo "[ERROR] Bootstrap PR for ${name} contains an unexpected diff" >&2
     return 1
@@ -928,6 +1313,49 @@ bootstrap_one() {
     echo "[ERROR] Super-Linter caller changed after exact PR verification for ${name}" >&2
     return 1
   fi
+  verified_linked_blob=$(gh api \
+    "repos/${slug}/contents/${linked_caller_path}?ref=${verified_head}" --jq '.sha')
+  if [ "$verified_linked_blob" != "$expected_linked_blob" ]; then
+    echo "[ERROR] Linked-issue evaluator changed after exact PR verification for ${name}" >&2
+    return 1
+  fi
+  if [ "$actual_linked_blob" != "$expected_linked_blob" ]; then
+    if dispatch_and_verify_linked_status "$slug" "$pr_number" "$verified_head" false; then
+      rc=0
+    else
+      rc=$?
+    fi
+    if [ "$rc" -eq 0 ]; then
+      reconcile_required_checks "$name"
+    elif [ "$rc" -eq 85 ]; then
+      if legacy_linked_check_is_successful "$slug" "$verified_head"; then
+        rc=0
+      else
+        rc=$?
+      fi
+      if [ "$rc" -ne 0 ]; then
+        if [ "$rc" -eq 76 ]; then
+          echo "[DEFER] Waiting for the legacy linked-issue gate on ${name} PR #${pr_number}"
+        fi
+        return "$rc"
+      fi
+      transition_checks=$(transition_required_checks_for_repo "$name") || {
+        echo "[ERROR] Could not derive transitional required checks for ${slug}" >&2
+        return 1
+      }
+      reconcile_required_checks_to "$name" "$transition_checks"
+      jq -n --argjson pr "$pr_number" --arg head "$verified_head" \
+        '{pull_request: $pr, head: $head}' >"$work/linked-transition-${name}.json"
+    else
+      if [ "$rc" -eq 76 ]; then
+        echo "[DEFER] Waiting for the canonical linked-issue gate on ${name} PR #${pr_number}"
+      fi
+      return "$rc"
+    fi
+  else
+    dispatch_and_verify_linked_status "$slug" "$pr_number" "$verified_head" || return $?
+    reconcile_required_checks "$name"
+  fi
   gh pr merge "$pr_number" --repo "$slug" --auto --squash --delete-branch \
     --match-head-commit "$verified_head"
   echo "[BOOTSTRAP] ${name} caller PR #${pr_number} is queued for exact merge"
@@ -936,6 +1364,7 @@ bootstrap_one() {
 failures=0
 source_superseded=false
 newer_owner=false
+transition_pending=false
 while IFS= read -r name; do
   set +e
   retry 3 bootstrap_one "$name"
@@ -948,6 +1377,10 @@ while IFS= read -r name; do
   if [ "$rc" -eq 75 ]; then
     newer_owner=true
     break
+  fi
+  if [ "$rc" -eq 76 ]; then
+    transition_pending=true
+    continue
   fi
   if [ "$rc" -eq 84 ]; then
     exit 84
@@ -963,6 +1396,10 @@ if [ "$source_superseded" = true ]; then
 fi
 if [ "$newer_owner" = true ]; then
   echo "[DEFER] A newer bootstrap run owns the transition"
+  exit 83
+fi
+if [ "$transition_pending" = true ]; then
+  echo "[DEFER] Linked-issue transition checks remain pending"
   exit 83
 fi
 if [ "$failures" -gt 0 ]; then
@@ -1015,10 +1452,28 @@ while true; do
     84) exit 84 ;;
     *) exit 1 ;;
     esac
+
+    set +e
+    live_linked_blob=$(api_value_or_404 \
+      "repos/${slug}/contents/${linked_caller_path}?ref=${main_sha}" '.sha')
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      if ! printf '%s' "$live_linked_blob" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "[ERROR] Invalid live linked-issue evaluator receipt while verifying ${name}" >&2
+        exit 1
+      fi
+      [ "$live_linked_blob" = "$expected_linked_blob" ] || pending=$((pending + 1))
+      ;;
+    44) pending=$((pending + 1)) ;;
+    84) exit 84 ;;
+    *) exit 1 ;;
+    esac
   done < <(jq -r '.[]' "$downstream_config")
 
   if [ "$pending" -eq 0 ]; then
-    echo "[OK] Every downstream protected main contains both exact managed callers"
+    echo "[OK] Every downstream protected main contains all exact managed workflows"
     break
   fi
   if [ "$SECONDS" -ge "$deadline" ]; then
@@ -1027,6 +1482,17 @@ while true; do
   fi
   sleep "$poll_seconds"
 done
+
+while IFS= read -r name; do
+  set +e
+  finalize_linked_transition "$name"
+  rc=$?
+  set -e
+  if [ "$rc" -eq 76 ]; then
+    exit 83
+  fi
+  [ "$rc" -eq 0 ] || exit "$rc"
+done < <(jq -r '.[]' "$downstream_config")
 
 set +e
 assert_source_current

--- a/scripts/preflight-downstream-dispatch.sh
+++ b/scripts/preflight-downstream-dispatch.sh
@@ -16,9 +16,11 @@ pinned_blob=""
 source_blob=""
 expected_caller_blob=""
 expected_lint_caller_blob=""
+expected_linked_caller_blob=""
 downstream_main=""
 actual_caller_blob=""
 actual_lint_caller_blob=""
+actual_linked_caller_blob=""
 workflow_state=""
 
 github_api_into() {
@@ -139,6 +141,16 @@ if ! printf '%s' "$expected_lint_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
   echo "[ERROR] GitHub returned an invalid Super-Linter caller blob receipt" >&2
   exit 1
 fi
+if ! github_api_into expected_linked_caller_blob \
+  "repos/${repository}/contents/workflows/require-linked-issue.yml?ref=${source_sha}" \
+  --jq '.sha'; then
+  echo "[ERROR] Could not resolve the exact linked-issue evaluator" >&2
+  exit 1
+fi
+if ! printf '%s' "$expected_linked_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "[ERROR] GitHub returned an invalid linked-issue evaluator blob receipt" >&2
+  exit 1
+fi
 
 stale_callers=0
 state_mismatches=0
@@ -192,6 +204,24 @@ while IFS= read -r name; do
   fi
   if [ "$actual_lint_caller_blob" != "$expected_lint_caller_blob" ]; then
     echo "[BOOTSTRAP] ${name} does not contain the exact Super-Linter caller"
+    stale_callers=$((stale_callers + 1))
+    continue
+  fi
+  if ! github_api_into actual_linked_caller_blob \
+    "repos/${owner}/${name}/contents/.github/workflows/require-linked-issue.yml?ref=${downstream_main}" \
+    --jq '.sha'; then
+    if [ "$api_not_found" = true ]; then
+      actual_linked_caller_blob=""
+    else
+      echo "[ERROR] Could not read the live linked-issue evaluator for ${name}" >&2
+      exit 1
+    fi
+  elif ! printf '%s' "$actual_linked_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
+    echo "[ERROR] Invalid live linked-issue evaluator receipt for ${name}" >&2
+    exit 1
+  fi
+  if [ "$actual_linked_caller_blob" != "$expected_linked_caller_blob" ]; then
+    echo "[BOOTSTRAP] ${name} does not contain the exact linked-issue evaluator"
     stale_callers=$((stale_callers + 1))
     continue
   fi

--- a/tests/privileged-pr-workflow-behavior.mjs
+++ b/tests/privileged-pr-workflow-behavior.mjs
@@ -116,6 +116,11 @@ function linkedIssueHarness(pulls, linkedByNumber = new Map(), errorsByNumber = 
   const coreErrors = [];
   const failures = [];
   const listPulls = async () => pulls;
+  const getPull = async ({ pull_number }) => {
+    const pull = pulls.find(({ number }) => number === pull_number);
+    if (!pull) throw new Error(`pull request ${pull_number} not found`);
+    return { data: pull };
+  };
   const listComments = async () => [];
   const github = {
     paginate: async (endpoint, params) => endpoint(params),
@@ -130,7 +135,7 @@ function linkedIssueHarness(pulls, linkedByNumber = new Map(), errorsByNumber = 
       };
     },
     rest: {
-      pulls: { list: listPulls },
+      pulls: { list: listPulls, get: getPull },
       repos: {
         createCommitStatus: async (params) => statuses.push(params),
       },
@@ -146,6 +151,52 @@ function linkedIssueHarness(pulls, linkedByNumber = new Map(), errorsByNumber = 
     setFailed: (message) => failures.push(message),
   };
   return { github, core, statuses, comments, coreErrors, failures };
+}
+
+async function testLinkedIssueTargetedDispatch() {
+  const pull = { number: 30, state: 'closed', head: { ref: 'sync/exact-caller', sha: 'a'.repeat(40) } };
+  const harness = linkedIssueHarness([pull]);
+  const dispatchContext = {
+    ...context,
+    eventName: 'workflow_dispatch',
+    payload: {
+      inputs: {
+        pull_request_number: '30',
+        expected_head_sha: pull.head.sha,
+      },
+    },
+  };
+
+  await linkedIssueScript(harness.github, dispatchContext, harness.core);
+
+  assert.deepEqual(
+    harness.statuses.map(({ sha, state }) => [sha, state]),
+    [
+      [pull.head.sha, 'pending'],
+      [pull.head.sha, 'success'],
+    ],
+  );
+}
+
+async function testLinkedIssueTargetedDispatchRejectsHeadDrift() {
+  const pull = { number: 31, state: 'closed', head: { ref: 'sync/exact-caller', sha: 'b'.repeat(40) } };
+  const harness = linkedIssueHarness([pull]);
+  const dispatchContext = {
+    ...context,
+    eventName: 'workflow_dispatch',
+    payload: {
+      inputs: {
+        pull_request_number: '31',
+        expected_head_sha: 'c'.repeat(40),
+      },
+    },
+  };
+
+  await assert.rejects(
+    linkedIssueScript(harness.github, dispatchContext, harness.core),
+    /head changed before linked-issue evaluation/,
+  );
+  assert.deepEqual(harness.statuses, []);
 }
 
 async function testLinkedIssueOutcomes() {
@@ -201,4 +252,6 @@ await testDependabotSelection();
 await testDependabotIdempotence();
 await testLinkedIssueOutcomes();
 await testLinkedIssueApiFailure();
+await testLinkedIssueTargetedDispatch();
+await testLinkedIssueTargetedDispatchRejectsHeadDrift();
 console.log('PASS: privileged PR workflow behavior is deterministic and idempotent');

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -21,6 +21,9 @@ CALLER_BLOB=$(printf '%s\n' "$CALLER_TEXT" | git hash-object --stdin)
 LINT_CALLER_TEXT='name: Super-Linter'
 LINT_CALLER_CONTENT=$(printf '%s\n' "$LINT_CALLER_TEXT" | base64 | tr -d '\n')
 LINT_CALLER_BLOB=$(printf '%s\n' "$LINT_CALLER_TEXT" | git hash-object --stdin)
+LINKED_CALLER_TEXT='name: Require Linked Issue'
+LINKED_CALLER_CONTENT=$(printf '%s\n' "$LINKED_CALLER_TEXT" | base64 | tr -d '\n')
+LINKED_CALLER_BLOB=$(printf '%s\n' "$LINKED_CALLER_TEXT" | git hash-object --stdin)
 printf '["example"]\n' >"$WORK/repos.json"
 printf '{"revision":"%s"}\n' "$PIN_SHA" >"$WORK/pin.json"
 printf '{"state":"active"}\n' >"$WORK/rollout.json"
@@ -134,6 +137,14 @@ case "$1 $endpoint" in
         "$LINT_CALLER_BLOB" "$LINT_CALLER_CONTENT"
     fi
     ;;
+  'api repos/f5-sales-demo/docs-control/contents/workflows/require-linked-issue.yml?ref='*)
+    if [[ "$*" == *'--jq .sha'* ]]; then
+      printf '%s\n' "$LINKED_CALLER_BLOB"
+    else
+      printf '{"type":"file","encoding":"base64","sha":"%s","content":"%s"}\n' \
+        "$LINKED_CALLER_BLOB" "$LINKED_CALLER_CONTENT"
+    fi
+    ;;
   'api repos/f5-sales-demo/example/commits/main')
     if [ -f "$FAKE_STATE/required-check-failed" ]; then
       touch "$FAKE_STATE/continued-after-required-check-failure"
@@ -173,11 +184,35 @@ case "$1 $endpoint" in
       done
       [ -n "$input" ] || exit 64
       cp "$input" "$FAKE_STATE/required-checks-input.json"
-      touch "$FAKE_STATE/required-checks-reconciled"
+      if [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ]; then
+        if jq -e '
+          (.contexts | index("check / Check linked issues")) != null and
+          (.contexts | index("Check linked issues")) == null
+        ' "$input" >/dev/null; then
+          cp "$input" "$FAKE_STATE/transition-required-checks.json"
+          touch "$FAKE_STATE/transition-required-checks-reconciled"
+        elif jq -e '
+          (.contexts | index("Check linked issues")) != null and
+          (.contexts | index("check / Check linked issues")) == null
+        ' "$input" >/dev/null; then
+          cp "$input" "$FAKE_STATE/final-required-checks.json"
+          touch "$FAKE_STATE/final-required-checks-reconciled"
+        else
+          exit 65
+        fi
+      else
+        touch "$FAKE_STATE/required-checks-reconciled"
+      fi
     elif [ "${FAKE_REQUIRED_CHECKS_ERROR:-}" = 1 ]; then
       touch "$FAKE_STATE/required-check-failed"
       echo 'gh: synthetic required-check read failure (HTTP 500)' >&2
       exit 1
+    elif [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ] &&
+      [ -f "$FAKE_STATE/transition-required-checks-reconciled" ] &&
+      [ ! -f "$FAKE_STATE/final-required-checks-reconciled" ]; then
+      printf '{"strict":true,"contexts":["check / Check linked issues","Example CI","lint / Lint Code Base"]}\n'
+    elif [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ]; then
+      printf '{"strict":true,"contexts":["Check linked issues","Example CI","lint / Lint Code Base"]}\n'
     elif [ "${FAKE_STALE_REQUIRED_CHECKS:-}" = 1 ] &&
       { [ ! -f "$FAKE_STATE/required-checks-reconciled" ] ||
         [ "${FAKE_REQUIRED_CHECKS_VERIFY_DRIFT:-}" = 1 ]; }; then
@@ -187,6 +222,47 @@ case "$1 $endpoint" in
       printf '{"strict":true,"contexts":["check / Check linked issues","lint / Lint Code Base","lint / Shell Unit Tests"]}\n'
     else
       printf '{"strict":true,"contexts":["Check linked issues","Example CI","lint / Lint Code Base"]}\n'
+    fi
+    ;;
+  'api repos/f5-sales-demo/example/commits/'*'/check-runs')
+    if [ "${FAKE_LEGACY_LINKED_CHECK:-}" = 1 ]; then
+      jq -cn --arg sha "$BRANCH_HEAD" \
+        '{check_runs:[{name:"check / Check linked issues",head_sha:$sha,status:"completed",conclusion:"success",details_url:"https://github.com/f5-sales-demo/example/actions/runs/999/job/1000",app:{id:15368,slug:"github-actions"}}]}'
+    else
+      printf '{"check_runs":[]}\n'
+    fi
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/999')
+    jq -cn --arg sha "$BRANCH_HEAD" \
+      '{path:".github/workflows/require-linked-issue.yml",event:"pull_request_target",head_sha:$sha,status:"completed",conclusion:"success"}'
+    ;;
+  'api repos/f5-sales-demo/example/actions/workflows/require-linked-issue.yml/dispatches')
+    input=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--input" ]; then
+        input="$2"
+        break
+      fi
+      shift
+    done
+    [ -n "$input" ] || exit 64
+    if [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ] &&
+      ! jq -e '.inputs.pull_request_number and .inputs.expected_head_sha' "$input" >/dev/null; then
+      echo 'gh: workflow does not have workflow_dispatch trigger (HTTP 422)' >&2
+      exit 1
+    fi
+    count=0
+    [ ! -f "$FAKE_STATE/linked-dispatch-count" ] || count=$(cat "$FAKE_STATE/linked-dispatch-count")
+    count=$((count + 1))
+    printf '%s\n' "$count" >"$FAKE_STATE/linked-dispatch-count"
+    ;;
+  'api repos/f5-sales-demo/example/commits/'*'/statuses')
+    if [ -f "$FAKE_STATE/linked-dispatch-count" ]; then
+      status_id=$(cat "$FAKE_STATE/linked-dispatch-count")
+      jq -cn --argjson id "$status_id" \
+        '[{id:$id,context:"Check linked issues",state:"success",creator:{id:41898282,login:"github-actions[bot]",type:"Bot"}}]'
+    else
+      printf '[]\n'
     fi
     ;;
   'api repos/f5-sales-demo/example-two/commits/main') printf '%s\n' "$BASE_SHA" ;;
@@ -215,6 +291,9 @@ case "$1 $endpoint" in
     ;;
   'api repos/f5-sales-demo/example-two/contents/.github/workflows/super-linter.yml?ref='*)
     printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
+    ;;
+  'api repos/f5-sales-demo/example-two/contents/.github/workflows/require-linked-issue.yml?ref='*)
+    printf '%s\n' "$DOWNSTREAM_LINKED_BLOB"
     ;;
   'api repos/f5-sales-demo/example/actions/runs?status='*)
     if [ -n "${FAKE_RATE_LIMIT_STATUS:-}" ] &&
@@ -331,13 +410,26 @@ case "$1 $endpoint" in
       printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
     fi
     ;;
+  'api repos/f5-sales-demo/example/contents/.github/workflows/require-linked-issue.yml?ref='*)
+    ref=${endpoint##*ref=}
+    if [ "$ref" = "$BRANCH_HEAD" ] && [ -f "$FAKE_STATE/linked-updated" ]; then
+      printf '%s\n' "$LINKED_CALLER_BLOB"
+    elif [ "$ref" = "$BRANCH_HEAD" ]; then
+      printf '%s\n' "$DOWNSTREAM_LINKED_BLOB"
+    elif [ -f "$FAKE_STATE/merged" ]; then
+      printf '%s\n' "$LINKED_CALLER_BLOB"
+    else
+      printf '%s\n' "$DOWNSTREAM_LINKED_BLOB"
+    fi
+    ;;
   'api repos/f5-sales-demo/example') printf 'main\n' ;;
   'api repos/f5-sales-demo/example/git/ref/heads/main') printf '%s\n' "$BASE_SHA" ;;
   'api repos/f5-sales-demo/example/git/ref/heads/sync/exact-caller-'*)
     if [ -f "$FAKE_STATE/branch" ]; then
       if [ -f "$FAKE_STATE/corrupt" ]; then
         printf '%s\n' '8888888888888888888888888888888888888888'
-      elif [ -f "$FAKE_STATE/updated" ] || [ -f "$FAKE_STATE/lint-updated" ]; then
+      elif [ -f "$FAKE_STATE/updated" ] || [ -f "$FAKE_STATE/lint-updated" ] ||
+        [ -f "$FAKE_STATE/linked-updated" ]; then
         printf '%s\n' "$BRANCH_HEAD"
       else
         printf '%s\n' "$BASE_SHA"
@@ -354,6 +446,9 @@ case "$1 $endpoint" in
   'api repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml')
     touch "$FAKE_STATE/lint-updated"
     ;;
+  'api repos/f5-sales-demo/example/contents/.github/workflows/require-linked-issue.yml')
+    touch "$FAKE_STATE/linked-updated"
+    ;;
   'api repos/f5-sales-demo/example/compare/'*)
     files='[]'
     count=0
@@ -365,6 +460,11 @@ case "$1 $endpoint" in
     if [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
       files=$(jq -cn --argjson files "$files" --arg sha "$LINT_CALLER_BLOB" \
         '$files + [{filename:".github/workflows/super-linter.yml",sha:$sha,status:"modified"}]')
+      count=$((count + 1))
+    fi
+    if [ "$DOWNSTREAM_LINKED_BLOB" != "$LINKED_CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" --arg sha "$LINKED_CALLER_BLOB" \
+        '$files + [{filename:".github/workflows/require-linked-issue.yml",sha:$sha,status:"modified"}]')
       count=$((count + 1))
     fi
     jq -cn --argjson count "$count" --argjson files "$files" \
@@ -382,20 +482,29 @@ case "$1 $endpoint" in
         '[{number: 11, head: {ref: $branch, sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/page-two-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[], [{number: 9, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[], [{number: 9, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/huge-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[{number: 10, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-999999999999999999999999999999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[{number: 10, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-999999999999999999999999999999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/newer-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[{number: 8, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[{number: 8, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/current-pr" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg branch "$EXPECTED_BRANCH" \
         --arg repo "${GITHUB_REPOSITORY%/*}/example" \
         '[{number: 42, head: {ref: $branch, sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/old-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[{number: 7, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-12-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[{number: 7, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-12-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+    else
+      printf '[]\n'
+    fi
+    ;;
+  'api repos/f5-sales-demo/example/pulls?state=closed&sort=updated&direction=desc&per_page=100')
+    if [ "${FAKE_RECOVER_MERGED_TRANSITION:-}" = 1 ]; then
+      jq -cn --arg sha "$BRANCH_HEAD" --arg branch "$EXPECTED_BRANCH" \
+        --arg repo "${GITHUB_REPOSITORY%/*}/example" \
+        '[{number:42,merged_at:"2026-08-04T12:00:00Z",head:{ref:$branch,sha:$sha,repo:{full_name:$repo}},base:{ref:"main"}}]'
     else
       printf '[]\n'
     fi
@@ -421,6 +530,11 @@ case "$1 $endpoint" in
     fi
     if [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
       files=$(jq -cn --argjson files "$files" '$files + [{path:".github/workflows/super-linter.yml"}]')
+      count=$((count + 1))
+    fi
+    if [ "$DOWNSTREAM_LINKED_BLOB" != "$LINKED_CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" \
+        '$files + [{path:".github/workflows/require-linked-issue.yml"}]')
       count=$((count + 1))
     fi
     jq -cn --arg branch "$EXPECTED_BRANCH" --arg sha "$BRANCH_HEAD" \
@@ -455,6 +569,7 @@ run_bootstrap() {
     DOWNSTREAM_CONFIG="${TEST_DOWNSTREAM_CONFIG:-$WORK/repos.json}" \
     REPO_SETTINGS_CONFIG="${TEST_REPO_SETTINGS_CONFIG:-$WORK/repo-settings.json}" \
     BOOTSTRAP_WAIT_SECONDS=0 \
+    BOOTSTRAP_LINKED_WAIT_SECONDS=0 \
     FAKE_LOG="$WORK/gh.log" \
     FAKE_STATE="$state" \
     SOURCE_SHA="$SOURCE_SHA" \
@@ -465,13 +580,16 @@ run_bootstrap() {
     ENFORCE_BLOB="$ENFORCE_BLOB" \
     SYNC_BLOB="$SYNC_BLOB" \
     BRANCH_HEAD="$BRANCH_HEAD" \
-    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB:0:6}${LINT_CALLER_BLOB:0:6}-12345-1" \
+    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB:0:6}${LINT_CALLER_BLOB:0:6}${LINKED_CALLER_BLOB:0:6}-12345-1" \
     CALLER_BLOB="$CALLER_BLOB" \
     CALLER_CONTENT="$CALLER_CONTENT" \
     LINT_CALLER_BLOB="$LINT_CALLER_BLOB" \
     LINT_CALLER_CONTENT="$LINT_CALLER_CONTENT" \
+    LINKED_CALLER_BLOB="$LINKED_CALLER_BLOB" \
+    LINKED_CALLER_CONTENT="$LINKED_CALLER_CONTENT" \
     DOWNSTREAM_BLOB="$DOWNSTREAM_BLOB" \
     DOWNSTREAM_LINT_BLOB="${DOWNSTREAM_LINT_BLOB:-$LINT_CALLER_BLOB}" \
+    DOWNSTREAM_LINKED_BLOB="${DOWNSTREAM_LINKED_BLOB:-$LINKED_CALLER_BLOB}" \
     FAKE_READ_ERROR="${FAKE_READ_ERROR:-}" \
     FAKE_MAIN_ADVANCE_AT="${FAKE_MAIN_ADVANCE_AT:-}" \
     FAKE_MALFORMED_CALLER="${FAKE_MALFORMED_CALLER:-}" \
@@ -490,6 +608,9 @@ run_bootstrap() {
     FAKE_REQUIRED_CHECKS_ERROR="${FAKE_REQUIRED_CHECKS_ERROR:-}" \
     FAKE_REQUIRED_CHECKS_VERIFY_DRIFT="${FAKE_REQUIRED_CHECKS_VERIFY_DRIFT:-}" \
     FAKE_REQUIRED_CHECKS_PATCH_RATE_LIMIT="${FAKE_REQUIRED_CHECKS_PATCH_RATE_LIMIT:-}" \
+    FAKE_STAGED_LINKED_TRANSITION="${FAKE_STAGED_LINKED_TRANSITION:-}" \
+    FAKE_LEGACY_LINKED_CHECK="${FAKE_LEGACY_LINKED_CHECK:-}" \
+    FAKE_RECOVER_MERGED_TRANSITION="${FAKE_RECOVER_MERGED_TRANSITION:-}" \
     REPO_SETTINGS_TOKEN=settings-token \
     "$SOURCE"
 }
@@ -542,17 +663,22 @@ required_patch_line=$(grep -n \
   'example/branches/main/protection/required_status_checks --method PATCH' \
   "$WORK/gh.log" | cut -d: -f1 || true)
 branch_create_line=$(grep -n 'git/refs --method POST' "$WORK/gh.log" | cut -d: -f1 || true)
+linked_status_line=$(grep -n '/status' "$WORK/gh.log" | tail -1 | cut -d: -f1 || true)
+merge_line=$(grep -n '^pr merge ' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
 if [ "$rc" != 83 ] || [ -z "$required_patch_line" ] || [ -z "$branch_create_line" ] ||
-  [ "$required_patch_line" -ge "$branch_create_line" ] ||
+  [ -z "$linked_status_line" ] || [ -z "$merge_line" ] ||
+  [ "$branch_create_line" -ge "$linked_status_line" ] ||
+  [ "$linked_status_line" -ge "$required_patch_line" ] ||
+  [ "$required_patch_line" -ge "$merge_line" ] ||
   ! jq -e '
     .strict == true and
     .contexts == ["Check linked issues", "Example CI", "lint / Lint Code Base"]
   ' "$state/required-checks-input.json" >/dev/null; then
-  echo "[FAIL] stale required checks were not reconciled exactly before caller PR creation"
+  echo "[FAIL] stale required checks were not reconciled after exact evaluator proof"
   cat "$WORK/stale-required-checks.err"
   exit 1
 fi
-echo "[OK] stale required checks reconcile additions and exclusions before caller PR creation"
+echo "[OK] stale required checks reconcile only after exact evaluator proof"
 
 state="$WORK/state-required-check-read-failure"
 mkdir -p "$state"
@@ -565,10 +691,10 @@ run_bootstrap "$state" >/dev/null 2>&1
 rc=$?
 set -e
 unset FAKE_REQUIRED_CHECKS_ERROR
-if [ "$rc" = 0 ] || [ -f "$state/continued-after-required-check-failure" ] ||
-  grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr (create|merge)' \
+if [ "$rc" = 0 ] ||
+  grep -qE '^pr merge |actions/workflows/enforce-repo-settings.yml/enable' \
     "$WORK/gh.log"; then
-  echo "[FAIL] required-check API failure did not block caller mutation"
+  echo "[FAIL] required-check API failure did not block merge and enforcement"
   exit 1
 fi
 echo "[OK] required-check API failure blocks caller mutation"
@@ -585,9 +711,9 @@ run_bootstrap "$state" >/dev/null 2>"$WORK/required-check-patch-rate-limit.err"
 rc=$?
 set -e
 unset FAKE_STALE_REQUIRED_CHECKS FAKE_REQUIRED_CHECKS_PATCH_RATE_LIMIT
-if [ "$rc" != 84 ] || [ -f "$state/continued-after-required-check-failure" ] ||
+if [ "$rc" != 84 ] ||
   [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 1 ] ||
-  grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr (create|merge)' \
+  grep -qE '^pr merge |actions/workflows/enforce-repo-settings.yml/enable' \
     "$WORK/gh.log"; then
   echo "[FAIL] required-check rate exhaustion did not defer immediately before caller mutation"
   exit 1
@@ -606,10 +732,10 @@ run_bootstrap "$state" >/dev/null 2>&1
 rc=$?
 set -e
 unset FAKE_STALE_REQUIRED_CHECKS FAKE_REQUIRED_CHECKS_VERIFY_DRIFT
-if [ "$rc" = 0 ] || [ -f "$state/continued-after-required-check-failure" ] ||
+if [ "$rc" = 0 ] ||
   ! grep -q 'example/branches/main/protection/required_status_checks --method PATCH' \
     "$WORK/gh.log" ||
-  grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr (create|merge)' \
+  grep -qE '^pr merge |actions/workflows/enforce-repo-settings.yml/enable' \
     "$WORK/gh.log"; then
   echo "[FAIL] required-check postcondition drift did not fail before caller mutation"
   exit 1
@@ -636,6 +762,90 @@ if [ "$rc" != 83 ] ||
   exit 1
 fi
 echo "[OK] exact enforcement with stale lint updates only lint and remains quiesced"
+
+state="$WORK/state-stale-linked-only"
+mkdir -p "$state"
+touch "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+set +e
+run_bootstrap "$state" >"$WORK/stale-linked-only.out" 2>"$WORK/stale-linked-only.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINKED_BLOB
+if [ "$rc" != 83 ] ||
+  grep -q 'contents/.github/workflows/enforce-repo-settings.yml --method PUT' "$WORK/gh.log" ||
+  grep -q 'contents/.github/workflows/super-linter.yml --method PUT' "$WORK/gh.log" ||
+  ! grep -q 'contents/.github/workflows/require-linked-issue.yml --method PUT' "$WORK/gh.log" ||
+  ! grep -q 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log" ||
+  ! grep -q '^pr merge ' "$WORK/gh.log" ||
+  grep -q 'actions/workflows/enforce-repo-settings.yml/enable --method PUT' "$WORK/gh.log"; then
+  echo "[FAIL] stale linked-issue evaluator was not carried by its exact bounded PR"
+  cat "$WORK/stale-linked-only.err"
+  exit 1
+fi
+echo "[OK] stale linked-issue evaluator is bootstrapped before enforcement resumes"
+
+state="$WORK/state-staged-linked-transition"
+mkdir -p "$state"
+touch "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_STAGED_LINKED_TRANSITION=1
+FAKE_LEGACY_LINKED_CHECK=1
+FAKE_MERGE_LANDS=1
+set +e
+run_bootstrap "$state" >"$WORK/staged-linked-transition.out" \
+  2>"$WORK/staged-linked-transition.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINKED_BLOB FAKE_STAGED_LINKED_TRANSITION FAKE_LEGACY_LINKED_CHECK \
+  FAKE_MERGE_LANDS
+legacy_check_line=$(grep -n '/check-runs' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
+transition_patch_line=$(grep -n 'required_status_checks --method PATCH' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
+merge_line=$(grep -n '^pr merge ' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
+dispatch_line=$(grep -n 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log" | tail -1 | cut -d: -f1 || true)
+status_line=$(grep -n '/status' "$WORK/gh.log" | tail -1 | cut -d: -f1 || true)
+final_patch_line=$(grep -n 'required_status_checks --method PATCH' "$WORK/gh.log" | tail -1 | cut -d: -f1 || true)
+if [ "$rc" != 0 ] || [ -z "$legacy_check_line" ] || [ -z "$transition_patch_line" ] ||
+  [ -z "$merge_line" ] || [ -z "$dispatch_line" ] || [ -z "$status_line" ] ||
+  [ -z "$final_patch_line" ] || [ "$legacy_check_line" -ge "$transition_patch_line" ] ||
+  [ "$transition_patch_line" -ge "$merge_line" ] || [ "$merge_line" -ge "$dispatch_line" ] ||
+  [ "$dispatch_line" -ge "$status_line" ] || [ "$status_line" -ge "$final_patch_line" ] ||
+  [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 2 ] ||
+  ! jq -e '.contexts | index("check / Check linked issues") != null' \
+    "$state/transition-required-checks.json" >/dev/null ||
+  ! jq -e '.contexts | index("Check linked issues") != null' \
+    "$state/final-required-checks.json" >/dev/null; then
+  echo "[FAIL] linked-issue evaluator transition did not retain a real gate through both stages"
+  cat "$WORK/staged-linked-transition.err"
+  sed 's/^/  log: /' "$WORK/gh.log"
+  exit 1
+fi
+echo "[OK] linked-issue evaluator transition preserves a verified real gate throughout"
+
+state="$WORK/state-recover-linked-transition"
+mkdir -p "$state"
+touch "$state/transition-required-checks-reconciled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+FAKE_STAGED_LINKED_TRANSITION=1
+FAKE_RECOVER_MERGED_TRANSITION=1
+run_bootstrap "$state" >"$WORK/recover-linked-transition.out" \
+  2>"$WORK/recover-linked-transition.err"
+unset FAKE_STAGED_LINKED_TRANSITION FAKE_RECOVER_MERGED_TRANSITION
+if ! grep -q 'pulls?state=closed&sort=updated&direction=desc&per_page=100' "$WORK/gh.log" ||
+  ! grep -q 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log" ||
+  [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 1 ] ||
+  grep -qE 'git/refs --method POST|contents/.github/workflows/.* --method PUT|^pr (create|merge)' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] interrupted linked-issue transition did not recover from its merged exact receipt"
+  cat "$WORK/recover-linked-transition.err"
+  exit 1
+fi
+echo "[OK] interrupted transition recovers idempotently from its merged exact receipt"
 
 state="$WORK/state-exact"
 mkdir -p "$state"

--- a/tests/test-dispatch-preflight.sh
+++ b/tests/test-dispatch-preflight.sh
@@ -10,6 +10,7 @@ OTHER_SHA=3333333333333333333333333333333333333333
 ENFORCE_BLOB=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 SYNC_BLOB=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 LINT_CALLER_BLOB=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+LINKED_CALLER_BLOB=ffffffffffffffffffffffffffffffffffffffff
 PASS=0
 FAIL=0
 
@@ -40,6 +41,9 @@ case "$*" in
   *"contents/workflows/super-linter.yml?ref=$FAKE_SOURCE_SHA"*)
     printf '%s\n' "$FAKE_SOURCE_LINT_CALLER_BLOB"
     ;;
+  *"contents/workflows/require-linked-issue.yml?ref=$FAKE_SOURCE_SHA"*)
+    printf '%s\n' "$FAKE_SOURCE_LINKED_CALLER_BLOB"
+    ;;
   *"enforce-repo-settings.yml?ref=$FAKE_SOURCE_SHA"*) printf '%s\n' "$FAKE_SOURCE_ENFORCE_BLOB" ;;
   *"sync-managed-files.yml?ref=$FAKE_SOURCE_SHA"*) printf '%s\n' "$FAKE_SOURCE_SYNC_BLOB" ;;
   *"repos/f5-sales-demo/example/contents/.github/workflows/enforce-repo-settings.yml?ref=$FAKE_DOWNSTREAM_MAIN"*)
@@ -55,6 +59,13 @@ case "$*" in
       exit 1
     fi
     printf '%s\n' "$FAKE_DOWNSTREAM_LINT_CALLER_BLOB"
+    ;;
+  *"repos/f5-sales-demo/example/contents/.github/workflows/require-linked-issue.yml?ref=$FAKE_DOWNSTREAM_MAIN"*)
+    if [ "${FAKE_MISSING_CALLER:-}" = 1 ]; then
+      echo 'gh: Not Found (HTTP 404)' >&2
+      exit 1
+    fi
+    printf '%s\n' "$FAKE_DOWNSTREAM_LINKED_CALLER_BLOB"
     ;;
   *'repos/f5-sales-demo/example/actions/workflows/enforce-repo-settings.yml'*)
     if [ "${FAKE_MISSING_CALLER:-}" = 1 ] || [ "${FAKE_STATE_READ_FAIL:-}" = 1 ]; then
@@ -87,8 +98,10 @@ EOF
     FAKE_SOURCE_SYNC_BLOB="$FAKE_SOURCE_SYNC_BLOB" \
     FAKE_SOURCE_CALLER_BLOB="$FAKE_SOURCE_CALLER_BLOB" \
     FAKE_SOURCE_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB" \
+    FAKE_SOURCE_LINKED_CALLER_BLOB="$FAKE_SOURCE_LINKED_CALLER_BLOB" \
     FAKE_DOWNSTREAM_CALLER_BLOB="$FAKE_DOWNSTREAM_CALLER_BLOB" \
     FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_DOWNSTREAM_LINT_CALLER_BLOB" \
+    FAKE_DOWNSTREAM_LINKED_CALLER_BLOB="$FAKE_DOWNSTREAM_LINKED_CALLER_BLOB" \
     FAKE_DOWNSTREAM_MAIN="$FAKE_DOWNSTREAM_MAIN" \
     FAKE_MISSING_CALLER="${FAKE_MISSING_CALLER:-}" \
     FAKE_STATE_READ_FAIL="${FAKE_STATE_READ_FAIL:-}" \
@@ -115,8 +128,10 @@ FAKE_SOURCE_ENFORCE_BLOB="$ENFORCE_BLOB"
 FAKE_SOURCE_SYNC_BLOB="$SYNC_BLOB"
 FAKE_SOURCE_CALLER_BLOB=cccccccccccccccccccccccccccccccccccccccc
 FAKE_SOURCE_LINT_CALLER_BLOB="$LINT_CALLER_BLOB"
+FAKE_SOURCE_LINKED_CALLER_BLOB="$LINKED_CALLER_BLOB"
 FAKE_DOWNSTREAM_CALLER_BLOB="$FAKE_SOURCE_CALLER_BLOB"
 FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB"
+FAKE_DOWNSTREAM_LINKED_CALLER_BLOB="$FAKE_SOURCE_LINKED_CALLER_BLOB"
 FAKE_DOWNSTREAM_MAIN=dddddddddddddddddddddddddddddddddddddddd
 check_case "exact main receipt and exact caller pin permit fan-out" 0 "[OK]"
 
@@ -147,6 +162,13 @@ check_case "stale Super-Linter caller requires bootstrap" 80 \
   "[BOOTSTRAP] example does not contain the exact Super-Linter caller"
 unset FAKE_STATE_READ_FAIL
 FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB"
+
+FAKE_DOWNSTREAM_LINKED_CALLER_BLOB="$OTHER_SHA"
+FAKE_STATE_READ_FAIL=1
+check_case "stale linked-issue evaluator requires bootstrap" 80 \
+  "[BOOTSTRAP] example does not contain the exact linked-issue evaluator"
+unset FAKE_STATE_READ_FAIL
+FAKE_DOWNSTREAM_LINKED_CALLER_BLOB="$FAKE_SOURCE_LINKED_CALLER_BLOB"
 
 FAKE_MISSING_CALLER=1
 check_case "missing workflow reaches exact caller bootstrap" 80 "[BOOTSTRAP]"

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -5,6 +5,15 @@ on:
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Exact pull request to evaluate, including a just-merged bootstrap PR
+        required: false
+        type: string
+      expected_head_sha:
+        description: Full head SHA that the targeted pull request must still reference
+        required: false
+        type: string
 
 permissions: {}
 
@@ -43,12 +52,31 @@ jobs:
               globToRegex(pattern.trim()),
             );
 
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner,
-              repo,
-              state: "open",
-              per_page: 100,
-            });
+            const inputs = context.eventName === "workflow_dispatch" ? context.payload.inputs ?? {} : {};
+            const requestedNumber = inputs.pull_request_number ?? "";
+            const requestedHead = inputs.expected_head_sha ?? "";
+            let pulls;
+            if (requestedNumber !== "" || requestedHead !== "") {
+              if (!/^[1-9][0-9]*$/.test(requestedNumber) || !/^[0-9a-f]{40}$/.test(requestedHead)) {
+                throw new Error("Targeted linked-issue evaluation requires an exact PR number and head SHA");
+              }
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: Number(requestedNumber),
+              });
+              if (pull.head.sha !== requestedHead) {
+                throw new Error(`PR #${requestedNumber} head changed before linked-issue evaluation`);
+              }
+              pulls = [pull];
+            } else {
+              pulls = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100,
+              });
+            }
             const evaluationErrors = [];
 
             for (const pull of pulls) {


### PR DESCRIPTION
## Summary

Make linked-issue evaluation part of the exact downstream bootstrap transaction and preserve a genuine linked-issue gate while repositories move from the obsolete reusable check context to the canonical scheduled status context.

Closes #1162

## Changes

- include the linked-issue evaluator in preflight, exact branch receipts, bounded PR diffs, and protected-main verification
- add exact PR/head inputs for targeted evaluation of a just-merged bootstrap PR
- distinguish existing canonical evaluators through a fresh no-input dispatch and commit-status proof
- stage Terraform's legacy evaluator through a verified legacy workflow run before temporarily switching its required context
- verify a newly created canonical status from the immutable GitHub Actions bot before restoring authoritative protection
- recover interrupted transitions from a verified merged exact-caller receipt
- fail closed on malformed API responses, wrong workflow paths/events, identity drift, head drift, or ambiguous ownership

## Verification evidence

- TDD red baseline: stale linked evaluator was ignored and bootstrap returned success
- `bash tests/test-bootstrap-downstream-callers.sh` — 36/36 scenarios passed
- `bash tests/test-dispatch-preflight.sh` — 11/11 passed
- `bash tests/test-privileged-pr-workflows.sh` — security and behavior contracts passed
- every `tests/test-*.sh` program — 32/32 passed
- `pre-commit run --files ...` — all applicable hooks passed, including shellcheck, actionlint, zizmor, Checkov, Gitleaks, and PII enforcement
- live GitHub API inspection verified the legacy run path/event/head/app metadata and canonical status response shape
- `bash scripts/agy-pre-push-review.sh` at `28456f5` — PII clean; 0 blocking, 0 medium, 0 nit findings

## Checklist

- [x] Linked to a GitHub issue
- [x] Tests written from a reproduced failing contract
- [x] Focused and full local suites pass
- [x] Antigravity reviewed the exact pushed commit
- [ ] Required CI watched to green
- [x] No synthetic status, administrative merge, or branch-protection bypass
