### PR TITLE
feat(governance): onboard xcsh-action

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -2,6 +2,7 @@
   "source_repo": "f5-sales-demo/docs-control",
   "skip_files": {
     "xcsh": ["biome.json", "LICENSE", ".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/super-linter.yml"],
+    "xcsh-action": ["README.md"],
     "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
@@ -142,6 +143,7 @@
       "was": "content",
       "webapp-api-protection": "content",
       "xcsh": "developer",
+      "xcsh-action": "developer",
       "xcsh-chrome-extension": "developer"
     }
   }

--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -137,6 +137,12 @@
     "badges": [{ "name": "CI", "workflow": "ci.yml" }]
   },
   {
+    "label": "xcsh Action",
+    "url": "https://f5-sales-demo.github.io/xcsh-action/llms-full.txt",
+    "description": "Verified GitHub Action for deterministic F5 XC manifest operations",
+    "badges": [{ "name": "CI", "workflow": "ci.yml" }]
+  },
+  {
     "label": "CDN Simulator",
     "url": "https://f5-sales-demo.github.io/cdn-simulator/llms-full.txt",
     "description": "NGINX-based CDN edge node simulator on Azure for multi-vendor lab environments"

--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -23,6 +23,7 @@
   "devcontainer",
   "marketplace",
   "xcsh",
+  "xcsh-action",
   "cdn-simulator",
   "origin-server",
   "traffic-generator",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -128,6 +128,7 @@
         ".mypy.ini",
         ".github/workflows/super-linter.yml"
       ],
+      "xcsh-action": ["README.md"],
       "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],
       "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
       "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini", ".github/workflows/github-pages-deploy.yml"],
@@ -439,6 +440,7 @@
       "starlight-llms-txt": ["governance", "npm_publish"],
       "starlight-mega-menu": ["governance", "npm_publish"],
       "xcsh": ["governance", "npm_publish", "apple_signing"],
+      "xcsh-action": ["governance"],
       "vscode-xcsh": ["governance", "vscode_extension"],
       "terraform-provider-xcsh": ["governance", "terraform_provider"],
       "api-specs": ["governance"],


### PR DESCRIPTION
## What

- register `xcsh-action` for downstream governance dispatch
- classify the repository as `developer`
- add the xcsh Action documentation site
- preserve the Marketplace-specific README through matching opt-outs in both authoritative manifests
- assign the explicit `governance` secret role

## Why

The new public GitHub Action repository needs managed settings and workflow propagation before implementation, without requiring an Action-specific CI context before that context has been observed on `main`.

Closes #1197

## Testing

- JSON parse validation for all four changed manifests — passed
- `bash tests/test-linter-configs.sh` — 164 passed
- `bash tests/test-protect-managed-files.sh` — 133 passed
- `bash tests/test-review-layer-routing.sh` — 54 passed
- `bash tests/test-sync-managed-files.sh` — 69 passed
- `bash tests/test-readme-generation.sh` — 18 passed
- `bash tests/test-consumer-shell-tests.sh` — 25 passed
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean
- `bash scripts/agy-pre-push-review.sh` — clean on `82830cd`

---

- [x] Relevant shell regression suites pass
- [x] PII enforcement passes
- [x] Issue linked via `Closes #1197`
