### PR TITLE
fix(lint): keep Rust edition selection in exclude mode

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -297,6 +297,17 @@ jobs:
               ;;
           esac
 
+          # Super-Linter rejects a mix of explicit true (include mode) and
+          # false (exclude mode) VALIDATE_* settings. This workflow already
+          # excludes unrelated validators, so leave the selected Rust edition
+          # unset and dynamically exclude every other edition. `none` excludes
+          # them all.
+          for edition in 2015 2018 2021 2024; do
+            if [ "$RUST_EDITION" != "$edition" ]; then
+              echo "VALIDATE_RUST_${edition}=false" >> "$GITHUB_ENV"
+            fi
+          done
+
       - name: Run Super-Linter
         uses: super-linter/super-linter@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
@@ -398,13 +409,7 @@ jobs:
           # tuned per-repo (e.g., .clang-format-ignore in xcsh).
           VALIDATE_CPP: false
           VALIDATE_CPP_EPA: false
-          # Run exactly the Rust edition selected by the reusable-workflow caller.
-          # Multiple edition validators are not additive: an older rustfmt parser
-          # rejects valid syntax from a newer edition before formatting begins.
-          VALIDATE_RUST_2015: false
-          VALIDATE_RUST_2018: ${{ inputs.rust_edition == '2018' }}
-          VALIDATE_RUST_2021: ${{ inputs.rust_edition == '2021' }}
-          VALIDATE_RUST_2024: ${{ inputs.rust_edition == '2024' }}
+
           # Dockerfile hadolint: overlaps with CHECKOV for dockerfile
           # security scanning; running both is redundant noise.
           VALIDATE_DOCKERFILE_HADOLINT: false

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -407,20 +407,27 @@ else
     "the workflow must reject every value except none, 2018, 2021, or 2024"
 fi
 
-for edition in 2018 2021 2024; do
-  expected="VALIDATE_RUST_${edition}: \${{ inputs.rust_edition == '${edition}' }}"
-  if grep -Fq "$expected" "$SL_YML"; then
-    pass "5e.3 Rust ${edition} validation is selected only for edition ${edition}"
-  else
-    fail "5e.3 Rust ${edition} validation is selected only for edition ${edition}" \
-      "missing exact workflow_call input selector"
-  fi
-done
+if printf '%s' "$RUST_EDITION_STEP" | grep -Fq 'for edition in 2015 2018 2021 2024; do' &&
+  printf '%s' "$RUST_EDITION_STEP" | grep -Fq 'if [ "$RUST_EDITION" != "$edition" ]; then' &&
+  printf '%s' "$RUST_EDITION_STEP" | grep -Fq \
+    'echo "VALIDATE_RUST_${edition}=false" >> "$GITHUB_ENV"'; then
+  pass "5e.3 non-selected Rust editions are exported as exclusions"
+else
+  fail "5e.3 non-selected Rust editions are exported as exclusions" \
+    "the input step must disable every Rust validator except the selected edition"
+fi
+
+if grep -qE '^[[:space:]]*VALIDATE_RUST_[0-9]+:' "$SL_YML"; then
+  fail "5e.4 the Super-Linter env does not mix include and exclude modes" \
+    "Rust validator keys belong in GITHUB_ENV, not the static action env"
+else
+  pass "5e.4 the Super-Linter env does not mix include and exclude modes"
+fi
 
 # Each entry below is an explicit "not relevant" decision captured with
 # its rationale in the workflow comment. Removing a disable re-introduces
 # a full audit surface for that validator on every governed repo.
-for v in POWERSHELL HTML CPP RUST_2015 DOCKERFILE_HADOLINT BASH_EXEC EDITORCONFIG PROTOBUF; do
+for v in POWERSHELL HTML CPP DOCKERFILE_HADOLINT BASH_EXEC EDITORCONFIG PROTOBUF; do
   if grep -qE "^[[:space:]]*VALIDATE_${v}:[[:space:]]+false" "$SL_YML"; then
     pass "5e.x super-linter disables VALIDATE_${v}"
   else


### PR DESCRIPTION
Closes #1176

Super-Linter rejects configurations that mix explicit true and false VALIDATE_* values. The reusable workflow now remains in exclude mode: it validates rust_edition, exports false only for non-selected Rust editions, and leaves the selected validator unset. The none value excludes every Rust validator.

TDD evidence:
- Regression test was red first with 158 passed / 2 failed.
- bash tests/test-linter-configs.sh: 160 passed / 0 failed.
- All 32 shell test groups: passed.
- actionlint: passed.
- PII enforcement: clean.
- Antigravity pre-push review: no findings.