### PR TITLE
fix(i18n): validate translated structure

### DIFF
--- a/.agents/skills/i18n-translate/SKILL.md
+++ b/.agents/skills/i18n-translate/SKILL.md
@@ -81,12 +81,19 @@ Check for English source files that have been **deleted** from `docs/en/` or `sr
     translator: "machine"
   ```
 
-### Non-Translatable Elements
+### Translatable Prose and Protected Structure
 
-1. **Code Blocks & Inline Code**: Keep code blocks (fenced with ``` or ~~~) and inline code (`...`) completely untranslated.
-2. **JSX / MDX Elements**: Keep HTML/JSX component tags intact, including attributes, imports (`import ... from '...'`), and exports (`export ...`).
-3. **Brand & Product Names**: Keep technical product names untranslated (e.g., `F5`, `F5 Distributed Cloud`, `XC`, `NGINX`, `Terraform`, `Kubernetes`, `Docker`).
-4. **URLs & File Paths**: Do not translate image paths, hyperlinks, or absolute/relative URLs unless locale-specific pathing is explicitly required.
+1. **Fenced Blocks**: Preserve the number of fenced blocks and every info string after the
+   opening fence. Translate human-readable output and comments, but keep executable syntax,
+   commands, flags, identifiers, and configuration data unchanged.
+2. **Inline Code**: Translate a span only when it contains a natural-language interface label,
+   status, or message. Keep commands, identifiers, literal values, and file paths unchanged.
+3. **JSX / MDX Elements**: Keep element names, nesting, and attribute names intact. Translate
+   literal string values only for the prose attributes `title`, `text`, and `alt`; preserve every
+   other attribute value or expression. Keep imports (`import ... from '...'`) and exports
+   (`export ...`) unchanged.
+4. **Brand & Product Names**: Keep technical product names untranslated (e.g., `F5`, `F5 Distributed Cloud`, `XC`, `NGINX`, `Terraform`, `Kubernetes`, `Docker`).
+5. **URLs & File Paths**: Do not translate image paths, link targets, or absolute/relative URLs unless locale-specific pathing is explicitly required.
 
 ---
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -279,7 +279,7 @@ repos:
   # Translation validation — deterministic only. English-only source commits
   # are allowed through so the governed workflow can generate locale output;
   # any locale file that is staged locally must already match its English hash
-  # and preserve code, links, imports, and MDX component structure.
+  # and preserve fence shape, links, imports, and MDX component structure.
   # ===========================================================================
   - repo: local
     hooks:

--- a/scripts/validate-translations.sh
+++ b/scripts/validate-translations.sh
@@ -92,6 +92,7 @@ import os
 import re
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 MODE, BASE, HEAD = sys.argv[1:]
@@ -173,26 +174,67 @@ def without_frontmatter(text: str) -> str:
     return text
 
 
+PROSE_JSX_ATTRIBUTES = ("title", "text", "alt")
+PROSE_JSX_ATTRIBUTE_RE = re.compile(
+    r"(?<![-A-Za-z0-9_:.])(" + "|".join(PROSE_JSX_ATTRIBUTES)
+    + r")\s*=\s*(?:\"[^\"\n]*\"|'[^'\n]*')"
+)
+FENCE_RE = re.compile(
+    r"(?ms)^\s*(?P<f>`{3,}|~{3,})(?P<info>[^\n]*)\n.*?^\s*(?P=f)\s*$"
+)
+MDX_TAG_RE = re.compile(
+    r"(?s)</?[A-Z][A-Za-z0-9_.:-]*(?:\s+[^<>]*?)?/?>"
+)
+
+
+def normalize_mdx_tag(tag: str) -> str:
+    return PROSE_JSX_ATTRIBUTE_RE.sub(
+        lambda match: f"{match.group(1)}=<translated>", tag
+    )
+
+
 def protected_fragments(raw: bytes) -> dict[str, list[str]]:
     body = without_frontmatter(raw.decode("utf-8", "strict"))
-    fence_blocks = [
-        match.group(0)
-        for match in re.finditer(r"(?ms)^\s*(?P<f>`{3,}|~{3,})[^\n]*\n.*?^\s*(?P=f)\s*$", body)
-    ]
-    body_without_fences = re.sub(
-        r"(?ms)^\s*(?P<f>`{3,}|~{3,})[^\n]*\n.*?^\s*(?P=f)\s*$", "", body
-    )
+    body_without_fences = FENCE_RE.sub("", body)
     return {
-        "fenced code blocks": fence_blocks,
-        "inline code": re.findall(r"(?<!`)`[^`\n]+`(?!`)", body_without_fences),
+        "fence signatures": [
+            match.group("info").strip() for match in FENCE_RE.finditer(body)
+        ],
         "URLs": re.findall(r"https?://[^\s<>\]\)\"']+", body_without_fences),
+        "link targets": re.findall(r"\]\(([^)]+)\)", body_without_fences),
         "MDX imports/exports": re.findall(
             r"(?m)^(?:import|export)\s+.*$", body_without_fences
         ),
-        "MDX component tags": re.findall(
-            r"(?s)</?[A-Z][A-Za-z0-9_.:-]*(?:\s+[^<>]*?)?/?>", body_without_fences
-        ),
+        "MDX component tags": [
+            normalize_mdx_tag(match.group(0))
+            for match in MDX_TAG_RE.finditer(body_without_fences)
+        ],
     }
+
+
+def describe_fragment_drift(source_values: list[str], target_values: list[str]) -> str:
+    details = []
+    source_counts = Counter(source_values)
+    target_counts = Counter(target_values)
+    for direction, drift in (
+        ("missing", source_counts - target_counts),
+        ("unexpected", target_counts - source_counts),
+    ):
+        items = sorted(drift.items())
+        for value, count in items[:3]:
+            details.append(f"{direction} {value!r} (count {count})")
+        if len(items) > 3:
+            details.append(f"{direction} {len(items) - 3} more fragment kinds")
+    if not details:
+        for index, (source_value, target_value) in enumerate(
+            zip(source_values, target_values), 1
+        ):
+            if source_value != target_value:
+                details.append(
+                    f"position {index} expected {source_value!r}, got {target_value!r}"
+                )
+                break
+    return "; ".join(details)
 
 
 def validate_target(source_raw: bytes, target_raw: bytes, target: str) -> None:
@@ -206,7 +248,8 @@ def validate_target(source_raw: bytes, target_raw: bytes, target: str) -> None:
     target_fragments = protected_fragments(target_raw)
     for category, values in source_fragments.items():
         if target_fragments[category] != values:
-            raise ValueError(f"{target}: {category} changed during translation")
+            drift = describe_fragment_drift(values, target_fragments[category])
+            raise ValueError(f"{target}: protected {category} changed: {drift}")
 
 
 def counterparts(source_path: str) -> list[str]:

--- a/tests/test-validate-translations.sh
+++ b/tests/test-validate-translations.sh
@@ -28,7 +28,7 @@ PY
 }
 
 write_target() {
-  local repo=$1 locale=$2 hash=$3 code=${4:-'echo safe'}
+  local repo=$1 locale=$2 hash=$3 code=${4:-'echo safe'} fence_info=${5:-sh}
   mkdir -p "$repo/docs/$locale"
   printf '%s\n' \
     '---' \
@@ -38,9 +38,20 @@ write_target() {
     '  translator: "machine"' \
     '---' \
     '' \
-    'Texte `literal` https://example.com/docs.' \
+    'import { Aside, Badge, Image } from "@components";' \
     '' \
-    '```sh' \
+    '<Aside type="note" title="確認済み">本文。</Aside>' \
+    '<Badge text="33 コマンド" variant="note" />' \
+    '<Image src="/images/hero.svg" alt="主要図" />' \
+    '' \
+    '本文 `2026-07-28 に確認済み` https://example.com/docs [案内](../guide/).' \
+    '' \
+    '```text' \
+    '管理/SLO    タイムアウト' \
+    '```' \
+    '' \
+    "\`\`\`$fence_info" \
+    '# 安全なコマンド' \
     "$code" \
     '```' >"$repo/docs/$locale/page.mdx"
 }
@@ -57,9 +68,20 @@ make_repo() {
     'title: Page' \
     '---' \
     '' \
-    'Text `literal` https://example.com/docs.' \
+    'import { Aside, Badge, Image } from "@components";' \
+    '' \
+    '<Aside type="note" title="What is verified here">Body.</Aside>' \
+    '<Badge text="33 commands" variant="note" />' \
+    '<Image src="/images/hero.svg" alt="Hero diagram" />' \
+    '' \
+    'Status: `Observed 2026-07-28` https://example.com/docs [Guide](../guide/).' \
+    '' \
+    '```text' \
+    'management/SLO address    timed out' \
+    '```' \
     '' \
     '```sh' \
+    '# Safe command' \
     'echo safe' \
     '```' >"$repo/docs/en/page.mdx"
   local hash
@@ -155,11 +177,41 @@ git -C "$repo" rm -q docs/fr/unrelated.mdx
 git -C "$repo" commit -qm remove-out-of-scope
 head=$(git -C "$repo" rev-parse HEAD)
 
-write_target "$repo" fr "$hash" 'echo changed'
+write_target "$repo" fr "$hash" 'echo safe' bash
 if (cd "$repo" && bash "$SCRIPT" --base "$base" --head "$head" >/dev/null 2>&1); then
-  fail "translated fenced code fails" "validator returned success"
+  fail "changed fence info string fails" "validator returned success"
 else
-  pass "translated fenced code fails"
+  pass "changed fence info string fails"
+fi
+
+repo=$(make_repo)
+sed -i.bak 's/type="note"/type="warning"/' "$repo/docs/fr/page.mdx"
+rm -f "$repo/docs/fr/page.mdx.bak"
+git -C "$repo" add docs/fr/page.mdx
+if output=$(cd "$repo" && bash "$SCRIPT" --staged 2>&1); then
+  fail "functional JSX drift reports the exact token" "validator returned success"
+elif grep -qF 'docs/fr/page.mdx: protected MDX component tags changed' <<<"$output" &&
+  grep -qF 'missing' <<<"$output" &&
+  grep -qF 'type="note"' <<<"$output" &&
+  grep -qF 'unexpected' <<<"$output" &&
+  grep -qF 'type="warning"' <<<"$output"; then
+  pass "functional JSX drift reports the exact token"
+else
+  fail "functional JSX drift reports the exact token" "$output"
+fi
+
+repo=$(make_repo)
+sed -i.bak 's#](../guide/)#](../translated/)#' "$repo/docs/fr/page.mdx"
+rm -f "$repo/docs/fr/page.mdx.bak"
+git -C "$repo" add docs/fr/page.mdx
+if output=$(cd "$repo" && bash "$SCRIPT" --staged 2>&1); then
+  fail "link-target drift reports the exact token" "validator returned success"
+elif grep -qF 'protected link targets changed' <<<"$output" &&
+  grep -qF "missing '../guide/'" <<<"$output" &&
+  grep -qF "unexpected '../translated/'" <<<"$output"; then
+  pass "link-target drift reports the exact token"
+else
+  fail "link-target drift reports the exact token" "$output"
 fi
 
 repo=$(make_repo)


### PR DESCRIPTION
## Summary

Fix deterministic translation validation so it protects functional Markdown/MDX structure without requiring translatable prose to remain byte-identical.

## Related Issue

Closes #1185

## Changes

- Compare fenced-block count and info strings while allowing localized body output and comments.
- Allow natural-language inline spans and literal JSX `title`, `text`, and `alt` values to be translated.
- Keep URLs, link targets, imports/exports, JSX element structure, and all functional attribute values protected.
- Report the exact missing and unexpected protected fragment when validation fails.
- Align the managed translation skill and pre-commit contract with the deterministic validator.
- Add hermetic coverage for corpus-compatible output, fence signature drift, functional JSX drift, link-target drift, both validation modes, metadata, output scope, and deletion behavior.

## Verification evidence

Local verification against exact HEAD `d8d119f`:

- `bash tests/test-validate-translations.sh` — 12 passed, 0 failed.
- `bash tests/test-translation-suspension.sh` — 10 passed, 0 failed.
- `bash tests/test-agent-guidance.sh` — 59 passed, 0 failed.
- `bash -n scripts/validate-translations.sh tests/test-validate-translations.sh` — passed.
- `shellcheck scripts/validate-translations.sh tests/test-validate-translations.sh` — passed.
- `shfmt -d scripts/validate-translations.sh tests/test-validate-translations.sh` — clean.
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean.
- `pre-commit run --all-files` — all hooks passed.
- `bash scripts/agy-pre-push-review.sh` — exact-HEAD PII and semantic review passed; no critical or high finding remains.

Independent downstream evidence supplied by the `mcn` developer for the same structural policy before the current-main rebase:

- Static failures fell from 457/552 locale files to 121/552; the residual files were all stale by `sourceHash` and therefore legitimate regeneration candidates.
- An end-to-end run on `mcn`'s `demo/present.mdx` regenerated and staged all 12 locales, exited 0, and passed the 552-file parity gate.

CI evidence is intentionally not claimed here until the required contexts complete on this PR.

## Checklist

- [x] Linked to a detailed issue
- [x] Test-first regression coverage added
- [x] Local deterministic checks pass
- [x] Exact-HEAD Antigravity review passes
- [ ] Required CI contexts watched to green
- [ ] Auto-merge completes
