### PR TITLE
fix(auto-merge): require the canonical token instead of falling back

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -8,14 +8,16 @@ name: Auto-Merge
 on:
   pull_request:
     types: [opened, reopened, ready_for_review]
-  # Declared so callers can pass REPO_SYNC_TOKEN EXPLICITLY instead of
+  # Declared so callers pass REPO_SYNC_TOKEN EXPLICITLY instead of
   # `secrets: inherit` (least privilege — the caller hands over one secret, not
-  # every repository secret). `required: false` preserves the documented
-  # REPO_SYNC_TOKEN || GITHUB_TOKEN fallback for repos without the PAT.
+  # every repository secret). `required: true` because auto-merge has exactly one
+  # credential: a merge pushed with the automatic token cannot start the downstream
+  # workflows a merge is meant to start, so a repository without the PAT must fail
+  # loudly rather than merge in a way that silently breaks release and regeneration.
   workflow_call:
     secrets:
       REPO_SYNC_TOKEN:
-        required: false
+        required: true
 
 permissions: {}
 
@@ -57,11 +59,16 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           # PAT (REPO_SYNC_TOKEN) so the eventual merge-push is attributed to a
           # real user — not github-actions[bot] — which lets it trigger downstream
-          # workflows (release.yml, github-pages-deploy.yml, CI); GITHUB_TOKEN
-          # merges are blocked by GitHub's recursion prevention. The same token
-          # reads the author's repo permission for the trust gate. Falls back to
-          # GITHUB_TOKEN for repos without REPO_SYNC_TOKEN.
-          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
+          # workflows (release.yml, github-pages-deploy.yml, CI); a merge pushed
+          # with the automatic token is blocked by GitHub's recursion prevention.
+          # The same token reads the author's repo permission for the trust gate.
+          #
+          # There is deliberately no alternate credential. Substituting the
+          # automatic token would still merge, but the merge would start none of
+          # the downstream work it exists to start — a silent half-failure that is
+          # harder to diagnose than a refused merge. Callers declare this secret as
+          # required and preflight it, so absence fails before any merge is enabled.
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
         run: |
           if bash .governance/scripts/pr-author-trusted.sh "$REPO" "$PR_AUTHOR"; then
             gh pr merge --auto --squash "$PR_URL"

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -10,20 +10,49 @@ on:
 permissions: {}
 
 jobs:
-  call:
-    # Candidate filter only (non-draft, non-dependabot). The reusable further gates
-    # the actual merge on author write/admin permission, and branch protection +
-    # required checks still gate the merge. Dependabot uses dependabot-auto-merge.yml.
+  # Auto-merge has exactly one credential: the REPO_SYNC_TOKEN PAT. A merge pushed
+  # with the automatic token cannot start the downstream workflows a merge is meant
+  # to start — GitHub blocks that recursion — so a repository without the PAT would
+  # appear to auto-merge while silently breaking release, pages and regeneration
+  # runs. This preflight turns that into a loud configuration failure.
+  #
+  # Fork pull requests are excluded rather than failed: they legitimately receive no
+  # secrets, so an absent token there is not a misconfiguration.
+  require-token:
+    name: Require canonical auto-merge token
     if: >-
       github.event.pull_request.draft == false &&
-      github.actor != 'dependabot[bot]'
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require downstream-triggering token
+        env:
+          REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${REPO_SYNC_TOKEN:-}" ]; then
+            echo "::error::REPO_SYNC_TOKEN is required for auto-merge. A merge pushed with the automatic token cannot trigger downstream workflows, so auto-merge is refused rather than performed silently."
+            exit 1
+          fi
+          echo "Canonical auto-merge token is present"
+
+  call:
+    # Candidate filter only (non-draft, non-dependabot, same repository). The
+    # reusable further gates the actual merge on author write/admin permission, and
+    # branch protection + required checks still gate the merge. Dependabot uses
+    # dependabot-auto-merge.yml.
+    needs: [require-token]
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@7a9e56e38268119eb55947c09b4b0749e424f697
     permissions:
-      contents: write # fallback GITHUB_TOKEN must be able to complete the merge
+      contents: write # the reusable completes the merge
       pull-requests: write # enable auto-merge and update the pull request
-    # Least privilege: pass ONLY the secret the reusable needs, not every
-    # repository secret (`secrets: inherit`). REPO_SYNC_TOKEN is the PAT that lets
-    # an auto-merge trigger downstream workflows; the reusable falls back to
-    # GITHUB_TOKEN when it is unset, so repos without the PAT still work.
+    # Least privilege: pass ONLY the secret the reusable needs, not every repository
+    # secret (`secrets: inherit`). REPO_SYNC_TOKEN is the PAT that lets an
+    # auto-merge trigger downstream workflows, and the reusable now requires it.
     secrets:
       REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}


### PR DESCRIPTION
## Require the canonical auto-merge token instead of falling back

Auto-merge resolved two credentials:

```yaml
GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN || secrets.GITHUB_TOKEN }}
```

That fallback does not degrade gracefully. A merge pushed with the automatic token *succeeds*, but GitHub's recursion prevention means it starts none of the downstream workflows a merge exists to start — release, pages, regeneration, CI. So a repository without the PAT appears to auto-merge correctly while quietly breaking its own automation, which is harder to diagnose than a refused merge would be.

### Changes

- The reusable declares `REPO_SYNC_TOKEN` as `required: true` and uses it alone.
- The caller template gains a `require-token` preflight that fails closed with a readable error when the secret is absent, and `call` now `needs: [require-token]` — so a misconfigured repository stops before auto-merge is ever enabled.
- Both jobs gate on `github.event.pull_request.head.repo.full_name == github.repository`. Fork pull requests are *excluded* from the preflight rather than failed by it: forks legitimately receive no secrets, so an absent token there is not a misconfiguration.
- The stale comments claiming a documented fallback are gone, including `contents: write # fallback GITHUB_TOKEN must be able to complete the merge`.

### Blast radius, checked before proposing it

Removing a fallback is only safe if the primary is universally present. Sampled 8 fleet repositories — `terraform-provider-xcsh`, `api-specs-enriched`, `docs-control`, `api-specs`, `console`, `xcsh`, `vscode-xcsh`, `i18n-core` — and all 8 already have `REPO_SYNC_TOKEN`. I could not enumerate org-level secrets (403, needs `admin:org`), so if a repository outside that sample lacks the PAT, its auto-merge will now fail loudly with `REPO_SYNC_TOKEN is required` rather than merge without triggering anything. That is the intended behaviour, but worth knowing before merge.

### Why this is here and not downstream

`TestAutoMergeRequiresCanonicalToken` in f5-sales-demo/terraform-provider-xcsh#1460 asserts exactly this contract — no fallback path, a `require-token` preflight, and the same-repository gate. It is red today and cannot be fixed there: `auto-merge.yml` is a protected managed file, so a local edit is blocked by hook and reverted by the next sync.

### Verification

- `actionlint`, `yamllint` — clean
- `zizmor --config zizmor.yaml` — exit 0, no findings
- `tests/test-privileged-pr-workflows.sh` — pass
- `tests/test-linter-configs.sh` — 159 passed, 0 failed
- `tests/test-bootstrap-downstream-callers.sh` — pass

### Two other items from #1144 withdrawn

I opened #1144 asking for three things; the other two were wrong and I have withdrawn them there in detail:

- **Reusable-workflow SHA pins** — already delivered. `scripts/update-governed-workflow-pins.sh` does this, and consumers are pinned to `8eaaced5…` / `94a0cb51…` today. My request was based on a 2026-08-01 snapshot.
- **`.gitleaks.toml` allowlist** — withdrawn, and this repository is right to refuse it. `tests/test-linter-configs.sh` §16.1 forbids allowlists in the managed config, and the mechanism I proposed would not even have worked: a `paths` allowlist excludes the file wholesale, and adding `regexes` *widens* the exemption because gitleaks OR-s the conditions. The real cause is data shape — `generic-api-key` fires on the literal `api` inside asset filenames such as `api-catalog.json` sitting next to a digest. Storing digests as `sha256:<hex>`, matching the format GitHub already reports, produces zero findings with the default rules fully intact. That fix belongs in the repositories that own the file, and I am making it there.

Closes #1144
