### PR TITLE
fix(ci): stabilize exact-caller ownership

### DIFF
--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -583,6 +583,17 @@ decimal_greater_than() {
   [[ "$left" > "$right" ]]
 }
 
+parse_exact_caller_owner() {
+  local head_ref="$1"
+  exact_caller_owner_run=""
+  exact_caller_owner_attempt=""
+  if [[ ! "$head_ref" =~ ^sync/exact-caller-[A-Za-z0-9][A-Za-z0-9._-]*-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
+    return 1
+  fi
+  exact_caller_owner_run="${BASH_REMATCH[1]}"
+  exact_caller_owner_attempt="${BASH_REMATCH[2]}"
+}
+
 read_bootstrap_prs() {
   local slug="$1" destination="$2" response rc
   response=$(mktemp "$work/bootstrap-pr-pages.XXXXXX")
@@ -647,7 +658,7 @@ reconcile_bootstrap_prs() {
       rm -f "$open_prs"
       return 1
     fi
-    if [[ ! "$head_ref" =~ ^sync/exact-caller-[0-9a-f]{18}-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
+    if ! parse_exact_caller_owner "$head_ref"; then
       echo "[ERROR] Unrecognized exact-caller automation branch for ${slug}" >&2
       rm -f "$open_prs"
       return 1
@@ -658,8 +669,8 @@ reconcile_bootstrap_prs() {
       bootstrap_pr_head_oid="$head_oid"
       continue
     fi
-    other_run="${BASH_REMATCH[1]}"
-    other_attempt="${BASH_REMATCH[2]}"
+    other_run="$exact_caller_owner_run"
+    other_attempt="$exact_caller_owner_attempt"
     if decimal_greater_than "$other_run" "$run_id" ||
       { [ "$other_run" = "$run_id" ] &&
         decimal_greater_than "$other_attempt" "$run_attempt"; }; then
@@ -724,7 +735,7 @@ reconcile_bootstrap_prs() {
       rm -f "$open_prs"
       return 1
     fi
-    if [[ ! "$head_ref" =~ ^sync/exact-caller-[0-9a-f]{18}-([1-9][0-9]*)-([1-9][0-9]*)$ ]]; then
+    if ! parse_exact_caller_owner "$head_ref"; then
       echo "[ERROR] Unrecognized exact-caller automation branch for ${slug}" >&2
       rm -f "$open_prs"
       return 1
@@ -1398,13 +1409,13 @@ if [ "$newer_owner" = true ]; then
   echo "[DEFER] A newer bootstrap run owns the transition"
   exit 83
 fi
-if [ "$transition_pending" = true ]; then
-  echo "[DEFER] Linked-issue transition checks remain pending"
-  exit 83
-fi
 if [ "$failures" -gt 0 ]; then
   echo "[ERROR] ${failures} downstream caller bootstrap(s) failed" >&2
   exit 1
+fi
+if [ "$transition_pending" = true ]; then
+  echo "[DEFER] Linked-issue transition checks remain pending"
+  exit 83
 fi
 
 deadline=$((SECONDS + wait_seconds))

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -265,7 +265,13 @@ case "$1 $endpoint" in
       printf '[]\n'
     fi
     ;;
-  'api repos/f5-sales-demo/example-two/commits/main') printf '%s\n' "$BASE_SHA" ;;
+  'api repos/f5-sales-demo/example-two/commits/main')
+    if [ "${FAKE_FAIL_SECOND_BOOTSTRAP:-}" = 1 ]; then
+      echo 'gh: synthetic protected-main read failure (HTTP 500)' >&2
+      exit 1
+    fi
+    printf '%s\n' "$BASE_SHA"
+    ;;
   'api repos/f5-sales-demo/example-two/actions/workflows/enforce-repo-settings.yml')
     if [ -f "$FAKE_STATE/disabled-example-two" ]; then
       printf 'disabled_manually\n'
@@ -482,20 +488,23 @@ case "$1 $endpoint" in
         '[{number: 11, head: {ref: $branch, sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/page-two-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[], [{number: 9, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[], [{number: 9, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/huge-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[{number: 10, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-999999999999999999999999999999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[{number: 10, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-999999999999999999999999999999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/newer-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[{number: 8, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[{number: 8, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-99999-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+    elif [ -f "$FAKE_STATE/malformed-owner-open" ]; then
+      jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
+        '[{number: 14, head: {ref: "sync/exact-caller-invalid", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/current-pr" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg branch "$EXPECTED_BRANCH" \
         --arg repo "${GITHUB_REPOSITORY%/*}/example" \
         '[{number: 42, head: {ref: $branch, sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     elif [ -f "$FAKE_STATE/old-open" ]; then
       jq -cn --arg sha "$BRANCH_HEAD" --arg repo "${GITHUB_REPOSITORY%/*}/example" \
-        '[{number: 7, head: {ref: "sync/exact-caller-aaaaaaaaaaaaaaaaaa-12-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
+        '[{number: 7, head: {ref: "sync/exact-caller-aaaaaaaaaaaa-12-1", sha: $sha, repo: {full_name: $repo}}, base: {ref: "main"}}]'
     else
       printf '[]\n'
     fi
@@ -611,6 +620,7 @@ run_bootstrap() {
     FAKE_STAGED_LINKED_TRANSITION="${FAKE_STAGED_LINKED_TRANSITION:-}" \
     FAKE_LEGACY_LINKED_CHECK="${FAKE_LEGACY_LINKED_CHECK:-}" \
     FAKE_RECOVER_MERGED_TRANSITION="${FAKE_RECOVER_MERGED_TRANSITION:-}" \
+    FAKE_FAIL_SECOND_BOOTSTRAP="${FAKE_FAIL_SECOND_BOOTSTRAP:-}" \
     REPO_SETTINGS_TOKEN=settings-token \
     "$SOURCE"
 }
@@ -1060,6 +1070,23 @@ if [ "$rc" = 0 ] ||
 fi
 echo "[OK] hostile same-ref fork PR blocks exact-caller mutation"
 
+state="$WORK/state-malformed-owner"
+mkdir -p "$state"
+touch "$state/malformed-owner-open" "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+set +e
+run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+if [ "$rc" = 0 ] ||
+  grep -qE '^pr (close|create|merge) |git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] malformed reserved-namespace ownership was mutated"
+  exit 1
+fi
+echo "[OK] malformed reserved-namespace ownership fails closed"
+
 state="$WORK/state-duplicate-current"
 mkdir -p "$state"
 touch "$state/duplicate-current-open" "$state/disabled"
@@ -1202,6 +1229,26 @@ fi
 echo "[OK] source advancement during enable re-quiesces the fleet"
 
 printf '["example","example-two"]\n' >"$WORK/repos-two.json"
+state="$WORK/state-mixed-pending-and-failure"
+mkdir -p "$state"
+touch "$state/disabled" "$state/disabled-example-two"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_STAGED_LINKED_TRANSITION=1
+FAKE_FAIL_SECOND_BOOTSTRAP=1
+set +e
+TEST_DOWNSTREAM_CONFIG="$WORK/repos-two.json" run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+unset DOWNSTREAM_LINKED_BLOB FAKE_STAGED_LINKED_TRANSITION FAKE_FAIL_SECOND_BOOTSTRAP
+if [ "$rc" != 1 ] || grep -q 'actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+  "$WORK/gh.log"; then
+  echo "[FAIL] recoverable transition state masked a permanent fleet bootstrap failure"
+  exit 1
+fi
+echo "[OK] permanent fleet bootstrap failures take precedence over recoverable transition state"
+
 state="$WORK/state-partial-enable-failure"
 mkdir -p "$state"
 touch "$state/disabled" "$state/disabled-example-two"


### PR DESCRIPTION
## Summary

- Parse reserved exact-caller ownership independently of the managed caller digest width while retaining exact repository, protected-main, run-ID, attempt, and newer-owner checks.
- Make permanent per-repository bootstrap failures take precedence over recoverable pending transitions.
- Add regressions for the prior digest shape, malformed ownership, oversized/newer owners, and mixed pending-plus-failed fleet outcomes.

## Related Issue

Closes #1168

## Verification evidence

- Red test before implementation: the prior 12-character digest fixture failed with `Unrecognized exact-caller automation branch` and exit 1.
- `BOOTSTRAP_POLL_SECONDS=1 bash tests/test-bootstrap-downstream-callers.sh`: all 38 contract cases passed.
- Complete `tests/test-*.sh` matrix: 32/32 shell test programs passed.
- `shellcheck scripts/bootstrap-downstream-callers.sh tests/test-bootstrap-downstream-callers.sh`: passed.
- `pre-commit run --all-files`: every hook passed, including ShellCheck, actionlint, zizmor, Checkov, Gitleaks, repository hygiene, and translation routing.
- `bash scripts/agy-pre-push-review.sh` against commit `4754a90`: PII enforce clean; zero blocking, medium, or nit findings.

## Checklist

- [x] Linked to a detailed GitHub issue
- [x] Feature-complete root-cause fix with no manual branch-protection bypass
- [x] Tests written red-first and passing
- [x] Verified locally with the complete registered shell-test matrix
- [x] Required sandboxed Antigravity review passed for the pushed HEAD
- [ ] Required PR CI watched to green before merge
- [x] Protected `main` is changed only through this PR