### PR TITLE
fix: pace governance secret inventory

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -56,6 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
+          PROVISION_REQUEST_DELAY_SECONDS: 1
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -206,9 +207,11 @@ jobs:
           done
           TOTAL=${#REPOS[@]}
           BATCH_SIZE=5
-          # Seven gaps at the current fleet size consume 210 seconds, leaving
-          # 90 seconds of the runner's five-minute budget for API work/retries.
-          BATCH_DELAY=30
+          # Seven fan-out gaps consume 175 seconds. Combined with the 37
+          # one-second repository-secret inventory gaps, deterministic waits
+          # consume 212 seconds and leave 88 seconds of the runner's
+          # five-minute budget for API work and retries.
+          BATCH_DELAY=25
           echo "Dispatching enforce-repo-settings to ${TOTAL} repos (batches of ${BATCH_SIZE}, ${BATCH_DELAY}s delay)..."
 
           LOG=$(mktemp)

--- a/scripts/provision-governance-secrets.sh
+++ b/scripts/provision-governance-secrets.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
 owner="${GITHUB_REPOSITORY_OWNER:-}"
+request_delay_seconds="${PROVISION_REQUEST_DELAY_SECONDS:-1}"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
@@ -19,6 +20,11 @@ if [ -z "${REPO_SETTINGS_TOKEN:-}" ]; then
 fi
 if [ -z "${REPO_SYNC_TOKEN:-}" ]; then
   echo "[ERROR] REPO_SYNC_TOKEN is required as a repository secret source" >&2
+  exit 1
+fi
+if ! printf '%s' "$request_delay_seconds" | grep -qE '^[0-9]+$' ||
+  [ "$request_delay_seconds" -gt 60 ]; then
+  echo "[ERROR] Repository-secret request delay must be between 0 and 60 seconds" >&2
   exit 1
 fi
 if ! jq -e '
@@ -79,6 +85,8 @@ inventory_has() {
     jq -e --arg name "$name" 'any(.[]; .name == $name)' >/dev/null
 }
 
+repository_count=$(jq 'length' "$downstream_config")
+repository_index=0
 while IFS= read -r name; do
   slug="${owner}/${name}"
   set +e
@@ -126,4 +134,9 @@ while IFS= read -r name; do
     fi
   done
   printf '[OK] %s governance repository secrets are present\n' "$slug"
+  repository_index=$((repository_index + 1))
+  if [ "$repository_index" -lt "$repository_count" ] &&
+    [ "$request_delay_seconds" -gt 0 ]; then
+    sleep "$request_delay_seconds"
+  fi
 done < <(jq -r '.[]' "$downstream_config")

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -34,13 +34,20 @@ check "BATCH_SIZE=5 for parallelism cap" "grep -q 'BATCH_SIZE=5' '$WF'"
 # budget in deterministic inter-batch sleeps.
 BATCH_SIZE_VALUE=$(sed -nE 's/^[[:space:]]*BATCH_SIZE=([0-9]+)$/\1/p' "$WF")
 BATCH_DELAY_VALUE=$(sed -nE 's/^[[:space:]]*BATCH_DELAY=([0-9]+)$/\1/p' "$WF")
+PROVISION_DELAY_VALUE=$(sed -nE \
+  's/^[[:space:]]*PROVISION_REQUEST_DELAY_SECONDS: ([0-9]+)$/\1/p' "$WF")
+PROVISION_DELAY_VALUE=${PROVISION_DELAY_VALUE:-0}
 FLEET_SIZE=$(jq 'length' "$CONFIG")
 BATCH_COUNT=$(((FLEET_SIZE + BATCH_SIZE_VALUE - 1) / BATCH_SIZE_VALUE))
-SCHEDULED_SLEEP_SECONDS=$(((BATCH_COUNT - 1) * BATCH_DELAY_VALUE))
+SCHEDULED_SLEEP_SECONDS=$(((\
+  BATCH_COUNT - 1) * BATCH_DELAY_VALUE + (\
+  FLEET_SIZE - 1) * PROVISION_DELAY_VALUE))
 RUNNER_BUDGET_SECONDS=300
 RUNNER_RESERVE_SECONDS=60
-check "inter-batch sleeps leave 60s of the runner budget" \
+check "inventory pacing and inter-batch sleeps leave 60s of the runner budget" \
   "[ '$SCHEDULED_SLEEP_SECONDS' -le '$((RUNNER_BUDGET_SECONDS - RUNNER_RESERVE_SECONDS))' ]"
+check "repository-secret inventory is paced at one request per second" \
+  "[ '$PROVISION_DELAY_VALUE' -eq 1 ]"
 
 # Retry-with-backoff preserved (2s → 4s → 8s).
 check "retry max=3 attempts" "grep -Eq 'max=3' '$WF'"

--- a/tests/test-provision-governance-secrets.sh
+++ b/tests/test-provision-governance-secrets.sh
@@ -16,6 +16,11 @@ pass() {
 }
 
 mkdir -p "$WORK/bin" "$WORK/state"
+cat >"$WORK/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$FAKE_SLEEP_LOG"
+EOF
 cat >"$WORK/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -97,6 +102,7 @@ if [ "${FAKE_GH_MODE:-}" != "drop-write" ]; then
 fi
 EOF
 chmod +x "$WORK/bin/gh"
+chmod +x "$WORK/bin/sleep"
 
 SETTINGS_TOKEN='settings-value-must-not-leak'
 SYNC_TOKEN='sync-value-must-not-leak'
@@ -104,6 +110,7 @@ printf '["alpha","beta"]\n' >"$WORK/repos.json"
 printf 'REPO_SETTINGS_TOKEN\nREPO_SYNC_TOKEN\n' >"$WORK/state/f5-sales-demo__alpha"
 printf 'REPO_SETTINGS_TOKEN\n' >"$WORK/state/f5-sales-demo__beta"
 : >"$WORK/gh.log"
+: >"$WORK/sleep.log"
 
 run_provisioner() {
   env \
@@ -116,7 +123,9 @@ run_provisioner() {
     EXPECTED_SYNC_TOKEN="$SYNC_TOKEN" \
     FAKE_GH_LOG="$WORK/gh.log" \
     FAKE_GH_STATE="$WORK/state" \
+    FAKE_SLEEP_LOG="$WORK/sleep.log" \
     FAKE_GH_MODE="${PROVISION_FAKE_MODE:-}" \
+    PROVISION_REQUEST_DELAY_SECONDS="${PROVISION_TEST_DELAY:-0}" \
     bash "$SCRIPT"
 }
 
@@ -154,6 +163,20 @@ if grep -q '^secret set ' "$WORK/gh.log"; then
   fail "existing secrets are never rewritten"
 fi
 pass "idempotent rerun does not rewrite existing secrets"
+
+: >"$WORK/sleep.log"
+PROVISION_TEST_DELAY=1 run_provisioner >/dev/null 2>&1 ||
+  fail "paced inventory succeeds"
+[ "$(cat "$WORK/sleep.log")" = "1" ] ||
+  fail "inventory requests are paced between repositories"
+pass "inventory requests are paced between repositories"
+
+set +e
+PROVISION_TEST_DELAY=invalid run_provisioner >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "invalid request pacing fails closed"
+pass "invalid request pacing fails closed"
 
 printf '{"not":"an array"}\n' >"$WORK/repos-invalid.json"
 set +e


### PR DESCRIPTION
## Summary

Prevent the governance-secret inventory from repeatedly triggering secondary API rate limiting before downstream preflight.

## Related Issue

Closes #1214

## Changes

- pace repository-secret inventory requests at one second per repository
- validate the pacing configuration and test it without real delays
- reduce fan-out gaps from 30s to 25s, keeping deterministic waits at 212s and preserving 88s of the five-minute budget

## Verification evidence

- Live runs `30960139441`, `30960425834`, and `30960538009` reproduced the unpaced inventory/preflight rate-limit boundary
- `bash tests/test-provision-governance-secrets.sh` — all checks passed, including pacing and invalid configuration
- `bash tests/test-dispatch-matrix.sh` — all structural, timing-budget, and recovery checks passed
- `bash tests/test-dispatch-preflight.sh` — 12 passed, 0 failed
- `shellcheck scripts/provision-governance-secrets.sh tests/test-provision-governance-secrets.sh tests/test-dispatch-matrix.sh` — passed
- `actionlint .github/workflows/dispatch-downstream.yml` — passed
- `pre-commit run --all-files` — all enabled hooks passed
- `bash scripts/agy-pre-push-review.sh` — PII head scan clean; Antigravity gate passed with no critical/high finding

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
