### PR TITLE
fix: provision downstream governance secrets

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -21,6 +21,7 @@ on:
       - '.github/config/governed-workflow-pin.json'
       - '.github/config/governance-rollout.json'
       - '.github/workflows/dispatch-downstream.yml'
+      - 'scripts/provision-governance-secrets.sh'
       - 'workflows/enforce-repo-settings.yml'
       - 'README.md.tpl'
   schedule:
@@ -63,6 +64,22 @@ jobs:
             echo "::error::Could not resolve an exact docs-control source commit"
             exit 1
           fi
+
+          set +e
+          scripts/provision-governance-secrets.sh
+          provision_rc=$?
+          set -e
+          case "$provision_rc" in
+            0) ;;
+            84)
+              echo "[DEFER] GitHub API rate capacity was exhausted; scheduled recovery is active"
+              exit 0
+              ;;
+            *)
+              echo "::error::Governance repository-secret provisioning failed"
+              exit "$provision_rc"
+              ;;
+          esac
 
           set +e
           scripts/preflight-downstream-dispatch.sh

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -504,6 +504,10 @@ jobs:
         if: hashFiles('tests/test-retry-stdout.sh') != ''
         run: bash tests/test-retry-stdout.sh
 
+      - name: Run governance-secret provisioning test
+        if: hashFiles('tests/test-provision-governance-secrets.sh') != ''
+        run: bash tests/test-provision-governance-secrets.sh
+
       - name: Run dispatch-matrix test
         if: hashFiles('tests/test-dispatch-matrix.sh') != ''
         run: bash tests/test-dispatch-matrix.sh

--- a/scripts/provision-governance-secrets.sh
+++ b/scripts/provision-governance-secrets.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Ensure every governed downstream repository can run the centrally dispatched
+# repository-settings workflow. Values cross the GitHub CLI boundary only on
+# standard input and are never written into command arguments or output.
+set -euo pipefail
+
+downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
+owner="${GITHUB_REPOSITORY_OWNER:-}"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+if ! printf '%s' "$owner" | grep -qE '^[A-Za-z0-9_.-]+$'; then
+  echo "[ERROR] GITHUB_REPOSITORY_OWNER is invalid" >&2
+  exit 1
+fi
+if [ -z "${REPO_SETTINGS_TOKEN:-}" ]; then
+  echo "[ERROR] REPO_SETTINGS_TOKEN is required to administer repository secrets" >&2
+  exit 1
+fi
+if [ -z "${REPO_SYNC_TOKEN:-}" ]; then
+  echo "[ERROR] REPO_SYNC_TOKEN is required as a repository secret source" >&2
+  exit 1
+fi
+if ! jq -e '
+  type == "array" and length > 0 and
+  all(.[]; type == "string" and test("^[A-Za-z0-9_.-]+$")) and
+  (length == (unique | length))
+' "$downstream_config" >/dev/null; then
+  echo "[ERROR] Downstream inventory must be a non-empty array of unique repository names" >&2
+  exit 1
+fi
+
+run_gh() {
+  local err_file rc
+  err_file=$(mktemp "$work/gh-err.XXXXXX")
+  set +e
+  GH_TOKEN="$REPO_SETTINGS_TOKEN" command gh "$@" 2>"$err_file"
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    rm -f "$err_file"
+    return 0
+  fi
+  if grep -qiE 'rate[[:space:]-]*limit|HTTP 429|abuse[ -]?detection' "$err_file"; then
+    rm -f "$err_file"
+    echo "[DEFER] GitHub API rate capacity was exhausted; scheduled recovery is active" >&2
+    return 84
+  fi
+  rm -f "$err_file"
+  echo "[ERROR] GitHub repository-secret operation failed closed" >&2
+  return 1
+}
+
+list_secret_inventory() {
+  local slug="$1" inventory rc
+  set +e
+  inventory=$(run_gh secret list --repo "$slug" --json name)
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    return "$rc"
+  fi
+  if ! printf '%s' "$inventory" | jq -e '
+    type == "array" and
+    all(.[];
+      type == "object" and
+      (.name | type == "string" and test("^[A-Za-z_][A-Za-z0-9_]*$"))) and
+    ([.[].name] | length == (unique | length))
+  ' >/dev/null; then
+    echo "[ERROR] GitHub returned a malformed repository-secret inventory for ${slug}" >&2
+    return 1
+  fi
+  printf '%s' "$inventory"
+}
+
+inventory_has() {
+  local inventory="$1" name="$2"
+  printf '%s' "$inventory" |
+    jq -e --arg name "$name" 'any(.[]; .name == $name)' >/dev/null
+}
+
+while IFS= read -r name; do
+  slug="${owner}/${name}"
+  set +e
+  inventory=$(list_secret_inventory "$slug")
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    exit "$rc"
+  fi
+
+  changed=false
+  for secret_name in REPO_SETTINGS_TOKEN REPO_SYNC_TOKEN; do
+    if inventory_has "$inventory" "$secret_name"; then
+      continue
+    fi
+    case "$secret_name" in
+    REPO_SETTINGS_TOKEN) secret_value="$REPO_SETTINGS_TOKEN" ;;
+    REPO_SYNC_TOKEN) secret_value="$REPO_SYNC_TOKEN" ;;
+    esac
+    set +e
+    printf '%s' "$secret_value" |
+      run_gh secret set "$secret_name" --repo "$slug"
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      exit "$rc"
+    fi
+    changed=true
+    printf '[SET] %s: %s\n' "$slug" "$secret_name"
+  done
+
+  if [ "$changed" = true ]; then
+    set +e
+    inventory=$(list_secret_inventory "$slug")
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      exit "$rc"
+    fi
+  fi
+  for secret_name in REPO_SETTINGS_TOKEN REPO_SYNC_TOKEN; do
+    if ! inventory_has "$inventory" "$secret_name"; then
+      echo "[ERROR] ${slug} is missing ${secret_name} after provisioning" >&2
+      exit 1
+    fi
+  done
+  printf '[OK] %s governance repository secrets are present\n' "$slug"
+done < <(jq -r '.[]' "$downstream_config")

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -72,6 +72,8 @@ check "triggers when fleet membership changes" \
   "grep -q 'downstream-repos.json' '$WF'"
 check "triggers when the dispatcher contract changes" \
   "grep -q 'dispatch-downstream.yml' '$WF'"
+check "triggers when governance-secret provisioning changes" \
+  "grep -q 'scripts/provision-governance-secrets.sh' '$WF'"
 check "triggers when the exact managed caller changes" \
   "grep -q 'workflows/enforce-repo-settings.yml' '$WF'"
 check "triggers after the immutable governed workflow pin rolls forward" \
@@ -94,6 +96,12 @@ check "forwards the exact source receipt to every downstream run" \
   "grep -Fq -- '-f source_sha=\"\$SOURCE_SHA\"' '$WF'"
 check "runs exact-source and immutable-pin preflight before fan-out" \
   "grep -q 'scripts/preflight-downstream-dispatch.sh' '$WF'"
+PROVISION_LINE=$(grep -n '^[[:space:]]*scripts/provision-governance-secrets.sh$' "$WF" |
+  head -n1 | cut -d: -f1 || true)
+PREFLIGHT_LINE=$(grep -n '^[[:space:]]*scripts/preflight-downstream-dispatch.sh$' "$WF" |
+  head -n1 | cut -d: -f1 || true)
+check "provisions governance secrets before downstream preflight" \
+  "[ -n '$PROVISION_LINE' ] && [ -n '$PREFLIGHT_LINE' ] && [ '$PROVISION_LINE' -lt '$PREFLIGHT_LINE' ]"
 check "defers fan-out until the governed caller pin is exact" \
   "grep -q '\[DEFER\].*governed workflow pin' '$WF'"
 check "bootstraps stale downstream callers without legacy reusable code" \
@@ -132,6 +140,10 @@ count=$((count + 1))
 printf '%s\n' "$count" >"$count_file"
 [ "$count" -eq 1 ] && exit 80
 exit 78
+EOF
+cat >"$WORK/scripts/provision-governance-secrets.sh" <<'EOF'
+#!/usr/bin/env bash
+exit "${FAKE_PROVISION_RC:-0}"
 EOF
 cat >"$WORK/scripts/bootstrap-downstream-callers.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -224,5 +236,26 @@ recovery_rc=$?
 set -e
 check "preflight API rate exhaustion defers to scheduled recovery" \
   "[ '$recovery_rc' -eq 0 ] && ! grep -q 'workflow run dispatch-downstream.yml' '$WORK/gh.log'"
+
+rm -f "$WORK/.preflight-count"
+: >"$WORK/gh.log"
+set +e
+(
+  cd "$WORK"
+  env \
+    PATH="$WORK/bin:$PATH" \
+    FAKE_GH_LOG="$WORK/gh.log" \
+    FAKE_PROVISION_RC=84 \
+    GITHUB_REPOSITORY=f5-sales-demo/docs-control \
+    GITHUB_REPOSITORY_OWNER=f5-sales-demo \
+    SOURCE_SHA=1111111111111111111111111111111111111111 \
+    REPO_SETTINGS_TOKEN=settings-token \
+    REPO_SYNC_TOKEN=sync-token \
+    bash "$WORK/dispatch.sh"
+)
+recovery_rc=$?
+set -e
+check "secret-provisioning rate exhaustion defers before preflight" \
+  "[ '$recovery_rc' -eq 0 ] && [ ! -e '$WORK/.preflight-count' ] && ! grep -q 'workflow run dispatch-downstream.yml' '$WORK/gh.log'"
 
 exit "$FAIL"

--- a/tests/test-provision-governance-secrets.sh
+++ b/tests/test-provision-governance-secrets.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SCRIPT="${REPO_ROOT}/scripts/provision-governance-secrets.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() {
+  printf '[FAIL] %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf '[OK] %s\n' "$1"
+}
+
+mkdir -p "$WORK/bin" "$WORK/state"
+cat >"$WORK/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$FAKE_GH_LOG"
+
+if [ "${1:-}" != "secret" ] || { [ "${2:-}" != "list" ] && [ "${2:-}" != "set" ]; }; then
+  echo "unexpected gh invocation" >&2
+  exit 2
+fi
+
+operation="$2"
+shift 2
+name=""
+if [ "$operation" = "set" ]; then
+  name="${1:-}"
+  shift
+fi
+
+repo=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --json)
+      [ "${2:-}" = "name" ] || exit 2
+      shift 2
+      ;;
+    *)
+      echo "unexpected gh argument" >&2
+      exit 2
+      ;;
+  esac
+done
+
+[ -n "$repo" ] || exit 2
+state_file="$FAKE_GH_STATE/${repo//\//__}"
+touch "$state_file"
+
+if [ "$operation" = "list" ]; then
+  case "${FAKE_GH_MODE:-}" in
+    list-error)
+      echo 'gh: forbidden (HTTP 403)' >&2
+      exit 1
+      ;;
+    list-rate)
+      echo 'gh: API rate limit exceeded (HTTP 403)' >&2
+      exit 1
+      ;;
+  esac
+  jq -Rsc 'split("\n") | map(select(length > 0) | {name: .})' "$state_file"
+  exit 0
+fi
+
+case "${FAKE_GH_MODE:-}" in
+  set-error)
+    echo 'gh: forbidden (HTTP 403)' >&2
+    exit 1
+    ;;
+  set-rate)
+    echo 'gh: secondary rate limit (HTTP 403)' >&2
+    exit 1
+    ;;
+esac
+
+payload=$(cat)
+case "$name" in
+  REPO_SETTINGS_TOKEN) expected="$EXPECTED_SETTINGS_TOKEN" ;;
+  REPO_SYNC_TOKEN) expected="$EXPECTED_SYNC_TOKEN" ;;
+  *) exit 2 ;;
+esac
+[ "$payload" = "$expected" ] || exit 3
+
+if [ "${FAKE_GH_MODE:-}" != "drop-write" ]; then
+  printf '%s\n' "$name" >>"$state_file"
+  sort -u -o "$state_file" "$state_file"
+fi
+EOF
+chmod +x "$WORK/bin/gh"
+
+SETTINGS_TOKEN='settings-value-must-not-leak'
+SYNC_TOKEN='sync-value-must-not-leak'
+printf '["alpha","beta"]\n' >"$WORK/repos.json"
+printf 'REPO_SETTINGS_TOKEN\nREPO_SYNC_TOKEN\n' >"$WORK/state/f5-sales-demo__alpha"
+printf 'REPO_SETTINGS_TOKEN\n' >"$WORK/state/f5-sales-demo__beta"
+: >"$WORK/gh.log"
+
+run_provisioner() {
+  env \
+    PATH="$WORK/bin:$PATH" \
+    DOWNSTREAM_CONFIG="${PROVISION_CONFIG:-$WORK/repos.json}" \
+    GITHUB_REPOSITORY_OWNER=f5-sales-demo \
+    REPO_SETTINGS_TOKEN="${PROVISION_SETTINGS_TOKEN-$SETTINGS_TOKEN}" \
+    REPO_SYNC_TOKEN="${PROVISION_SYNC_TOKEN-$SYNC_TOKEN}" \
+    EXPECTED_SETTINGS_TOKEN="$SETTINGS_TOKEN" \
+    EXPECTED_SYNC_TOKEN="$SYNC_TOKEN" \
+    FAKE_GH_LOG="$WORK/gh.log" \
+    FAKE_GH_STATE="$WORK/state" \
+    FAKE_GH_MODE="${PROVISION_FAKE_MODE:-}" \
+    bash "$SCRIPT"
+}
+
+if [ -e "$SCRIPT" ]; then
+  pass "provisioning script exists"
+else
+  fail "provisioning script exists"
+fi
+
+output=$(run_provisioner 2>&1) || fail "missing secret is provisioned"
+pass "missing secret is provisioned"
+
+set_calls=$(grep -c '^secret set ' "$WORK/gh.log" || true)
+[ "$set_calls" -eq 1 ] || fail "only one missing secret is written"
+grep -q '^secret set REPO_SYNC_TOKEN --repo f5-sales-demo/beta$' "$WORK/gh.log" ||
+  fail "the exact missing repository secret is written"
+pass "only the exact missing repository secret is written"
+
+grep -qx 'REPO_SYNC_TOKEN' "$WORK/state/f5-sales-demo__beta" ||
+  fail "secret value is accepted through standard input"
+pass "secret value is accepted through standard input"
+
+if printf '%s\n%s\n' "$output" "$(cat "$WORK/gh.log")" |
+  grep -Fq -e "$SETTINGS_TOKEN" -e "$SYNC_TOKEN"; then
+  fail "secret values stay out of output and command arguments"
+fi
+if grep -Eq -- '--(org|env|visibility|repos)( |$)' "$WORK/gh.log"; then
+  fail "only GitHub Free repository secrets are used"
+fi
+pass "secret values stay out of logs and only repository secrets are used"
+
+: >"$WORK/gh.log"
+run_provisioner >/dev/null 2>&1 || fail "idempotent rerun succeeds"
+if grep -q '^secret set ' "$WORK/gh.log"; then
+  fail "existing secrets are never rewritten"
+fi
+pass "idempotent rerun does not rewrite existing secrets"
+
+printf '{"not":"an array"}\n' >"$WORK/repos-invalid.json"
+set +e
+PROVISION_CONFIG="$WORK/repos-invalid.json" run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "malformed inventory fails closed"
+pass "malformed inventory fails closed"
+
+set +e
+PROVISION_SETTINGS_TOKEN='' run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "missing administrative credential fails closed"
+
+set +e
+PROVISION_SYNC_TOKEN='' run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "missing sync credential fails closed"
+pass "missing source credentials fail closed"
+
+set +e
+PROVISION_FAKE_MODE=list-error run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "inventory API failure fails closed"
+
+set +e
+PROVISION_FAKE_MODE=list-rate run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 84 ] || fail "inventory rate exhaustion returns 84"
+pass "inventory API failures fail closed and rate exhaustion returns 84"
+
+printf 'REPO_SETTINGS_TOKEN\n' >"$WORK/state/f5-sales-demo__beta"
+set +e
+PROVISION_FAKE_MODE=set-error run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "secret write API failure fails closed"
+
+set +e
+PROVISION_FAKE_MODE=set-rate run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 84 ] || fail "secret write rate exhaustion returns 84"
+pass "secret write failures fail closed and rate exhaustion returns 84"
+
+set +e
+PROVISION_FAKE_MODE=drop-write run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "missing postcondition fails closed"
+pass "post-write inventory must contain both governance secrets"


### PR DESCRIPTION
## Summary

Provision missing governance repository secrets from the trusted central dispatch before downstream preflight, without exposing values or requiring GitHub Enterprise features.

## Related Issue

Closes #1214

## Changes

- add an idempotent, fail-closed repository-secret provisioner
- pass secret values only through standard input and verify post-write inventory
- defer safely on API rate exhaustion and test dispatch ordering
- run the hermetic provisioner test in Shell Unit Tests

## Verification evidence

- `bash tests/test-provision-governance-secrets.sh` — 11 checks passed
- `bash tests/test-dispatch-matrix.sh` — all structural and recovery checks passed
- `bash tests/test-dispatch-preflight.sh` — 12 passed, 0 failed
- `shellcheck scripts/provision-governance-secrets.sh tests/test-provision-governance-secrets.sh tests/test-dispatch-matrix.sh` — passed
- `actionlint .github/workflows/dispatch-downstream.yml .github/workflows/super-linter.yml` — passed
- `pre-commit run --all-files` — all enabled hooks passed
- `bash scripts/agy-pre-push-review.sh` — PII head scan clean; Antigravity gate passed with no critical/high finding

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
