### PR TITLE
fix(ci): keep workflow security audit runnable

### DIFF
--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -43,4 +43,8 @@ jobs:
           persist-credentials: false
 
       - name: Reject every workflow security finding
-        run: pipx run zizmor --no-config --no-ignores --persona=auditor .github/workflows/ workflows/*.yml
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          targets=(.github/workflows/ workflows/*.yml)
+          pipx run zizmor --no-config --no-ignores --persona=auditor "${targets[@]}"

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -602,6 +602,55 @@ else
   pass "6.4 audit gate fails on every finding"
 fi
 
+ZIZMOR_RUN=$(python3 - "$ZIZMOR_GATE" <<'PY'
+import sys
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    workflow = yaml.safe_load(handle)
+for step in workflow["jobs"]["audit"]["steps"]:
+    if step.get("name") == "Reject every workflow security finding":
+        print(step["run"])
+        break
+else:
+    raise SystemExit("zizmor audit step not found")
+PY
+)
+ZIZMOR_TMP=$(mktemp -d /tmp/test-linter-configs-zizmor-XXXXXX)
+mkdir -p "$ZIZMOR_TMP/bin" "$ZIZMOR_TMP/without/.github/workflows" \
+  "$ZIZMOR_TMP/with/.github/workflows" "$ZIZMOR_TMP/with/workflows"
+printf '%s\n' '#!/bin/sh' \
+  'printf "%s\\n" "$@" > "${ZIZMOR_ARGS:?}"' >"$ZIZMOR_TMP/bin/pipx"
+chmod +x "$ZIZMOR_TMP/bin/pipx"
+touch "$ZIZMOR_TMP/with/workflows/source.yml"
+
+(
+  cd "$ZIZMOR_TMP/without"
+  PATH="$ZIZMOR_TMP/bin:$PATH" ZIZMOR_ARGS="$ZIZMOR_TMP/without.args" \
+    env -u BASH_ENV bash -euo pipefail -c "$ZIZMOR_RUN"
+)
+if grep -Fxq '.github/workflows/' "$ZIZMOR_TMP/without.args" &&
+  ! grep -Fq 'workflows/*.yml' "$ZIZMOR_TMP/without.args"; then
+  pass "6.5 audit omits an unmatched optional workflow-source glob"
+else
+  fail "6.5 audit omits an unmatched optional workflow-source glob" \
+    "an absent workflows directory must not become a remote zizmor target"
+fi
+
+(
+  cd "$ZIZMOR_TMP/with"
+  PATH="$ZIZMOR_TMP/bin:$PATH" ZIZMOR_ARGS="$ZIZMOR_TMP/with.args" \
+    env -u BASH_ENV bash -euo pipefail -c "$ZIZMOR_RUN"
+)
+if grep -Fxq '.github/workflows/' "$ZIZMOR_TMP/with.args" &&
+  grep -Fxq 'workflows/source.yml' "$ZIZMOR_TMP/with.args"; then
+  pass "6.6 audit includes optional workflow sources when present"
+else
+  fail "6.6 audit includes optional workflow sources when present" \
+    "present canonical workflow sources must remain covered"
+fi
+rm -rf "$ZIZMOR_TMP"
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5a: .jscpd.json guardrails — threshold + ignore patterns
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -602,7 +602,8 @@ else
   pass "6.4 audit gate fails on every finding"
 fi
 
-ZIZMOR_RUN=$(python3 - "$ZIZMOR_GATE" <<'PY'
+ZIZMOR_RUN=$(
+  python3 - "$ZIZMOR_GATE" <<'PY'
 import sys
 import yaml
 

--- a/tests/test-privileged-pr-workflows.sh
+++ b/tests/test-privileged-pr-workflows.sh
@@ -93,6 +93,12 @@ for file in \
   require_literal "$file" '<!-- require-linked-issue -->' "${file#"$REPO_ROOT/"} preserves the deduplicated guidance comment"
 done
 
+AUTO_MERGE_CALLER="$REPO_ROOT/workflows/auto-merge.yml"
+require_literal "$AUTO_MERGE_CALLER" 'group: caller-auto-merge-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}' \
+  'managed auto-merge caller limits concurrency without colliding with the reusable'
+require_literal "$AUTO_MERGE_CALLER" '    environment: repository-settings' \
+  'managed auto-merge token preflight uses the existing protected environment'
+
 reject_literal "$REPO_ROOT/zizmor.yaml" 'disable:' 'zizmor configuration disables no audits'
 reject_literal "$REPO_ROOT/zizmor.yaml" 'ignore:' 'zizmor configuration ignores no findings'
 require_literal "$REPO_ROOT/workflows/workflow-security-audit.yml" '--no-config --no-ignores --persona=auditor' 'managed audit refuses configuration and inline suppressions'

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -9,6 +9,12 @@ on:
 
 permissions: {}
 
+# Keep caller cancellation separate from the reusable workflow's concurrency
+# group; sharing a group lets the called run cancel its own caller.
+concurrency:
+  group: caller-auto-merge-${{ github.repository }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # Auto-merge has exactly one credential: the REPO_SYNC_TOKEN PAT. A merge pushed
   # with the automatic token cannot start the downstream workflows a merge is meant
@@ -20,6 +26,7 @@ jobs:
   # secrets, so an absent token there is not a misconfiguration.
   require-token:
     name: Require canonical auto-merge token
+    environment: repository-settings
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&

--- a/workflows/workflow-security-audit.yml
+++ b/workflows/workflow-security-audit.yml
@@ -43,4 +43,8 @@ jobs:
           persist-credentials: false
 
       - name: Reject every workflow security finding
-        run: pipx run zizmor --no-config --no-ignores --persona=auditor .github/workflows/ workflows/*.yml
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          targets=(.github/workflows/ workflows/*.yml)
+          pipx run zizmor --no-config --no-ignores --persona=auditor "${targets[@]}"


### PR DESCRIPTION
Closes #1183

Fixes the post-merge audit failure observed on xcsh main:

- Build zizmor targets with Bash nullglob so an absent optional workflows directory is omitted rather than interpreted as a remote repository.
- Preserve canonical workflow-source coverage when those files exist.
- Resolve the two unsuppressed findings introduced by the latest managed auto-merge caller: add a caller-specific concurrency group and bind the token preflight to the existing repository-settings environment.
- Cover both target shapes and both auto-merge security contracts with red-first regressions.

Verification:
- tests/test-linter-configs.sh: 162 passed / 0 failed.
- All 32 shell test programs: passed.
- Actionlint: passed.
- Unsuppressed zizmor 1.29 audit: no findings.
- PII enforcement: clean.
- Antigravity pre-push review: no findings.