### PR TITLE
fix: throttle governance secret inventory

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -56,7 +56,7 @@ jobs:
           GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
-          PROVISION_REQUEST_DELAY_SECONDS: 1
+          PROVISION_REQUEST_DELAY_SECONDS: 2
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -207,11 +207,11 @@ jobs:
           done
           TOTAL=${#REPOS[@]}
           BATCH_SIZE=5
-          # Seven fan-out gaps consume 175 seconds. Combined with the 37
-          # one-second repository-secret inventory gaps, deterministic waits
-          # consume 212 seconds and leave 88 seconds of the runner's
+          # Seven fan-out gaps consume 140 seconds. Combined with the 37
+          # two-second repository-secret inventory gaps, deterministic waits
+          # consume 214 seconds and leave 86 seconds of the runner's
           # five-minute budget for API work and retries.
-          BATCH_DELAY=25
+          BATCH_DELAY=20
           echo "Dispatching enforce-repo-settings to ${TOTAL} repos (batches of ${BATCH_SIZE}, ${BATCH_DELAY}s delay)..."
 
           LOG=$(mktemp)

--- a/scripts/provision-governance-secrets.sh
+++ b/scripts/provision-governance-secrets.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
 owner="${GITHUB_REPOSITORY_OWNER:-}"
-request_delay_seconds="${PROVISION_REQUEST_DELAY_SECONDS:-1}"
+request_delay_seconds="${PROVISION_REQUEST_DELAY_SECONDS:-2}"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -46,8 +46,8 @@ RUNNER_BUDGET_SECONDS=300
 RUNNER_RESERVE_SECONDS=60
 check "inventory pacing and inter-batch sleeps leave 60s of the runner budget" \
   "[ '$SCHEDULED_SLEEP_SECONDS' -le '$((RUNNER_BUDGET_SECONDS - RUNNER_RESERVE_SECONDS))' ]"
-check "repository-secret inventory is paced at one request per second" \
-  "[ '$PROVISION_DELAY_VALUE' -eq 1 ]"
+check "repository-secret inventory stays below 30 requests per minute" \
+  "[ '$PROVISION_DELAY_VALUE' -eq 2 ]"
 
 # Retry-with-backoff preserved (2s → 4s → 8s).
 check "retry max=3 attempts" "grep -Eq 'max=3' '$WF'"

--- a/tests/test-provision-governance-secrets.sh
+++ b/tests/test-provision-governance-secrets.sh
@@ -165,9 +165,9 @@ fi
 pass "idempotent rerun does not rewrite existing secrets"
 
 : >"$WORK/sleep.log"
-PROVISION_TEST_DELAY=1 run_provisioner >/dev/null 2>&1 ||
+PROVISION_TEST_DELAY=2 run_provisioner >/dev/null 2>&1 ||
   fail "paced inventory succeeds"
-[ "$(cat "$WORK/sleep.log")" = "1" ] ||
+[ "$(cat "$WORK/sleep.log")" = "2" ] ||
   fail "inventory requests are paced between repositories"
 pass "inventory requests are paced between repositories"
 


### PR DESCRIPTION
## Summary

Throttle governance-secret inventory below the live secondary API boundary while preserving the dispatcher timing budget.

## Related Issue

Closes #1214

## Changes

- use two-second repository inventory spacing, keeping the steady-state rate below 30 requests/minute
- reduce fan-out gaps from 25s to 20s so deterministic waits remain 214s with 86s reserved
- update hermetic pacing and timing-budget assertions

## Verification evidence

- Live run `30961432794` proved one-second spacing still reached the rate boundary after 38 inventories
- `bash tests/test-provision-governance-secrets.sh` — all checks passed with two-second pacing
- `bash tests/test-dispatch-matrix.sh` — all structural, timing-budget, and recovery checks passed
- `bash tests/test-dispatch-preflight.sh` — 12 passed, 0 failed
- Shellcheck and actionlint — passed
- `pre-commit run --all-files` — all enabled hooks passed
- `bash scripts/agy-pre-push-review.sh` — PII head scan clean; Antigravity gate passed with no critical/high finding

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
