### PR TITLE
fix(ci): honor caller opt-outs during bootstrap

### DIFF
--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -9,6 +9,7 @@ source_sha="${SOURCE_SHA:-}"
 downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
 rollout_config="${ROLLOUT_CONFIG:-.github/config/governance-rollout.json}"
 repo_settings_config="${REPO_SETTINGS_CONFIG:-.github/config/repo-settings.json}"
+governance_config="${GOVERNANCE_CONFIG:-.claude/governance.json}"
 caller_path=".github/workflows/enforce-repo-settings.yml"
 lint_caller_path=".github/workflows/super-linter.yml"
 linked_caller_path=".github/workflows/require-linked-issue.yml"
@@ -38,6 +39,17 @@ if ! jq -e '
   (length == (unique | length))
 ' "$downstream_config" >/dev/null; then
   echo "[ERROR] Downstream inventory must be a non-empty array of unique repository names" >&2
+  exit 1
+fi
+if ! jq -e '
+  (.skip_files | type == "object") and
+  all(.skip_files | to_entries[];
+    (.key | test("^[A-Za-z0-9_.-]+$")) and
+    (.value | type == "array" and
+      all(.[]; type == "string" and length > 0) and
+      length == (unique | length)))
+' "$governance_config" >/dev/null; then
+  echo "[ERROR] Governance skip_files policy is missing or invalid" >&2
   exit 1
 fi
 if ! jq -e '
@@ -98,6 +110,24 @@ gh() {
   cat "$err_file" >&2
   rm -f "$err_file"
   return "$rc"
+}
+
+# Enforcement and linked-issue callers are universal. Super-Linter is the one
+# exact caller with intentional repository-owned variants declared in skip_files.
+lint_caller_applies() {
+  local name="$1"
+  ! jq -e --arg repo "$name" --arg path "$lint_caller_path" \
+    '(.skip_files[$repo] // []) | index($path) != null' \
+    "$governance_config" >/dev/null
+}
+
+exact_caller_branch_for_repo() {
+  local name="$1" lint_receipt=skipped
+  if lint_caller_applies "$name"; then
+    lint_receipt="$expected_lint_blob"
+  fi
+  printf 'sync/exact-caller-%s%s%s' \
+    "$expected_blob" "$lint_receipt" "$expected_linked_blob"
 }
 
 api_value_or_404() {
@@ -490,7 +520,7 @@ dispatch_and_verify_linked_status() {
 recover_linked_transition_receipt() {
   local name="$1" slug expected_ref response candidate pr_number head actual
   slug="${owner}/${name}"
-  expected_ref="sync/exact-caller-${expected_blob}${expected_lint_blob}${expected_linked_blob}"
+  expected_ref=$(exact_caller_branch_for_repo "$name")
   response=$(mktemp "$work/merged-bootstrap-prs.XXXXXX")
   gh api "repos/${slug}/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
     >"$response"
@@ -526,8 +556,10 @@ recover_linked_transition_receipt() {
   fi
   actual=$(gh api "repos/${slug}/contents/${caller_path}?ref=${head}" --jq '.sha')
   [ "$actual" = "$expected_blob" ] || return 1
-  actual=$(gh api "repos/${slug}/contents/${lint_caller_path}?ref=${head}" --jq '.sha')
-  [ "$actual" = "$expected_lint_blob" ] || return 1
+  if lint_caller_applies "$name"; then
+    actual=$(gh api "repos/${slug}/contents/${lint_caller_path}?ref=${head}" --jq '.sha')
+    [ "$actual" = "$expected_lint_blob" ] || return 1
+  fi
   actual=$(gh api "repos/${slug}/contents/${linked_caller_path}?ref=${head}" --jq '.sha')
   [ "$actual" = "$expected_linked_blob" ] || return 1
   jq -n --argjson pr "$pr_number" --arg head "$head" \
@@ -834,7 +866,8 @@ enable_one() {
 # The mutating path independently repeats the dispatch safety proof.
 callers_exact=false
 set +e
-GH_TOKEN="$REPO_SETTINGS_TOKEN" scripts/preflight-downstream-dispatch.sh
+GOVERNANCE_CONFIG="$governance_config" GH_TOKEN="$REPO_SETTINGS_TOKEN" \
+  scripts/preflight-downstream-dispatch.sh
 preflight_rc=$?
 set -e
 case "$preflight_rc" in
@@ -943,8 +976,6 @@ if [ "$(git hash-object "$work/linked-caller.yml")" != "$expected_linked_blob" ]
   echo "[ERROR] Linked-issue evaluator bytes do not match the GitHub blob receipt" >&2
   exit 1
 fi
-branch="sync/exact-caller-${expected_blob}${expected_lint_blob}${expected_linked_blob}"
-
 if [ "$callers_exact" = true ]; then
   finalization_pending=false
   while IFS= read -r name; do
@@ -996,12 +1027,16 @@ echo "[OK] Downstream enforcement workflows are disabled with no active runs"
 bootstrap_one() {
   local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob
   local actual_linked_blob rc branch_head branch_blob branch_lint_blob branch_linked_blob
-  local expected_change_count
+  local branch expected_change_count manages_lint_caller=true lint_caller_exact=true
   local pr_number pr_url created_pr_number compare_file pr_file verified_head verified_blob
   local verified_lint_blob verified_linked_blob transition_checks
   local base_commit_file base_tree_sha refresh_tree_file refresh_tree_sha refresh_commit_file
   local refresh_head refresh_ref_file current_base_sha current_branch_head
   slug="${owner}/${name}"
+  if ! lint_caller_applies "$name"; then
+    manages_lint_caller=false
+  fi
+  branch=$(exact_caller_branch_for_repo "$name")
 
   assert_source_current
   main_sha=$(gh api "repos/${slug}/commits/main" --jq '.sha')
@@ -1025,22 +1060,26 @@ bootstrap_one() {
   84) return 84 ;;
   *) return 1 ;;
   esac
-  set +e
-  actual_lint_blob=$(api_value_or_404 \
-    "repos/${slug}/contents/${lint_caller_path}?ref=${main_sha}" '.sha')
-  rc=$?
-  set -e
-  case "$rc" in
-  0)
-    if ! printf '%s' "$actual_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
-      echo "[ERROR] Invalid live Super-Linter caller blob for ${name}" >&2
-      return 1
-    fi
-    ;;
-  44) actual_lint_blob="" ;;
-  84) return 84 ;;
-  *) return 1 ;;
-  esac
+  actual_lint_blob=""
+  if [ "$manages_lint_caller" = true ]; then
+    set +e
+    actual_lint_blob=$(api_value_or_404 \
+      "repos/${slug}/contents/${lint_caller_path}?ref=${main_sha}" '.sha')
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      if ! printf '%s' "$actual_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "[ERROR] Invalid live Super-Linter caller blob for ${name}" >&2
+        return 1
+      fi
+      ;;
+    44) actual_lint_blob="" ;;
+    84) return 84 ;;
+    *) return 1 ;;
+    esac
+    [ "$actual_lint_blob" = "$expected_lint_blob" ] || lint_caller_exact=false
+  fi
   set +e
   actual_linked_blob=$(api_value_or_404 \
     "repos/${slug}/contents/${linked_caller_path}?ref=${main_sha}" '.sha')
@@ -1058,13 +1097,13 @@ bootstrap_one() {
   *) return 1 ;;
   esac
   if [ "$actual_blob" = "$expected_blob" ] &&
-    [ "$actual_lint_blob" = "$expected_lint_blob" ] &&
+    [ "$lint_caller_exact" = true ] &&
     [ "$actual_linked_blob" = "$expected_linked_blob" ]; then
     return 0
   fi
   expected_change_count=0
   [ "$actual_blob" = "$expected_blob" ] || expected_change_count=$((expected_change_count + 1))
-  [ "$actual_lint_blob" = "$expected_lint_blob" ] || expected_change_count=$((expected_change_count + 1))
+  [ "$lint_caller_exact" = true ] || expected_change_count=$((expected_change_count + 1))
   [ "$actual_linked_blob" = "$expected_linked_blob" ] || expected_change_count=$((expected_change_count + 1))
 
   default_branch=$(gh api "repos/${slug}" --jq '.default_branch')
@@ -1119,22 +1158,25 @@ bootstrap_one() {
   *) return 1 ;;
   esac
 
-  set +e
-  branch_lint_blob=$(api_value_or_404 \
-    "repos/${slug}/contents/${lint_caller_path}?ref=${branch_head}" '.sha')
-  rc=$?
-  set -e
-  case "$rc" in
-  0)
-    if ! printf '%s' "$branch_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
-      echo "[ERROR] Invalid bootstrap Super-Linter caller blob for ${name}" >&2
-      return 1
-    fi
-    ;;
-  44) branch_lint_blob="" ;;
-  84) return 84 ;;
-  *) return 1 ;;
-  esac
+  branch_lint_blob=""
+  if [ "$manages_lint_caller" = true ]; then
+    set +e
+    branch_lint_blob=$(api_value_or_404 \
+      "repos/${slug}/contents/${lint_caller_path}?ref=${branch_head}" '.sha')
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      if ! printf '%s' "$branch_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "[ERROR] Invalid bootstrap Super-Linter caller blob for ${name}" >&2
+        return 1
+      fi
+      ;;
+    44) branch_lint_blob="" ;;
+    84) return 84 ;;
+    *) return 1 ;;
+    esac
+  fi
 
   set +e
   branch_linked_blob=$(api_value_or_404 \
@@ -1154,7 +1196,8 @@ bootstrap_one() {
   esac
 
   if { [ "$branch_blob" != "$expected_blob" ] ||
-    [ "$branch_lint_blob" != "$expected_lint_blob" ] ||
+    { [ "$manages_lint_caller" = true ] &&
+      [ "$branch_lint_blob" != "$expected_lint_blob" ]; } ||
     [ "$branch_linked_blob" != "$expected_linked_blob" ]; } &&
     [ "$branch_head" != "$base_sha" ]; then
     echo "[ERROR] Refusing to append to a non-exact bootstrap branch for ${name}" >&2
@@ -1172,7 +1215,8 @@ bootstrap_one() {
       --method PUT --input "$work/update-${name}.json" >/dev/null
     branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
   fi
-  if [ "$branch_lint_blob" != "$expected_lint_blob" ]; then
+  if [ "$manages_lint_caller" = true ] &&
+    [ "$branch_lint_blob" != "$expected_lint_blob" ]; then
     jq -n \
       --arg message "chore(governance): bootstrap exact Super-Linter caller" \
       --arg branch "$branch" \
@@ -1211,12 +1255,13 @@ bootstrap_one() {
     if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" \
       --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
       --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
+      --argjson manages_lint "$manages_lint_caller" \
       --argjson change_count "$expected_change_count" '
       .status == "diverged" and .ahead_by > 0 and .behind_by > 0 and
       (.files | length) == $change_count and
       all(.files[];
         ((.filename == $path and .sha == $blob) or
-         (.filename == $lint_path and .sha == $lint_blob) or
+         ($manages_lint and .filename == $lint_path and .sha == $lint_blob) or
          (.filename == $linked_path and .sha == $linked_blob)) and
         (.status == "added" or .status == "modified"))
     ' "$compare_file" >/dev/null; then
@@ -1237,14 +1282,17 @@ bootstrap_one() {
     jq -n --arg base_tree "$base_tree_sha" \
       --arg path "$caller_path" --arg blob "$expected_blob" \
       --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
-      --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" '
+      --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
+      --argjson manages_lint "$manages_lint_caller" '
       {
         base_tree: $base_tree,
-        tree: [
-          {path: $path, mode: "100644", type: "blob", sha: $blob},
-          {path: $lint_path, mode: "100644", type: "blob", sha: $lint_blob},
-          {path: $linked_path, mode: "100644", type: "blob", sha: $linked_blob}
-        ]
+        tree: (
+          [{path: $path, mode: "100644", type: "blob", sha: $blob}] +
+          (if $manages_lint then
+            [{path: $lint_path, mode: "100644", type: "blob", sha: $lint_blob}]
+          else [] end) +
+          [{path: $linked_path, mode: "100644", type: "blob", sha: $linked_blob}]
+        )
       }
     ' >"$work/refresh-tree-${name}.json"
     refresh_tree_file="$work/refresh-tree-response-${name}.json"
@@ -1310,13 +1358,14 @@ bootstrap_one() {
   if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" \
     --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
     --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
+    --argjson manages_lint "$manages_lint_caller" \
     --argjson change_count "$expected_change_count" '
     .status == "ahead" and .behind_by == 0 and .ahead_by >= $change_count and
     .total_commits == .ahead_by and (.commits | length) == .total_commits and
     (.files | length) == $change_count and
     all(.files[];
       ((.filename == $path and .sha == $blob) or
-       (.filename == $lint_path and .sha == $lint_blob) or
+       ($manages_lint and .filename == $lint_path and .sha == $lint_blob) or
        (.filename == $linked_path and .sha == $linked_blob)) and
       (.status == "added" or .status == "modified"))
   ' "$compare_file" >/dev/null; then
@@ -1332,7 +1381,7 @@ bootstrap_one() {
       --base "$default_branch" \
       --head "$branch" \
       --title "chore(governance): bootstrap exact managed callers" \
-      --body "Installs the exact enforcement, Super-Linter, and linked-issue workflows before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
+      --body "Installs the exact applicable managed callers before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
     pr_number=${pr_url##*/}
     created_pr_number="$pr_number"
     if ! printf '%s' "$created_pr_number" | grep -qE '^[1-9][0-9]*$'; then
@@ -1353,10 +1402,13 @@ bootstrap_one() {
   if ! jq -e --arg path "$caller_path" --arg lint_path "$lint_caller_path" \
     --arg linked_path "$linked_caller_path" \
     --arg base "$default_branch" --arg head "$branch" --arg oid "$branch_head" \
+    --argjson manages_lint "$manages_lint_caller" \
     --argjson change_count "$expected_change_count" '
     .baseRefName == $base and .headRefName == $head and .headRefOid == $oid and
     (.commits | length) >= $change_count and (.files | length) == $change_count and
-    all(.files[]; .path == $path or .path == $lint_path or .path == $linked_path)
+    all(.files[];
+      .path == $path or ($manages_lint and .path == $lint_path) or
+      .path == $linked_path)
   ' "$pr_file" >/dev/null; then
     echo "[ERROR] Bootstrap PR for ${name} contains an unexpected diff" >&2
     return 1
@@ -1380,11 +1432,13 @@ bootstrap_one() {
     echo "[ERROR] Bootstrap caller changed after exact PR verification for ${name}" >&2
     return 1
   fi
-  verified_lint_blob=$(gh api \
-    "repos/${slug}/contents/${lint_caller_path}?ref=${verified_head}" --jq '.sha')
-  if [ "$verified_lint_blob" != "$expected_lint_blob" ]; then
-    echo "[ERROR] Super-Linter caller changed after exact PR verification for ${name}" >&2
-    return 1
+  if [ "$manages_lint_caller" = true ]; then
+    verified_lint_blob=$(gh api \
+      "repos/${slug}/contents/${lint_caller_path}?ref=${verified_head}" --jq '.sha')
+    if [ "$verified_lint_blob" != "$expected_lint_blob" ]; then
+      echo "[ERROR] Super-Linter caller changed after exact PR verification for ${name}" >&2
+      return 1
+    fi
   fi
   verified_linked_blob=$(gh api \
     "repos/${slug}/contents/${linked_caller_path}?ref=${verified_head}" --jq '.sha')
@@ -1499,23 +1553,25 @@ while true; do
     *) exit 1 ;;
     esac
 
-    set +e
-    live_lint_blob=$(api_value_or_404 \
-      "repos/${slug}/contents/${lint_caller_path}?ref=${main_sha}" '.sha')
-    rc=$?
-    set -e
-    case "$rc" in
-    0)
-      if ! printf '%s' "$live_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
-        echo "[ERROR] Invalid live Super-Linter caller receipt while verifying ${name}" >&2
-        exit 1
-      fi
-      [ "$live_lint_blob" = "$expected_lint_blob" ] || pending=$((pending + 1))
-      ;;
-    44) pending=$((pending + 1)) ;;
-    84) exit 84 ;;
-    *) exit 1 ;;
-    esac
+    if lint_caller_applies "$name"; then
+      set +e
+      live_lint_blob=$(api_value_or_404 \
+        "repos/${slug}/contents/${lint_caller_path}?ref=${main_sha}" '.sha')
+      rc=$?
+      set -e
+      case "$rc" in
+      0)
+        if ! printf '%s' "$live_lint_blob" | grep -qE '^[0-9a-f]{40}$'; then
+          echo "[ERROR] Invalid live Super-Linter caller receipt while verifying ${name}" >&2
+          exit 1
+        fi
+        [ "$live_lint_blob" = "$expected_lint_blob" ] || pending=$((pending + 1))
+        ;;
+      44) pending=$((pending + 1)) ;;
+      84) exit 84 ;;
+      *) exit 1 ;;
+      esac
+    fi
 
     set +e
     live_linked_blob=$(api_value_or_404 \

--- a/scripts/preflight-downstream-dispatch.sh
+++ b/scripts/preflight-downstream-dispatch.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 pin_config="${PIN_CONFIG:-.github/config/governed-workflow-pin.json}"
 downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
 rollout_config="${ROLLOUT_CONFIG:-.github/config/governance-rollout.json}"
+governance_config="${GOVERNANCE_CONFIG:-.claude/governance.json}"
 repository="${GITHUB_REPOSITORY:-}"
 owner="${repository%%/*}"
 source_sha="${SOURCE_SHA:-}"
@@ -22,6 +23,7 @@ actual_caller_blob=""
 actual_lint_caller_blob=""
 actual_linked_caller_blob=""
 workflow_state=""
+lint_caller_path=".github/workflows/super-linter.yml"
 
 github_api_into() {
   local target="$1"
@@ -62,6 +64,17 @@ if ! jq -e '
   (length == (unique | length))
 ' "$downstream_config" >/dev/null; then
   echo "[ERROR] Downstream inventory must be a non-empty array of unique repository names" >&2
+  exit 1
+fi
+if ! jq -e '
+  (.skip_files | type == "object") and
+  all(.skip_files | to_entries[];
+    (.key | test("^[A-Za-z0-9_.-]+$")) and
+    (.value | type == "array" and
+      all(.[]; type == "string" and length > 0) and
+      length == (unique | length)))
+' "$governance_config" >/dev/null; then
+  echo "[ERROR] Governance skip_files policy is missing or invalid" >&2
   exit 1
 fi
 if ! rollout_state=$(jq -er '.state | select(. == "quiesced" or . == "active")' \
@@ -189,23 +202,28 @@ while IFS= read -r name; do
     # required until the exact caller has landed.
     continue
   fi
-  if ! github_api_into actual_lint_caller_blob \
-    "repos/${owner}/${name}/contents/.github/workflows/super-linter.yml?ref=${downstream_main}" \
-    --jq '.sha'; then
-    if [ "$api_not_found" = true ]; then
-      actual_lint_caller_blob=""
-    else
-      echo "[ERROR] Could not read the live Super-Linter caller for ${name}" >&2
+  # A skip_files entry means the repository owns this caller's exact bytes.
+  if ! jq -e --arg repo "$name" --arg path "$lint_caller_path" \
+    '(.skip_files[$repo] // []) | index($path) != null' \
+    "$governance_config" >/dev/null; then
+    if ! github_api_into actual_lint_caller_blob \
+      "repos/${owner}/${name}/contents/${lint_caller_path}?ref=${downstream_main}" \
+      --jq '.sha'; then
+      if [ "$api_not_found" = true ]; then
+        actual_lint_caller_blob=""
+      else
+        echo "[ERROR] Could not read the live Super-Linter caller for ${name}" >&2
+        exit 1
+      fi
+    elif ! printf '%s' "$actual_lint_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
+      echo "[ERROR] Invalid live Super-Linter caller blob receipt for ${name}" >&2
       exit 1
     fi
-  elif ! printf '%s' "$actual_lint_caller_blob" | grep -qE '^[0-9a-f]{40}$'; then
-    echo "[ERROR] Invalid live Super-Linter caller blob receipt for ${name}" >&2
-    exit 1
-  fi
-  if [ "$actual_lint_caller_blob" != "$expected_lint_caller_blob" ]; then
-    echo "[BOOTSTRAP] ${name} does not contain the exact Super-Linter caller"
-    stale_callers=$((stale_callers + 1))
-    continue
+    if [ "$actual_lint_caller_blob" != "$expected_lint_caller_blob" ]; then
+      echo "[BOOTSTRAP] ${name} does not contain the exact Super-Linter caller"
+      stale_callers=$((stale_callers + 1))
+      continue
+    fi
   fi
   if ! github_api_into actual_linked_caller_blob \
     "repos/${owner}/${name}/contents/.github/workflows/require-linked-issue.yml?ref=${downstream_main}" \

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -30,6 +30,7 @@ LINKED_CALLER_BLOB=$(printf '%s\n' "$LINKED_CALLER_TEXT" | git hash-object --std
 printf '["example"]\n' >"$WORK/repos.json"
 printf '{"revision":"%s"}\n' "$PIN_SHA" >"$WORK/pin.json"
 printf '{"state":"active"}\n' >"$WORK/rollout.json"
+printf '{"skip_files":{}}\n' >"$WORK/governance.json"
 cat >"$WORK/repo-settings.json" <<'EOF'
 {
   "branch_protection": [
@@ -409,6 +410,10 @@ case "$1 $endpoint" in
     fi
     ;;
   'api repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml?ref='*)
+    if [ "${FAKE_FORBID_LINT_READ:-}" = 1 ]; then
+      echo 'unexpected opted-out Super-Linter caller read' >&2
+      exit 65
+    fi
     ref=${endpoint##*ref=}
     if { [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; } &&
       [ -f "$FAKE_STATE/lint-updated" ]; then
@@ -467,14 +472,19 @@ case "$1 $endpoint" in
       shift
     done
     [ -n "$input" ] || exit 64
+    skip_lint=false
+    [ "${FAKE_SKIP_LINT_CALLER:-}" != 1 ] || skip_lint=true
     jq -e --arg base "$BASE_TREE" --arg caller "$CALLER_BLOB" \
-      --arg lint "$LINT_CALLER_BLOB" --arg linked "$LINKED_CALLER_BLOB" '
+      --arg lint "$LINT_CALLER_BLOB" --arg linked "$LINKED_CALLER_BLOB" \
+      --argjson skip_lint "$skip_lint" '
       .base_tree == $base and
-      .tree == [
-        {path:".github/workflows/enforce-repo-settings.yml",mode:"100644",type:"blob",sha:$caller},
-        {path:".github/workflows/super-linter.yml",mode:"100644",type:"blob",sha:$lint},
-        {path:".github/workflows/require-linked-issue.yml",mode:"100644",type:"blob",sha:$linked}
-      ]
+      .tree == (
+        [{path:".github/workflows/enforce-repo-settings.yml",mode:"100644",type:"blob",sha:$caller}] +
+        (if $skip_lint then [] else
+          [{path:".github/workflows/super-linter.yml",mode:"100644",type:"blob",sha:$lint}]
+        end) +
+        [{path:".github/workflows/require-linked-issue.yml",mode:"100644",type:"blob",sha:$linked}]
+      )
     ' "$input" >/dev/null || exit 65
     touch "$FAKE_STATE/refresh-tree-created"
     jq -cn --arg sha "$REFRESH_TREE" '{sha:$sha}'
@@ -532,7 +542,8 @@ case "$1 $endpoint" in
         '$files + [{filename:".github/workflows/enforce-repo-settings.yml",sha:$sha,status:"modified"}]')
       count=$((count + 1))
     fi
-    if [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
+    if [ "${FAKE_SKIP_LINT_CALLER:-}" != 1 ] &&
+      [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
       files=$(jq -cn --argjson files "$files" --arg sha "$LINT_CALLER_BLOB" \
         '$files + [{filename:".github/workflows/super-linter.yml",sha:$sha,status:"modified"}]')
       count=$((count + 1))
@@ -611,7 +622,8 @@ case "$1 $endpoint" in
       files=$(jq -cn --argjson files "$files" '$files + [{path:".github/workflows/enforce-repo-settings.yml"}]')
       count=$((count + 1))
     fi
-    if [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
+    if [ "${FAKE_SKIP_LINT_CALLER:-}" != 1 ] &&
+      [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
       files=$(jq -cn --argjson files "$files" '$files + [{path:".github/workflows/super-linter.yml"}]')
       count=$((count + 1))
     fi
@@ -647,6 +659,10 @@ chmod +x "$WORK/bin/gh"
 
 run_bootstrap() {
   local state="$1"
+  local expected_lint_receipt="$LINT_CALLER_BLOB"
+  if [ "${FAKE_SKIP_LINT_CALLER:-}" = 1 ]; then
+    expected_lint_receipt=skipped
+  fi
   env \
     PATH="$WORK/bin:$PATH" \
     GITHUB_REPOSITORY=f5-sales-demo/docs-control \
@@ -655,6 +671,7 @@ run_bootstrap() {
     ROLLOUT_CONFIG="${TEST_ROLLOUT_CONFIG:-$WORK/rollout.json}" \
     DOWNSTREAM_CONFIG="${TEST_DOWNSTREAM_CONFIG:-$WORK/repos.json}" \
     REPO_SETTINGS_CONFIG="${TEST_REPO_SETTINGS_CONFIG:-$WORK/repo-settings.json}" \
+    GOVERNANCE_CONFIG="${TEST_GOVERNANCE_CONFIG:-$WORK/governance.json}" \
     BOOTSTRAP_WAIT_SECONDS=0 \
     BOOTSTRAP_LINKED_WAIT_SECONDS=0 \
     FAKE_LOG="$WORK/gh.log" \
@@ -670,7 +687,7 @@ run_bootstrap() {
     BRANCH_HEAD="$BRANCH_HEAD" \
     REFRESH_TREE="$REFRESH_TREE" \
     REFRESH_HEAD="$REFRESH_HEAD" \
-    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB}${LINT_CALLER_BLOB}${LINKED_CALLER_BLOB}" \
+    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB}${expected_lint_receipt}${LINKED_CALLER_BLOB}" \
     CALLER_BLOB="$CALLER_BLOB" \
     CALLER_CONTENT="$CALLER_CONTENT" \
     LINT_CALLER_BLOB="$LINT_CALLER_BLOB" \
@@ -680,6 +697,8 @@ run_bootstrap() {
     DOWNSTREAM_BLOB="$DOWNSTREAM_BLOB" \
     DOWNSTREAM_LINT_BLOB="${DOWNSTREAM_LINT_BLOB:-$LINT_CALLER_BLOB}" \
     DOWNSTREAM_LINKED_BLOB="${DOWNSTREAM_LINKED_BLOB:-$LINKED_CALLER_BLOB}" \
+    FAKE_SKIP_LINT_CALLER="${FAKE_SKIP_LINT_CALLER:-}" \
+    FAKE_FORBID_LINT_READ="${FAKE_FORBID_LINT_READ:-}" \
     FAKE_READ_ERROR="${FAKE_READ_ERROR:-}" \
     FAKE_MAIN_ADVANCE_AT="${FAKE_MAIN_ADVANCE_AT:-}" \
     FAKE_DIVERGED_BASE="${FAKE_DIVERGED_BASE:-}" \
@@ -918,6 +937,69 @@ if [ "$rc" != 83 ] ||
   exit 1
 fi
 echo "[OK] exact enforcement with stale lint updates only lint and remains quiesced"
+
+cat >"$WORK/governance-skip-lint.json" <<'EOF'
+{"skip_files":{"example":[".github/workflows/super-linter.yml"]}}
+EOF
+state="$WORK/state-skip-stale-lint"
+mkdir -p "$state"
+touch "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+FAKE_SKIP_LINT_CALLER=1
+FAKE_FORBID_LINT_READ=1
+set +e
+TEST_GOVERNANCE_CONFIG="$WORK/governance-skip-lint.json" run_bootstrap "$state" \
+  >"$WORK/skip-stale-lint.out" 2>"$WORK/skip-stale-lint.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINT_BLOB FAKE_SKIP_LINT_CALLER FAKE_FORBID_LINT_READ \
+  TEST_GOVERNANCE_CONFIG
+if [ "$rc" != 83 ] ||
+  ! grep -q 'contents/.github/workflows/enforce-repo-settings.yml --method PUT' \
+    "$WORK/gh.log" ||
+  grep -q 'example/contents/.github/workflows/super-linter.yml' "$WORK/gh.log" ||
+  grep -q 'contents/.github/workflows/super-linter.yml --method PUT' "$WORK/gh.log" ||
+  grep -q 'actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] opted-out lint caller was read, changed, or allowed to bypass exact enforcement"
+  cat "$WORK/skip-stale-lint.err"
+  sed 's/^/  log: /' "$WORK/gh.log"
+  exit 1
+fi
+echo "[OK] opted-out lint caller is untouched while mandatory callers stay fail-closed"
+
+state="$WORK/state-diverged-skip-stale-lint"
+mkdir -p "$state"
+touch "$state/disabled" "$state/branch" "$state/current-pr" \
+  "$state/updated" "$state/linked-updated"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_DIVERGED_BASE=1
+FAKE_SKIP_LINT_CALLER=1
+FAKE_FORBID_LINT_READ=1
+set +e
+TEST_GOVERNANCE_CONFIG="$WORK/governance-skip-lint.json" run_bootstrap "$state" \
+  >"$WORK/diverged-skip-stale-lint.out" 2>"$WORK/diverged-skip-stale-lint.err"
+rc=$?
+set -e
+unset FAKE_DIVERGED_BASE FAKE_SKIP_LINT_CALLER FAKE_FORBID_LINT_READ \
+  DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB TEST_GOVERNANCE_CONFIG
+if [ "$rc" != 83 ] ||
+  ! grep -q 'git/trees --method POST' "$WORK/gh.log" ||
+  grep -q 'example/contents/.github/workflows/super-linter.yml' "$WORK/gh.log" ||
+  grep -q 'contents/.github/workflows/super-linter.yml --method PUT' "$WORK/gh.log" ||
+  grep -qE '^pr (close|create) |(^|[[:space:]])--force([[:space:]]|$)|"force"[[:space:]]*:[[:space:]]*true' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] protected-main refresh read or replaced an opted-out lint caller"
+  cat "$WORK/diverged-skip-stale-lint.err"
+  sed 's/^/  log: /' "$WORK/gh.log"
+  exit 1
+fi
+echo "[OK] protected-main refresh preserves an opted-out repository-owned lint caller"
 
 state="$WORK/state-stale-linked-only"
 mkdir -p "$state"

--- a/tests/test-dispatch-preflight.sh
+++ b/tests/test-dispatch-preflight.sh
@@ -22,6 +22,12 @@ check_case() {
   printf '{"revision":"%s"}\n' "$PIN_SHA" >"$work/pin.json"
   printf '["example"]\n' >"$work/repos.json"
   printf '{"state":"active"}\n' >"$work/rollout.json"
+  if [ "${FAKE_SKIP_LINT_CALLER:-}" = 1 ]; then
+    printf '{"skip_files":{"example":[".github/workflows/super-linter.yml"]}}\n' \
+      >"$work/governance.json"
+  else
+    printf '{"skip_files":{}}\n' >"$work/governance.json"
+  fi
   cat >"$work/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$GH_LOG"
@@ -54,6 +60,10 @@ case "$*" in
     printf '%s\n' "$FAKE_DOWNSTREAM_CALLER_BLOB"
     ;;
   *"repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml?ref=$FAKE_DOWNSTREAM_MAIN"*)
+    if [ "${FAKE_FORBID_LINT_READ:-}" = 1 ]; then
+      echo 'unexpected opted-out Super-Linter caller read' >&2
+      exit 65
+    fi
     if [ "${FAKE_MISSING_CALLER:-}" = 1 ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
       exit 1
@@ -88,6 +98,7 @@ EOF
     PIN_CONFIG="$work/pin.json" \
     DOWNSTREAM_CONFIG="$work/repos.json" \
     ROLLOUT_CONFIG="$work/rollout.json" \
+    GOVERNANCE_CONFIG="$work/governance.json" \
     FAKE_MAIN_SHA="$FAKE_MAIN_SHA" \
     FAKE_COMPARE_STATUS="$FAKE_COMPARE_STATUS" \
     FAKE_PIN_SHA="$PIN_SHA" \
@@ -105,6 +116,7 @@ EOF
     FAKE_DOWNSTREAM_MAIN="$FAKE_DOWNSTREAM_MAIN" \
     FAKE_MISSING_CALLER="${FAKE_MISSING_CALLER:-}" \
     FAKE_STATE_READ_FAIL="${FAKE_STATE_READ_FAIL:-}" \
+    FAKE_FORBID_LINT_READ="${FAKE_FORBID_LINT_READ:-}" \
     FAKE_API_FAIL_MATCH="${FAKE_API_FAIL_MATCH:-}" \
     FAKE_API_FAIL_MESSAGE="${FAKE_API_FAIL_MESSAGE:-}" \
     "$SOURCE" 2>&1)
@@ -161,6 +173,13 @@ FAKE_STATE_READ_FAIL=1
 check_case "stale Super-Linter caller requires bootstrap" 80 \
   "[BOOTSTRAP] example does not contain the exact Super-Linter caller"
 unset FAKE_STATE_READ_FAIL
+FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB"
+
+FAKE_SKIP_LINT_CALLER=1
+FAKE_FORBID_LINT_READ=1
+FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$OTHER_SHA"
+check_case "opted-out Super-Linter caller is neither read nor bootstrapped" 0 "[OK]"
+unset FAKE_SKIP_LINT_CALLER FAKE_FORBID_LINT_READ
 FAKE_DOWNSTREAM_LINT_CALLER_BLOB="$FAKE_SOURCE_LINT_CALLER_BLOB"
 
 FAKE_DOWNSTREAM_LINKED_CALLER_BLOB="$OTHER_SHA"


### PR DESCRIPTION
## Summary

Honor the authoritative governance `skip_files` policy throughout exact-caller preflight, bootstrap, recovery, verification, and convergence.

## Related Issue

Closes #1195

## Changes

- Validate and consume `.claude/governance.json` in both preflight and bootstrap.
- Leave repository-owned Super-Linter callers unread and unchanged while enforcement and linked-issue callers remain mandatory.
- Scope diff counts, branch identities, PR allowlists, transition recovery, protected-main refresh trees, and polling to each repository's applicable caller set.
- Add regressions for ordinary and diverged opted-out branches, including proof that refresh trees preserve the repository-owned lint caller.

## Verification evidence

- `bash tests/test-bootstrap-downstream-callers.sh` — all acceptance scenarios passed, including protected-main drift, opted-out lint preservation, recovery, and fail-closed behavior.
- `bash tests/test-dispatch-preflight.sh` — `12 passed, 0 failed`.
- `bash tests/test-dispatch-matrix.sh` — all dispatcher contract and actionlint checks passed.
- `shellcheck ...`, `shfmt -d ...`, and `git diff --check origin/main...HEAD` — clean.
- `pre-commit run --all-files` — every applicable repository hook passed.
- Live shipped preflight scoped to `xcsh` at protected main `c29994d` returned only the expected workflow-state reconciliation (`disabled_manually` versus active). Its request log read the mandatory enforcement and linked-issue callers and did not request `.github/workflows/super-linter.yml`.
- `bash scripts/agy-pre-push-review.sh` — PII enforcement clean; Antigravity gate passed with no critical or high finding remaining on exact HEAD `664ea61`.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
