### PR TITLE
fix(governance): bind first-repo transition ownership

### DIFF
--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -180,6 +180,27 @@ api_value_or_404() {
   return 1
 }
 
+branch_protection_state() {
+  local slug="$1" protection rc
+  set +e
+  protection=$(api_value_or_404 \
+    "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN")
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    if ! printf '%s' "$protection" | jq -e 'type == "object"' >/dev/null; then
+      echo "[ERROR] Branch-protection response is malformed for ${slug}" >&2
+      return 1
+    fi
+    printf 'protected'
+    ;;
+  44) printf 'unprotected' ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
+}
+
 retry() {
   local max="$1"
   shift
@@ -349,7 +370,34 @@ normalize_current_bootstrap_protection() {
 reconcile_first_repo_controls() {
   local name="$1" slug desired_repo current_repo verified_repo repo_payload verified_protection
   local desired_protection desired_state current_protection current_state rc protection_payload
+  local created_protection=false
   slug="${owner}/${name}"
+  desired_protection=$(first_transition_protection_for_repo "$name") || {
+    echo "[ERROR] Could not derive first-repository protection for ${slug}" >&2
+    return 1
+  }
+  desired_state=$(printf '%s' "$desired_protection" | normalize_desired_bootstrap_protection)
+  set +e
+  current_protection=$(api_value_or_404 \
+    "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN")
+  rc=$?
+  set -e
+  case "$rc" in
+  0)
+    current_state=$(printf '%s' "$current_protection" | normalize_current_bootstrap_protection) || {
+      echo "[ERROR] Branch-protection response is malformed for ${slug}" >&2
+      return 1
+    }
+    if [ "$current_state" != "$desired_state" ]; then
+      echo "[ERROR] Refusing first-repository transition over existing protection for ${slug}" >&2
+      return 1
+    fi
+    ;;
+  44) current_state="" ;;
+  84) return 84 ;;
+  *) return 1 ;;
+  esac
+
   desired_repo=$(jq -c '{
     allow_squash_merge: .repository.allow_squash_merge,
     allow_auto_merge: .repository.allow_auto_merge,
@@ -380,34 +428,38 @@ reconcile_first_repo_controls() {
     return 1
   fi
 
-  desired_protection=$(first_transition_protection_for_repo "$name") || {
-    echo "[ERROR] Could not derive first-repository protection for ${slug}" >&2
-    return 1
-  }
-  desired_state=$(printf '%s' "$desired_protection" | normalize_desired_bootstrap_protection)
-  set +e
-  current_protection=$(api_value_or_404 \
-    "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN")
-  rc=$?
-  set -e
-  case "$rc" in
-  0)
-    current_state=$(printf '%s' "$current_protection" | normalize_current_bootstrap_protection) || {
-      echo "[ERROR] Branch-protection response is malformed for ${slug}" >&2
-      return 1
-    }
-    ;;
-  44) current_state="" ;;
-  84) return 84 ;;
-  *) return 1 ;;
-  esac
-  if [ "$current_state" != "$desired_state" ]; then
+  if [ -z "$current_state" ]; then
+    set +e
+    current_protection=$(api_value_or_404 \
+      "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN")
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      current_state=$(printf '%s' "$current_protection" | normalize_current_bootstrap_protection) || {
+        echo "[ERROR] Branch-protection response is malformed for ${slug}" >&2
+        return 1
+      }
+      if [ "$current_state" != "$desired_state" ]; then
+        echo "[ERROR] Branch protection changed before first-repository creation for ${slug}" >&2
+        return 1
+      fi
+      ;;
+    44)
+      assert_source_current
+      protection_payload="$work/first-repo-protection-${name}.json"
+      printf '%s\n' "$desired_protection" >"$protection_payload"
+      GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+        "repos/${slug}/branches/main/protection" --method PUT \
+        --input "$protection_payload" >/dev/null
+      created_protection=true
+      ;;
+    84) return 84 ;;
+    *) return 1 ;;
+    esac
+  fi
+  if [ "$created_protection" = true ]; then
     assert_source_current
-    protection_payload="$work/first-repo-protection-${name}.json"
-    printf '%s\n' "$desired_protection" >"$protection_payload"
-    GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
-      "repos/${slug}/branches/main/protection" --method PUT \
-      --input "$protection_payload" >/dev/null
   fi
   verified_protection=$(api_value_or_404 \
     "repos/${slug}/branches/main/protection" '.' "$REPO_SETTINGS_TOKEN") || return $?
@@ -1183,7 +1235,8 @@ echo "[OK] Downstream enforcement workflows are disabled with no active runs"
 
 bootstrap_one() {
   local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob
-  local actual_linked_blob rc branch_head branch_blob branch_lint_blob branch_linked_blob
+  local actual_linked_blob protection_state rc branch_head branch_blob branch_lint_blob
+  local branch_linked_blob
   local expected_change_count first_repo=false
   local branch manages_lint_caller=true lint_caller_exact=true
   local pr_number pr_url pr_body created_pr_number compare_file pr_file verified_head verified_blob
@@ -1262,6 +1315,13 @@ bootstrap_one() {
     [ "$lint_caller_exact" = true ] &&
     [ "$actual_linked_blob" = "$expected_linked_blob" ]; then
     return 0
+  fi
+  if [ "$first_repo" != true ]; then
+    protection_state=$(branch_protection_state "$slug") || return $?
+    if [ "$protection_state" = unprotected ]; then
+      echo "[ERROR] Unprotected main is not a pristine governed repository for ${slug}" >&2
+      return 1
+    fi
   fi
   expected_change_count=0
   [ "$actual_blob" = "$expected_blob" ] || expected_change_count=$((expected_change_count + 1))

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -178,7 +178,8 @@ case "$1 $endpoint" in
     printf '%s\n' "$BASE_SHA"
     ;;
   'api repos/f5-sales-demo/example/actions/workflows/enforce-repo-settings.yml')
-    if { [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] || [ "${FAKE_FIRST_REPO:-}" = 1 ]; } &&
+    if { [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] || [ "${FAKE_FIRST_REPO:-}" = 1 ] ||
+      [ "${FAKE_PROTECTED_EMPTY_CALLERS:-}" = 1 ]; } &&
       [ ! -f "$FAKE_STATE/merged" ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
       exit 1
@@ -434,7 +435,11 @@ case "$1 $endpoint" in
       exit 1
     fi
     ref=${endpoint##*ref=}
-    if { [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] || [ "${FAKE_FIRST_REPO:-}" = 1 ]; } &&
+    if [ "${FAKE_FIRST_REPO_PARTIAL:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ] &&
+      [ "$ref" != "$BRANCH_HEAD" ]; then
+      printf '%s\n' "$OLD_BLOB"
+    elif { [ "${FAKE_MISSING_WORKFLOW:-}" = 1 ] || [ "${FAKE_FIRST_REPO:-}" = 1 ] ||
+      [ "${FAKE_PROTECTED_EMPTY_CALLERS:-}" = 1 ]; } &&
       [ ! -f "$FAKE_STATE/merged" ] &&
       [ "$ref" != "$BRANCH_HEAD" ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
@@ -456,7 +461,9 @@ case "$1 $endpoint" in
       exit 65
     fi
     ref=${endpoint##*ref=}
-    if [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ] &&
+    if { [ "${FAKE_FIRST_REPO:-}" = 1 ] ||
+      [ "${FAKE_PROTECTED_EMPTY_CALLERS:-}" = 1 ]; } &&
+      [ ! -f "$FAKE_STATE/merged" ] &&
       [ "$ref" != "$BRANCH_HEAD" ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
       exit 1
@@ -475,7 +482,9 @@ case "$1 $endpoint" in
     ref=${endpoint##*ref=}
     if [ "${FAKE_BAD_RECOVER_LINKED:-}" = 1 ] && [ "$ref" = "$BRANCH_HEAD" ]; then
       printf '%s\n' "$OLD_BLOB"
-    elif [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/merged" ] &&
+    elif { [ "${FAKE_FIRST_REPO:-}" = 1 ] ||
+      [ "${FAKE_PROTECTED_EMPTY_CALLERS:-}" = 1 ]; } &&
+      [ ! -f "$FAKE_STATE/merged" ] &&
       [ "$ref" != "$BRANCH_HEAD" ]; then
       echo 'gh: Not Found (HTTP 404)' >&2
       exit 1
@@ -513,7 +522,7 @@ case "$1 $endpoint" in
     elif [ "${FAKE_FIRST_REPO:-}" = 1 ] && [ ! -f "$FAKE_STATE/protection-created" ]; then
       echo 'gh: Branch not protected (HTTP 404)' >&2
       exit 1
-    else
+    elif [ "${FAKE_FIRST_REPO:-}" = 1 ]; then
       jq -cn --slurpfile desired "$FAKE_STATE/transition-protection.json" '
         $desired[0] | {
           enforce_admins:{enabled:.enforce_admins},
@@ -528,6 +537,8 @@ case "$1 $endpoint" in
           lock_branch:{enabled:.lock_branch},
           allow_fork_syncing:{enabled:.allow_fork_syncing}
         }'
+    else
+      printf '%s\n' '{"enforce_admins":{"enabled":true},"required_status_checks":{"strict":true,"contexts":["Check linked issues","Example CI","lint / Lint Code Base"]},"required_pull_request_reviews":null,"restrictions":null,"required_linear_history":{"enabled":false},"allow_force_pushes":{"enabled":false},"allow_deletions":{"enabled":false},"block_creations":{"enabled":false},"required_conversation_resolution":{"enabled":false},"lock_branch":{"enabled":false},"allow_fork_syncing":{"enabled":false}}'
     fi
     ;;
   'api repos/f5-sales-demo/example')
@@ -837,6 +848,8 @@ run_bootstrap() {
     FAKE_LEGACY_LINKED_CHECK="${FAKE_LEGACY_LINKED_CHECK:-}" \
     FAKE_RECOVER_MERGED_TRANSITION="${FAKE_RECOVER_MERGED_TRANSITION:-}" \
     FAKE_FIRST_REPO="${FAKE_FIRST_REPO:-}" \
+    FAKE_FIRST_REPO_PARTIAL="${FAKE_FIRST_REPO_PARTIAL:-}" \
+    FAKE_PROTECTED_EMPTY_CALLERS="${FAKE_PROTECTED_EMPTY_CALLERS:-}" \
     FAKE_BAD_RECOVER_LINKED="${FAKE_BAD_RECOVER_LINKED:-}" \
     FAKE_FAIL_SECOND_BOOTSTRAP="${FAKE_FAIL_SECOND_BOOTSTRAP:-}" \
     REPO_SETTINGS_TOKEN=settings-token \
@@ -1610,6 +1623,48 @@ if [ "$rc" != 0 ] || [ ! -f "$state/legacy-canceled" ] ||
 fi
 echo "[OK] missing current workflow still inventories and cancels active legacy runs"
 
+state="$WORK/state-protected-empty-callers"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_PROTECTED_EMPTY_CALLERS=1
+set +e
+run_bootstrap "$state" >"$WORK/protected-empty-callers.out" \
+  2>"$WORK/protected-empty-callers.err"
+rc=$?
+set -e
+unset FAKE_PROTECTED_EMPTY_CALLERS
+if [ "$rc" = 0 ] ||
+  grep -qE 'repos/f5-sales-demo/example --method PATCH|branches/main/protection --method PUT|git/refs --method POST|contents/.* --method PUT|^pr (create|merge)' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] protected callerless repository entered the first-repository transition"
+  cat "$WORK/protected-empty-callers.err"
+  exit 1
+fi
+echo "[OK] existing protection cannot be replaced by the first-repository transition"
+
+state="$WORK/state-unprotected-partial-callers"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+FAKE_FIRST_REPO=1
+FAKE_FIRST_REPO_PARTIAL=1
+set +e
+run_bootstrap "$state" >"$WORK/unprotected-partial-callers.out" \
+  2>"$WORK/unprotected-partial-callers.err"
+rc=$?
+set -e
+unset FAKE_FIRST_REPO FAKE_FIRST_REPO_PARTIAL
+if [ "$rc" = 0 ] ||
+  grep -qE 'repos/f5-sales-demo/example --method PATCH|branches/main/protection --method PUT|git/refs --method POST|contents/.* --method PUT|^pr (create|merge)' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] unprotected partial caller set entered a bootstrap mutation"
+  cat "$WORK/unprotected-partial-callers.err"
+  exit 1
+fi
+echo "[OK] unprotected partial caller set fails before bootstrap mutation"
+
 state="$WORK/state-first-repo"
 mkdir -p "$state"
 : >"$WORK/gh.log"
@@ -1647,6 +1702,32 @@ if [ "$rc" != 0 ] || [ -z "$protection_line" ] || [ -z "$merge_line" ] ||
   exit 1
 fi
 echo "[OK] first governed repository installs three exact callers before restoring protection"
+
+state="$WORK/state-resume-first-repo-protection"
+mkdir -p "$state"
+touch "$state/protection-created"
+cp "$WORK/state-first-repo/transition-protection.json" \
+  "$state/transition-protection.json"
+: >"$WORK/gh.log"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_FIRST_REPO=1
+FAKE_MERGE_LANDS=1
+set +e
+run_bootstrap "$state" >"$WORK/resume-first-repo-protection.out" \
+  2>"$WORK/resume-first-repo-protection.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO FAKE_MERGE_LANDS
+if [ "$rc" != 0 ] ||
+  grep -q 'branches/main/protection --method PUT' "$WORK/gh.log" ||
+  ! grep -q '^pr merge ' "$WORK/gh.log" ||
+  ! grep -q 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log"; then
+  echo "[FAIL] exact first-repository protection receipt did not resume safely"
+  cat "$WORK/resume-first-repo-protection.err"
+  exit 1
+fi
+echo "[OK] exact first-repository protection receipt resumes without replacement"
 
 state="$WORK/state-recover-first-repo"
 mkdir -p "$state"


### PR DESCRIPTION
## Summary

- require a first-repository candidate to have either no branch protection or the exact previously-created transition protection
- reject an established protected repository with missing callers before any repository, protection, branch, or pull-request mutation
- reject an unprotected repository with a partial applicable caller set before bootstrap mutation
- re-prove absent protection after canonical merge settings settle, then verify the exact created protection
- preserve idempotent recovery from the exact transition protection receipt

## Verification

- bash tests/test-bootstrap-downstream-callers.sh — passed, including protected callerless rejection, unprotected partial-caller rejection, clean first onboarding, exact-transition resume, merged-transition recovery, and hostile receipt cases
- every other tests/test-*.sh script — passed
- bash tests/test-provision-governance-secrets.sh — passed after rebasing current main
- bash tests/test-governed-workflow-pins.sh — passed after rebasing current main
- bash tests/test-linter-configs.sh — 164 passed, 0 failed
- bash tests/test-dispatch-matrix.sh and bash tests/test-privileged-pr-workflows.sh — passed
- pre-commit run --all-files — passed
- staged and HEAD PII enforcement — clean
- bash scripts/agy-pre-push-review.sh — passed on exact head a7f64e0 with no critical or high finding

## Live acceptance evidence

- f5-sales-demo/xcsh-action PR #3 merged with lint / Lint Code Base and lint / Shell Unit Tests successful
- the canonical Check linked issues status on that exact bootstrap head is successful
- the latest observed downstream dispatch runs completed successfully

Closes #1197