### PR TITLE
fix(lint): select the target Rust edition

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -6,6 +6,12 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
   workflow_call:
+    inputs:
+      rust_edition:
+        description: Rust edition to format (none, 2018, 2021, or 2024)
+        required: false
+        type: string
+        default: "2021"
 
 permissions: {}
 
@@ -279,6 +285,18 @@ jobs:
             echo "scripts/lint-mdx-prose.sh not present in this repository — skipping"
           fi
 
+      - name: Validate Rust edition input
+        env:
+          RUST_EDITION: ${{ inputs.rust_edition || 'none' }}
+        run: |
+          case "$RUST_EDITION" in
+            none|2018|2021|2024) ;;
+            *)
+              echo "::error::rust_edition must be one of: none, 2018, 2021, 2024"
+              exit 1
+              ;;
+          esac
+
       - name: Run Super-Linter
         uses: super-linter/super-linter@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
@@ -380,9 +398,13 @@ jobs:
           # tuned per-repo (e.g., .clang-format-ignore in xcsh).
           VALIDATE_CPP: false
           VALIDATE_CPP_EPA: false
-          # Rust 2015 edition checks: governed repos target edition 2021
-          # or 2024; the 2015 validator flags normal modern-edition code.
+          # Run exactly the Rust edition selected by the reusable-workflow caller.
+          # Multiple edition validators are not additive: an older rustfmt parser
+          # rejects valid syntax from a newer edition before formatting begins.
           VALIDATE_RUST_2015: false
+          VALIDATE_RUST_2018: ${{ inputs.rust_edition == '2018' }}
+          VALIDATE_RUST_2021: ${{ inputs.rust_edition == '2021' }}
+          VALIDATE_RUST_2024: ${{ inputs.rust_edition == '2024' }}
           # Dockerfile hadolint: overlaps with CHECKOV for dockerfile
           # security scanning; running both is redundant noise.
           VALIDATE_DOCKERFILE_HADOLINT: false

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -388,6 +388,35 @@ echo ""
 echo "=== Section 5e: super-linter VALIDATE_* disables ==="
 
 SL_YML="$REPO_ROOT/.github/workflows/super-linter.yml"
+WORKFLOW_CALL_BLOCK=$(awk '/^[[:space:]]+workflow_call:/,/^permissions:/' "$SL_YML")
+
+if printf '%s' "$WORKFLOW_CALL_BLOCK" | grep -qE '^[[:space:]]+rust_edition:' &&
+  printf '%s' "$WORKFLOW_CALL_BLOCK" | grep -qE '^[[:space:]]+default:[[:space:]]+"2021"'; then
+  pass "5e.1 reusable workflow declares a Rust edition input with the fleet default"
+else
+  fail "5e.1 reusable workflow declares a Rust edition input with the fleet default" \
+    "workflow_call.rust_edition must default to edition 2021"
+fi
+
+RUST_EDITION_STEP=$(awk '/- name: Validate Rust edition input/,/- name: Run Super-Linter/' "$SL_YML")
+if printf '%s' "$RUST_EDITION_STEP" | grep -q 'none|2018|2021|2024' &&
+  printf '%s' "$RUST_EDITION_STEP" | grep -qE '^[[:space:]]*exit 1$'; then
+  pass "5e.2 invalid Rust editions fail closed"
+else
+  fail "5e.2 invalid Rust editions fail closed" \
+    "the workflow must reject every value except none, 2018, 2021, or 2024"
+fi
+
+for edition in 2018 2021 2024; do
+  expected="VALIDATE_RUST_${edition}: \${{ inputs.rust_edition == '${edition}' }}"
+  if grep -Fq "$expected" "$SL_YML"; then
+    pass "5e.3 Rust ${edition} validation is selected only for edition ${edition}"
+  else
+    fail "5e.3 Rust ${edition} validation is selected only for edition ${edition}" \
+      "missing exact workflow_call input selector"
+  fi
+done
+
 # Each entry below is an explicit "not relevant" decision captured with
 # its rationale in the workflow comment. Removing a disable re-introduces
 # a full audit surface for that validator on every governed repo.


### PR DESCRIPTION
## Summary

Make the reusable Super-Linter workflow select one caller-declared Rust edition, so older rustfmt parsers do not reject valid newer-edition syntax. Invalid edition values fail closed.

## Related Issue

Closes #1172

## Changes

- Add a rust_edition workflow_call input with the fleet default of 2021.
- Validate none, 2018, 2021, or 2024 and reject every other value.
- Enable exactly the matching Rust formatter in Super-Linter.
- Add TDD coverage for the input, validation, and selector mapping.

## Verification evidence

- Red: tests/test-linter-configs.sh reported 157 passed and 5 expected failures before implementation.
- Green: bash tests/test-linter-configs.sh — 162 passed, 0 failed.
- bash tests/test-protect-managed-files.sh — 133 passed, 0 failed.
- bash tests/test-consumer-shell-tests.sh — 25 passed, 0 failed.
- actionlint .github/workflows/super-linter.yml — clean.
- bash scripts/check-pii.sh --scope head --mode enforce — clean.
- Antigravity pre-push review — clean, no findings.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
