### PR TITLE
fix: bootstrap first governed repository safely

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,7 +305,7 @@ boundary; configure no reviewers, wait timer, or deployment rule on it.
      --review-enabled false --translations-enabled false --workflow-state active
    ```
 
-   It checks all 37 governed repositories plus `docs-control`, rejects repository-variable shadows,
+   It checks all 38 governed repositories plus `docs-control`, rejects repository-variable shadows,
    and exits 84 without retry amplification when GitHub reports a rate limit.
 
 ### Future restoration of the required freshness context

--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -76,6 +76,26 @@ if ! jq -e '
   echo "[ERROR] Repository settings contain an invalid required-check contract" >&2
   exit 1
 fi
+if ! jq -e '
+  (.repository | type == "object") and
+  (.repository.allow_squash_merge == true) and
+  (.repository.allow_auto_merge == true) and
+  (.repository.delete_branch_on_merge == true) and
+  ([.branch_protection[] | select(.branch == "main")][0] |
+    (.enforce_admins | type == "boolean") and
+    (.required_pull_request_reviews == null) and
+    (.restrictions == null) and
+    (.required_linear_history | type == "boolean") and
+    (.allow_force_pushes | type == "boolean") and
+    (.allow_deletions | type == "boolean") and
+    (.block_creations | type == "boolean") and
+    (.required_conversation_resolution | type == "boolean") and
+    (.lock_branch | type == "boolean") and
+    (.allow_fork_syncing | type == "boolean"))
+' "$repo_settings_config" >/dev/null; then
+  echo "[ERROR] First-repository controls must use GitHub Free-compatible classic protection" >&2
+  exit 1
+fi
 if ! rollout_state=$(jq -er '.state | select(. == "quiesced" or . == "active")' \
   "$rollout_config"); then
   echo "[ERROR] Governance rollout state is missing or invalid" >&2
@@ -259,6 +279,143 @@ transition_required_checks_for_repo() {
       .contexts = ([.contexts[] | select(. != $current)] + [$legacy] | unique | sort)
     end
   '
+}
+
+first_transition_required_checks_for_repo() {
+  local name="$1" desired
+  desired=$(required_checks_for_repo "$name")
+  printf '%s' "$desired" | jq -ce \
+    --arg current "$linked_context" --arg legacy "$legacy_linked_context" '
+    if ([.contexts[] | select(. == $current)] | length) != 1 or
+      ([.contexts[] | select(. == $legacy)] | length) != 0 then
+      error("authoritative first-repository linked context is not unique")
+    else
+      .contexts = [.contexts[] | select(. != $current)] |
+      if (.contexts | length) == 0 then error("first-repository transition has no real checks")
+      else . end
+    end
+  '
+}
+
+first_transition_protection_for_repo() {
+  local name="$1" checks
+  checks=$(first_transition_required_checks_for_repo "$name") || return 1
+  jq -ce --argjson checks "$checks" '
+    [.branch_protection[] | select(.branch == "main")][0] |
+    del(.branch) |
+    .required_status_checks = $checks |
+    .required_status_checks |= del(.self_contexts)
+  ' "$repo_settings_config"
+}
+
+normalize_desired_bootstrap_protection() {
+  jq -ce '{
+    enforce_admins: .enforce_admins,
+    required_status_checks: {
+      strict: .required_status_checks.strict,
+      contexts: (.required_status_checks.contexts | unique | sort)
+    },
+    required_pull_request_reviews: .required_pull_request_reviews,
+    restrictions: .restrictions,
+    required_linear_history: .required_linear_history,
+    allow_force_pushes: .allow_force_pushes,
+    allow_deletions: .allow_deletions,
+    block_creations: .block_creations,
+    required_conversation_resolution: .required_conversation_resolution,
+    lock_branch: .lock_branch,
+    allow_fork_syncing: .allow_fork_syncing
+  }'
+}
+
+normalize_current_bootstrap_protection() {
+  jq -ce '{
+    enforce_admins: .enforce_admins.enabled,
+    required_status_checks: {
+      strict: .required_status_checks.strict,
+      contexts: (.required_status_checks.contexts | unique | sort)
+    },
+    required_pull_request_reviews: .required_pull_request_reviews,
+    restrictions: .restrictions,
+    required_linear_history: .required_linear_history.enabled,
+    allow_force_pushes: .allow_force_pushes.enabled,
+    allow_deletions: .allow_deletions.enabled,
+    block_creations: .block_creations.enabled,
+    required_conversation_resolution: .required_conversation_resolution.enabled,
+    lock_branch: .lock_branch.enabled,
+    allow_fork_syncing: .allow_fork_syncing.enabled
+  }'
+}
+
+reconcile_first_repo_controls() {
+  local name="$1" slug desired_repo current_repo verified_repo repo_payload verified_protection
+  local desired_protection desired_state current_protection current_state rc protection_payload
+  slug="${owner}/${name}"
+  desired_repo=$(jq -c '{
+    allow_squash_merge: .repository.allow_squash_merge,
+    allow_auto_merge: .repository.allow_auto_merge,
+    delete_branch_on_merge: .repository.delete_branch_on_merge
+  }' "$repo_settings_config")
+  current_repo=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api "repos/${slug}")
+  if ! printf '%s' "$current_repo" | jq -e '
+    type == "object" and
+    (.allow_squash_merge | type == "boolean") and
+    (.allow_auto_merge | type == "boolean") and
+    (.delete_branch_on_merge | type == "boolean")
+  ' >/dev/null; then
+    echo "[ERROR] Repository merge settings response is malformed for ${slug}" >&2
+    return 1
+  fi
+  if [ "$(printf '%s' "$current_repo" | jq -c '{allow_squash_merge,allow_auto_merge,delete_branch_on_merge}')" != "$desired_repo" ]; then
+    assert_source_current
+    repo_payload="$work/first-repo-settings-${name}.json"
+    printf '%s\n' "$desired_repo" >"$repo_payload"
+    GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api "repos/${slug}" --method PATCH \
+      --input "$repo_payload" >/dev/null
+  fi
+  verified_repo=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api "repos/${slug}")
+  if ! printf '%s' "$verified_repo" | jq -e --argjson desired "$desired_repo" '
+    {allow_squash_merge,allow_auto_merge,delete_branch_on_merge} == $desired
+  ' >/dev/null; then
+    echo "[ERROR] Repository merge settings did not settle exactly for ${slug}" >&2
+    return 1
+  fi
+
+  desired_protection=$(first_transition_protection_for_repo "$name") || {
+    echo "[ERROR] Could not derive first-repository protection for ${slug}" >&2
+    return 1
+  }
+  desired_state=$(printf '%s' "$desired_protection" | normalize_desired_bootstrap_protection)
+  set +e
+  current_protection=$(api_value_or_404 \
+    "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN")
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    current_state=$(printf '%s' "$current_protection" | normalize_current_bootstrap_protection) || {
+      echo "[ERROR] Branch-protection response is malformed for ${slug}" >&2
+      return 1
+    }
+    ;;
+  44) current_state="" ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
+  if [ "$current_state" != "$desired_state" ]; then
+    assert_source_current
+    protection_payload="$work/first-repo-protection-${name}.json"
+    printf '%s\n' "$desired_protection" >"$protection_payload"
+    GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+      "repos/${slug}/branches/main/protection" --method PUT \
+      --input "$protection_payload" >/dev/null
+  fi
+  verified_protection=$(api_value_or_404 \
+    "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN") || return $?
+  if [ "$(printf '%s' "$verified_protection" | normalize_current_bootstrap_protection)" != "$desired_state" ]; then
+    echo "[ERROR] First-repository protection did not settle exactly for ${slug}" >&2
+    return 1
+  fi
+  echo "[OK] First-repository merge controls are exact for ${slug}"
 }
 
 reconcile_required_checks_to() {
@@ -1027,8 +1184,9 @@ echo "[OK] Downstream enforcement workflows are disabled with no active runs"
 bootstrap_one() {
   local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob
   local actual_linked_blob rc branch_head branch_blob branch_lint_blob branch_linked_blob
-  local branch expected_change_count manages_lint_caller=true lint_caller_exact=true
-  local pr_number pr_url created_pr_number compare_file pr_file verified_head verified_blob
+  local expected_change_count first_repo=false
+  local branch manages_lint_caller=true lint_caller_exact=true
+  local pr_number pr_url pr_body created_pr_number compare_file pr_file verified_head verified_blob
   local verified_lint_blob verified_linked_blob transition_checks
   local base_commit_file base_tree_sha refresh_tree_file refresh_tree_sha refresh_commit_file
   local refresh_head refresh_ref_file current_base_sha current_branch_head
@@ -1056,7 +1214,7 @@ bootstrap_one() {
       return 1
     fi
     ;;
-  44) ;;
+  44) actual_blob="" ;;
   84) return 84 ;;
   *) return 1 ;;
   esac
@@ -1096,6 +1254,10 @@ bootstrap_one() {
   84) return 84 ;;
   *) return 1 ;;
   esac
+  if [ -z "$actual_blob" ] && [ -z "$actual_linked_blob" ] &&
+    { [ "$manages_lint_caller" = false ] || [ -z "$actual_lint_blob" ]; }; then
+    first_repo=true
+  fi
   if [ "$actual_blob" = "$expected_blob" ] &&
     [ "$lint_caller_exact" = true ] &&
     [ "$actual_linked_blob" = "$expected_linked_blob" ]; then
@@ -1105,7 +1267,6 @@ bootstrap_one() {
   [ "$actual_blob" = "$expected_blob" ] || expected_change_count=$((expected_change_count + 1))
   [ "$lint_caller_exact" = true ] || expected_change_count=$((expected_change_count + 1))
   [ "$actual_linked_blob" = "$expected_linked_blob" ] || expected_change_count=$((expected_change_count + 1))
-
   default_branch=$(gh api "repos/${slug}" --jq '.default_branch')
   if [ "$default_branch" != "main" ]; then
     echo "[ERROR] Governed repository ${name} does not use protected main" >&2
@@ -1115,6 +1276,10 @@ bootstrap_one() {
   if ! printf '%s' "$base_sha" | grep -qE '^[0-9a-f]{40}$'; then
     echo "[ERROR] Invalid default-branch receipt for ${name}" >&2
     return 1
+  fi
+
+  if [ "$first_repo" = true ]; then
+    reconcile_first_repo_controls "$name"
   fi
 
   reconcile_bootstrap_prs "$slug" "$branch"
@@ -1376,12 +1541,16 @@ bootstrap_one() {
   pr_number="$bootstrap_pr_number"
   created_pr_number=""
   if [ -z "$pr_number" ]; then
+    pr_body="Installs the exact enforcement, Super-Linter, and linked-issue workflows before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement."
+    if [ "$first_repo" = true ]; then
+      pr_body="Installs the exact enforcement, Super-Linter, and linked-issue workflows for a first governed repository. Classic branch protection temporarily requires only real checks available on the bootstrap PR; the canonical linked-issue context is restored only after its default-branch workflow reports a real success."
+    fi
     pr_url=$(gh pr create \
       --repo "$slug" \
       --base "$default_branch" \
       --head "$branch" \
       --title "chore(governance): bootstrap exact managed callers" \
-      --body "Installs the exact applicable managed callers before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.")
+      --body "$pr_body")
     pr_number=${pr_url##*/}
     created_pr_number="$pr_number"
     if ! printf '%s' "$created_pr_number" | grep -qE '^[1-9][0-9]*$'; then
@@ -1446,7 +1615,10 @@ bootstrap_one() {
     echo "[ERROR] Linked-issue evaluator changed after exact PR verification for ${name}" >&2
     return 1
   fi
-  if [ "$actual_linked_blob" != "$expected_linked_blob" ]; then
+  if [ "$first_repo" = true ]; then
+    jq -n --argjson pr "$pr_number" --arg head "$verified_head" \
+      '{pull_request: $pr, head: $head}' >"$work/linked-transition-${name}.json"
+  elif [ "$actual_linked_blob" != "$expected_linked_blob" ]; then
     if dispatch_and_verify_linked_status "$slug" "$pr_number" "$verified_head" false; then
       rc=0
     else

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -11,7 +11,7 @@
 # masks a dangling link by creating the real thing (npm ci, pip install).
 #
 # The symlink check runs by default. The home-directory scan is opt-in via
-# --include-paths, because measuring it across all 37 governed repositories flagged
+# --include-paths, because measuring it across all 38 governed repositories flagged
 # 10 of them and only 2 findings were real: the rest were API routes (/Users/1),
 # URL paths (/home/index), shell variables (/home/${USERNAME}), placeholder names,
 # and upstream-generated specification examples. A gate that is ~80% false positives

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -33,17 +33,33 @@ printf '{"state":"active"}\n' >"$WORK/rollout.json"
 printf '{"skip_files":{}}\n' >"$WORK/governance.json"
 cat >"$WORK/repo-settings.json" <<'EOF'
 {
+  "repository": {
+    "allow_squash_merge": true,
+    "allow_auto_merge": true,
+    "delete_branch_on_merge": true
+  },
   "branch_protection": [
     {
       "branch": "main",
+      "enforce_admins": true,
       "required_status_checks": {
         "strict": true,
         "contexts": [
           "Check linked issues",
           "lint / Lint Code Base",
           "lint / Shell Unit Tests"
-        ]
-      }
+        ],
+        "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
+      },
+      "required_pull_request_reviews": null,
+      "restrictions": null,
+      "required_linear_history": false,
+      "allow_force_pushes": false,
+      "allow_deletions": false,
+      "block_creations": false,
+      "required_conversation_resolution": false,
+      "lock_branch": false,
+      "allow_fork_syncing": false
     }
   ],
   "repo_overrides": {
@@ -93,6 +109,12 @@ if ! grep -Fq 'contents/workflows/super-linter.yml?ref=${source_sha}' "$SOURCE" 
   exit 1
 fi
 echo "[OK] bootstrap carries the lint caller that validates its own PR"
+
+if grep -Fqi 'checkov' "$SOURCE" || ! grep -Fq 'first_repo' "$SOURCE"; then
+  echo "[FAIL] first-repository bootstrap is not limited to exact managed callers"
+  exit 1
+fi
+echo "[OK] first-repository bootstrap is limited to exact managed callers"
 
 cat >"$WORK/bin/gh" <<'EOF'
 #!/usr/bin/env bash
@@ -156,7 +178,8 @@ case "$1 $endpoint" in
     printf '%s\n' "$BASE_SHA"
     ;;
   'api repos/f5-sales-demo/example/actions/workflows/enforce-repo-settings.yml')
-    if [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ]; then
+    if { [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] || [ "${FAKE_FIRST_REPO:-}" = 1 ]; } &&
+      [ ! -f "$FAKE_STATE/merged" ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
       exit 1
     fi
@@ -188,7 +211,14 @@ case "$1 $endpoint" in
       done
       [ -n "$input" ] || exit 64
       cp "$input" "$FAKE_STATE/required-checks-input.json"
-      if [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ]; then
+      if [ "${FAKE_FIRST_REPO:-}" = 1 ]; then
+        jq -e '
+          (.contexts | index("Check linked issues")) != null and
+          (.contexts | index("check / Check linked issues")) == null
+        ' "$input" >/dev/null || exit 65
+        cp "$input" "$FAKE_STATE/final-required-checks.json"
+        touch "$FAKE_STATE/final-required-checks-reconciled"
+      elif [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ]; then
         if jq -e '
           (.contexts | index("check / Check linked issues")) != null and
           (.contexts | index("Check linked issues")) == null
@@ -207,6 +237,12 @@ case "$1 $endpoint" in
       else
         touch "$FAKE_STATE/required-checks-reconciled"
       fi
+    elif [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/protection-created" ]; then
+      echo 'gh: Branch not protected (HTTP 404)' >&2
+      exit 1
+    elif [ "${FAKE_FIRST_REPO:-}" = 1 ] &&
+      [ ! -f "$FAKE_STATE/final-required-checks-reconciled" ]; then
+      printf '{"strict":true,"contexts":["Example CI","lint / Lint Code Base"]}\n'
     elif [ "${FAKE_REQUIRED_CHECKS_ERROR:-}" = 1 ]; then
       touch "$FAKE_STATE/required-check-failed"
       echo 'gh: synthetic required-check read failure (HTTP 500)' >&2
@@ -250,6 +286,10 @@ case "$1 $endpoint" in
       shift
     done
     [ -n "$input" ] || exit 64
+    if [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ]; then
+      echo 'gh: Not Found (HTTP 404)' >&2
+      exit 1
+    fi
     if [ "${FAKE_STAGED_LINKED_TRANSITION:-}" = 1 ] &&
       ! jq -e '.inputs.pull_request_number and .inputs.expected_head_sha' "$input" >/dev/null; then
       echo 'gh: workflow does not have workflow_dispatch trigger (HTTP 422)' >&2
@@ -394,7 +434,8 @@ case "$1 $endpoint" in
       exit 1
     fi
     ref=${endpoint##*ref=}
-    if [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ] &&
+    if { [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] || [ "${FAKE_FIRST_REPO:-}" = 1 ]; } &&
+      [ ! -f "$FAKE_STATE/merged" ] &&
       [ "$ref" != "$BRANCH_HEAD" ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
       exit 1
@@ -415,7 +456,11 @@ case "$1 $endpoint" in
       exit 65
     fi
     ref=${endpoint##*ref=}
-    if { [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; } &&
+    if [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ] &&
+      [ "$ref" != "$BRANCH_HEAD" ]; then
+      echo 'gh: Not Found (HTTP 404)' >&2
+      exit 1
+    elif { [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; } &&
       [ -f "$FAKE_STATE/lint-updated" ]; then
       printf '%s\n' "$LINT_CALLER_BLOB"
     elif [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; then
@@ -428,7 +473,13 @@ case "$1 $endpoint" in
     ;;
   'api repos/f5-sales-demo/example/contents/.github/workflows/require-linked-issue.yml?ref='*)
     ref=${endpoint##*ref=}
-    if { [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; } &&
+    if [ "${FAKE_BAD_RECOVER_LINKED:-}" = 1 ] && [ "$ref" = "$BRANCH_HEAD" ]; then
+      printf '%s\n' "$OLD_BLOB"
+    elif [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ] &&
+      [ "$ref" != "$BRANCH_HEAD" ]; then
+      echo 'gh: Not Found (HTTP 404)' >&2
+      exit 1
+    elif { [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; } &&
       [ -f "$FAKE_STATE/linked-updated" ]; then
       printf '%s\n' "$LINKED_CALLER_BLOB"
     elif [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; then
@@ -439,7 +490,70 @@ case "$1 $endpoint" in
       printf '%s\n' "$DOWNSTREAM_LINKED_BLOB"
     fi
     ;;
-  'api repos/f5-sales-demo/example') printf 'main\n' ;;
+  'api repos/f5-sales-demo/example/branches/main/protection')
+    if [[ "$*" == *'--method PUT'* ]]; then
+      input=""
+      while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--input" ]; then
+          input="$2"
+          break
+        fi
+        shift
+      done
+      [ -n "$input" ] || exit 64
+      jq -e '
+        .enforce_admins == true and
+        .required_status_checks.strict == true and
+        .required_status_checks.contexts == ["Example CI", "lint / Lint Code Base"] and
+        .required_pull_request_reviews == null and .restrictions == null and
+        .allow_force_pushes == false and .allow_deletions == false
+      ' "$input" >/dev/null || exit 65
+      cp "$input" "$FAKE_STATE/transition-protection.json"
+      touch "$FAKE_STATE/protection-created"
+    elif [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/protection-created" ]; then
+      echo 'gh: Branch not protected (HTTP 404)' >&2
+      exit 1
+    else
+      jq -cn --slurpfile desired "$FAKE_STATE/transition-protection.json" '
+        $desired[0] | {
+          enforce_admins:{enabled:.enforce_admins},
+          required_status_checks:.required_status_checks,
+          required_pull_request_reviews:.required_pull_request_reviews,
+          restrictions:.restrictions,
+          required_linear_history:{enabled:.required_linear_history},
+          allow_force_pushes:{enabled:.allow_force_pushes},
+          allow_deletions:{enabled:.allow_deletions},
+          block_creations:{enabled:.block_creations},
+          required_conversation_resolution:{enabled:.required_conversation_resolution},
+          lock_branch:{enabled:.lock_branch},
+          allow_fork_syncing:{enabled:.allow_fork_syncing}
+        }'
+    fi
+    ;;
+  'api repos/f5-sales-demo/example')
+    if [[ "$*" == *'--method PATCH'* ]]; then
+      input=""
+      while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--input" ]; then
+          input="$2"
+          break
+        fi
+        shift
+      done
+      [ -n "$input" ] || exit 64
+      jq -e '
+        .allow_squash_merge == true and .allow_auto_merge == true and
+        .delete_branch_on_merge == true
+      ' "$input" >/dev/null || exit 65
+      touch "$FAKE_STATE/repo-settings-reconciled"
+    elif [[ "$*" == *'--jq .default_branch'* ]]; then
+      printf 'main\n'
+    elif [ -f "$FAKE_STATE/repo-settings-reconciled" ]; then
+      printf '{"allow_squash_merge":true,"allow_auto_merge":true,"delete_branch_on_merge":true}\n'
+    else
+      printf '{"allow_squash_merge":true,"allow_auto_merge":false,"delete_branch_on_merge":false}\n'
+    fi
+    ;;
   'api repos/f5-sales-demo/example/git/ref/heads/main') printf '%s\n' "$BASE_SHA" ;;
   'api repos/f5-sales-demo/example/git/ref/heads/sync/exact-caller-'*)
     if [ -f "$FAKE_STATE/branch" ]; then
@@ -663,6 +777,7 @@ run_bootstrap() {
   if [ "${FAKE_SKIP_LINT_CALLER:-}" = 1 ]; then
     expected_lint_receipt=skipped
   fi
+  local expected_branch="sync/exact-caller-${CALLER_BLOB}${expected_lint_receipt}${LINKED_CALLER_BLOB}"
   env \
     PATH="$WORK/bin:$PATH" \
     GITHUB_REPOSITORY=f5-sales-demo/docs-control \
@@ -687,7 +802,7 @@ run_bootstrap() {
     BRANCH_HEAD="$BRANCH_HEAD" \
     REFRESH_TREE="$REFRESH_TREE" \
     REFRESH_HEAD="$REFRESH_HEAD" \
-    EXPECTED_BRANCH="sync/exact-caller-${CALLER_BLOB}${expected_lint_receipt}${LINKED_CALLER_BLOB}" \
+    EXPECTED_BRANCH="$expected_branch" \
     CALLER_BLOB="$CALLER_BLOB" \
     CALLER_CONTENT="$CALLER_CONTENT" \
     LINT_CALLER_BLOB="$LINT_CALLER_BLOB" \
@@ -721,6 +836,8 @@ run_bootstrap() {
     FAKE_STAGED_LINKED_TRANSITION="${FAKE_STAGED_LINKED_TRANSITION:-}" \
     FAKE_LEGACY_LINKED_CHECK="${FAKE_LEGACY_LINKED_CHECK:-}" \
     FAKE_RECOVER_MERGED_TRANSITION="${FAKE_RECOVER_MERGED_TRANSITION:-}" \
+    FAKE_FIRST_REPO="${FAKE_FIRST_REPO:-}" \
+    FAKE_BAD_RECOVER_LINKED="${FAKE_BAD_RECOVER_LINKED:-}" \
     FAKE_FAIL_SECOND_BOOTSTRAP="${FAKE_FAIL_SECOND_BOOTSTRAP:-}" \
     REPO_SETTINGS_TOKEN=settings-token \
     "$SOURCE"
@@ -1492,6 +1609,91 @@ if [ "$rc" != 0 ] || [ ! -f "$state/legacy-canceled" ] ||
   exit 1
 fi
 echo "[OK] missing current workflow still inventories and cancels active legacy runs"
+
+state="$WORK/state-first-repo"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_FIRST_REPO=1
+FAKE_MERGE_LANDS=1
+set +e
+run_bootstrap "$state" >"$WORK/first-repo.out" 2>"$WORK/first-repo.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO FAKE_MERGE_LANDS
+protection_line=$(grep -n 'branches/main/protection --method PUT' "$WORK/gh.log" |
+  head -1 | cut -d: -f1 || true)
+merge_line=$(grep -n '^pr merge ' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
+dispatch_line=$(grep -n 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log" |
+  head -1 | cut -d: -f1 || true)
+final_context_line=$(grep -n 'required_status_checks --method PATCH' "$WORK/gh.log" |
+  tail -1 | cut -d: -f1 || true)
+if [ "$rc" != 0 ] || [ -z "$protection_line" ] || [ -z "$merge_line" ] ||
+  [ -z "$dispatch_line" ] || [ -z "$final_context_line" ] ||
+  [ "$protection_line" -ge "$merge_line" ] || [ "$merge_line" -ge "$dispatch_line" ] ||
+  [ "$dispatch_line" -ge "$final_context_line" ] ||
+  ! grep -q 'repos/f5-sales-demo/example --method PATCH' "$WORK/gh.log" ||
+  [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 1 ] ||
+  ! jq -e '.required_status_checks.contexts | index("Check linked issues") == null' \
+    "$state/transition-protection.json" >/dev/null ||
+  ! jq -e '.contexts | index("Check linked issues") != null' \
+    "$state/final-required-checks.json" >/dev/null; then
+  echo "[FAIL] first governed repository did not complete the verified three-caller transition"
+  echo "  rc=$rc"
+  sed 's/^/  /' "$WORK/first-repo.err"
+  sed 's/^/  log: /' "$WORK/gh.log"
+  exit 1
+fi
+echo "[OK] first governed repository installs three exact callers before restoring protection"
+
+state="$WORK/state-recover-first-repo"
+mkdir -p "$state"
+touch "$state/merged" "$state/protection-created"
+cp "$WORK/state-first-repo/transition-protection.json" \
+  "$state/transition-protection.json"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+FAKE_FIRST_REPO=1
+FAKE_RECOVER_MERGED_TRANSITION=1
+run_bootstrap "$state" >"$WORK/recover-first-repo.out" \
+  2>"$WORK/recover-first-repo.err"
+unset FAKE_FIRST_REPO FAKE_RECOVER_MERGED_TRANSITION
+if ! grep -q 'pulls?state=closed&sort=updated&direction=desc&per_page=100' "$WORK/gh.log" ||
+  ! grep -q 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log" ||
+  [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 1 ] ||
+  grep -qE 'git/refs --method POST|contents/.github/workflows/.* --method PUT|^pr (create|merge)' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] interrupted first-repository transition did not recover from three exact blobs"
+  cat "$WORK/recover-first-repo.err"
+  exit 1
+fi
+echo "[OK] interrupted first-repository transition recovers from three exact blobs"
+
+state="$WORK/state-hostile-first-repo-receipt"
+mkdir -p "$state"
+touch "$state/merged" "$state/protection-created"
+cp "$WORK/state-first-repo/transition-protection.json" \
+  "$state/transition-protection.json"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+FAKE_FIRST_REPO=1
+FAKE_RECOVER_MERGED_TRANSITION=1
+FAKE_BAD_RECOVER_LINKED=1
+set +e
+run_bootstrap "$state" >/dev/null 2>"$WORK/hostile-first-repo-receipt.err"
+rc=$?
+set -e
+unset FAKE_FIRST_REPO FAKE_RECOVER_MERGED_TRANSITION FAKE_BAD_RECOVER_LINKED
+if [ "$rc" = 0 ] ||
+  grep -qE 'require-linked-issue.yml/dispatches --method POST|required_status_checks --method PATCH|^pr merge' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] hostile first-repository receipt reached dispatch or protection mutation"
+  cat "$WORK/hostile-first-repo-receipt.err"
+  exit 1
+fi
+echo "[OK] hostile first-repository receipt fails before dispatch or protection mutation"
 
 state="$WORK/state-missing-workflow"
 mkdir -p "$state"


### PR DESCRIPTION
## Summary

Adds a fail-closed onboarding transition for a repository that has no governed callers or classic branch protection yet. The bootstrap creates one exact three-caller PR, requires only real checks available during bootstrap, waits until the linked-issue workflow exists on `main`, verifies a genuine canonical status, and only then restores the authoritative required contexts.

The transition uses GitHub Free-compatible repository settings and classic branch protection only. Repository-specific Super-Linter opt-outs remain intact.

## Related Issue

Closes #1201

## Changes

- Detect a first governed repository without relying on a pre-existing workflow.
- Reconcile GitHub Free merge settings and classic branch protection before the bootstrap PR.
- Install only the exact applicable enforcement, Super-Linter, and linked-issue callers.
- Recover interrupted transitions only from an exact merged caller receipt.
- Restore the canonical linked-issue context only after a verified post-merge dispatch.
- Update the governed-fleet count from 37 to 38.

## Verification evidence

- `bash tests/test-bootstrap-downstream-callers.sh` — passed, including first-repository merge, recovery, hostile-receipt, opt-out, and fail-closed cases.
- `pre-commit run --all-files` — all hooks passed, including shellcheck, actionlint, zizmor, Checkov, gitleaks, and PII checks.
- `bash scripts/agy-pre-push-review.sh` — Antigravity gate passed on commit `58eeb21`; no critical or high finding remains.

## Checklist

- [x] Linked to a GitHub issue
- [x] Feature-complete and locally verified
- [x] Tests pass for the changed surface
- [ ] CI watched to green
- [x] Uses GitHub Free-compatible controls only
- [x] Follows project conventions