### PR TITLE
fix(governance): unblock pristine caller bootstrap

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -1,6 +1,7 @@
 ---
 name: Enforce Repository Settings
 
+#checkov:skip=CKV_GHA_7:Exact source receipts are validated before any governed read or mutation.
 on:
   push:
     branches: [main]

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -1,6 +1,7 @@
 ---
 name: Require Linked Issue
 
+#checkov:skip=CKV_GHA_7:Targeted inputs are exact PR receipts validated before a status is written.
 on:
   schedule:
     - cron: '*/5 * * * *'

--- a/tests/test-privileged-pr-workflows.sh
+++ b/tests/test-privileged-pr-workflows.sh
@@ -68,6 +68,8 @@ done
 for file in \
   "$REPO_ROOT/workflows/require-linked-issue.yml" \
   "$REPO_ROOT/.github/workflows/require-linked-issue.yml"; do
+  require_literal "$file" '#checkov:skip=CKV_GHA_7:Targeted inputs are exact PR receipts validated before a status is written.' \
+    "${file#"$REPO_ROOT/"} carries its pristine-repository Checkov justification"
   published_context=$(sed -n 's/.*const STATUS_CONTEXT = "\([^"]*\)";.*/\1/p' "$file")
   for context_scope in contexts self_contexts; do
     case "$context_scope" in
@@ -91,6 +93,13 @@ for file in \
   require_literal "$file" 'postStatus("success"' "${file#"$REPO_ROOT/"} publishes a passing status"
   require_literal "$file" 'postStatus("failure"' "${file#"$REPO_ROOT/"} publishes a failing status"
   require_literal "$file" '<!-- require-linked-issue -->' "${file#"$REPO_ROOT/"} preserves the deduplicated guidance comment"
+done
+
+for file in \
+  "$REPO_ROOT/workflows/enforce-repo-settings.yml" \
+  "$REPO_ROOT/.github/workflows/enforce-repo-settings.yml"; do
+  require_literal "$file" '#checkov:skip=CKV_GHA_7:Exact source receipts are validated before any governed read or mutation.' \
+    "${file#"$REPO_ROOT/"} carries its pristine-repository Checkov justification"
 done
 
 AUTO_MERGE_CALLER="$REPO_ROOT/workflows/auto-merge.yml"

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -1,6 +1,7 @@
 ---
 name: Enforce Repository Settings
 
+#checkov:skip=CKV_GHA_7:Exact source receipts are validated before any governed read or mutation.
 on:
   schedule:
     - cron: '0 */6 * * *'

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -1,6 +1,7 @@
 ---
 name: Require Linked Issue
 
+#checkov:skip=CKV_GHA_7:Targeted inputs are exact PR receipts validated before a status is written.
 on:
   schedule:
     - cron: '*/5 * * * *'


### PR DESCRIPTION
## Summary

- add narrow inline `CKV_GHA_7` justifications to exact-receipt workflow-dispatch resources
- keep managed sources and active docs-control callers aligned
- assert the pristine-repository Checkov contract in the privileged-workflow regression suite

This unblocks the first managed-caller PR in a repository that does not yet have the fleet `.checkov.yaml`, as reproduced by f5-sales-demo/xcsh-action#2.

## Verification

- pristine three-workflow Checkov scan: 35 passed, 0 failed, 2 justified skips
- `bash tests/test-privileged-pr-workflows.sh`
- `bash tests/test-linter-configs.sh` (164 passed)
- `bash tests/test-bootstrap-downstream-callers.sh`
- `bash tests/test-dispatch-preflight.sh` (11 passed)
- `actionlint` on all four changed workflow files
- `shellcheck` and `shfmt -d` on the changed shell test
- staged and HEAD PII enforcement clean
- local Antigravity gate passed with no critical or high finding

Closes #1202.