### PR TITLE
fix: require authentic lint receipt before bootstrap merge

### DIFF
--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -8,6 +8,7 @@ owner="${repository%%/*}"
 source_sha="${SOURCE_SHA:-}"
 downstream_config="${DOWNSTREAM_CONFIG:-.github/config/downstream-repos.json}"
 rollout_config="${ROLLOUT_CONFIG:-.github/config/governance-rollout.json}"
+pin_config="${PIN_CONFIG:-.github/config/governed-workflow-pin.json}"
 repo_settings_config="${REPO_SETTINGS_CONFIG:-.github/config/repo-settings.json}"
 governance_config="${GOVERNANCE_CONFIG:-.claude/governance.json}"
 caller_path=".github/workflows/enforce-repo-settings.yml"
@@ -99,6 +100,12 @@ fi
 if ! rollout_state=$(jq -er '.state | select(. == "quiesced" or . == "active")' \
   "$rollout_config"); then
   echo "[ERROR] Governance rollout state is missing or invalid" >&2
+  exit 1
+fi
+if ! pin_revision=$(jq -er \
+  '.revision | select(type == "string" and test("^[0-9a-f]{40}$"))' \
+  "$pin_config"); then
+  echo "[ERROR] Governed workflow pin is missing or invalid" >&2
   exit 1
 fi
 if [ -z "${REPO_SETTINGS_TOKEN:-}" ]; then
@@ -468,6 +475,135 @@ reconcile_first_repo_controls() {
     return 1
   fi
   echo "[OK] First-repository merge controls are exact for ${slug}"
+}
+
+first_repo_lint_checks_are_successful() {
+  local slug="$1" branch="$2" head="$3"
+  local response run_response required_count run_id rc
+  local run_prefix="https://github.com/${slug}/actions/runs/"
+  local reusable="${repository}/.github/workflows/super-linter.yml@${pin_revision}"
+  response=$(mktemp "$work/first-repo-lint-checks.XXXXXX")
+  set +e
+  gh api "repos/${slug}/commits/${head}/check-runs?filter=latest&per_page=100" \
+    >"$response"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$response"
+    return "$rc"
+  fi
+  if ! jq -e '
+    type == "object" and
+    (.total_count | type == "number" and . >= 0 and . == floor) and
+    (.check_runs | type == "array") and
+    all(.check_runs[];
+      (.id | type == "number" and . >= 1 and . == floor) and
+      (.name | type == "string") and (.head_sha | type == "string") and
+      (.status | type == "string") and
+      (.conclusion == null or (.conclusion | type == "string")) and
+      (.details_url | type == "string") and
+      (.app.id | type == "number" and . >= 1 and . == floor) and
+      (.app.slug | type == "string"))
+  ' "$response" >/dev/null; then
+    echo "[ERROR] First-repository lint check response is malformed for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  required_count=$(jq -r '
+    [.check_runs[] |
+      select(.name == "lint / Lint Code Base" or
+        .name == "lint / Shell Unit Tests")] | length
+  ' "$response")
+  if [ "$required_count" -lt 2 ]; then
+    rm -f "$response"
+    return 76
+  fi
+  if [ "$required_count" -ne 2 ] || ! jq -e '
+    [.check_runs[] |
+      select(.name == "lint / Lint Code Base" or
+        .name == "lint / Shell Unit Tests") | .name] | sort ==
+    ["lint / Lint Code Base", "lint / Shell Unit Tests"]
+  ' "$response" >/dev/null; then
+    echo "[ERROR] First-repository lint checks are ambiguous for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  if ! jq -e --arg head "$head" --arg run_prefix "$run_prefix" '
+    [.check_runs[] |
+      select(.name == "lint / Lint Code Base" or
+        .name == "lint / Shell Unit Tests")] as $required |
+    all($required[];
+      .head_sha == $head and .app.id == 15368 and
+      .app.slug == "github-actions" and
+      (.details_url | startswith($run_prefix)) and
+      (.details_url |
+        test("/actions/runs/[1-9][0-9]*/job/[1-9][0-9]*$")))
+  ' "$response" >/dev/null; then
+    echo "[ERROR] First-repository lint checks are not authentic exact-head receipts for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  if jq -e '
+    [.check_runs[] |
+      select(.name == "lint / Lint Code Base" or
+        .name == "lint / Shell Unit Tests")] |
+    any(.[]; .status != "completed")
+  ' "$response" >/dev/null; then
+    rm -f "$response"
+    return 76
+  fi
+  if ! jq -e '
+    [.check_runs[] |
+      select(.name == "lint / Lint Code Base" or
+        .name == "lint / Shell Unit Tests")] |
+    all(.[]; .conclusion == "success")
+  ' "$response" >/dev/null; then
+    echo "[ERROR] First-repository lint checks did not succeed for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  if ! run_id=$(jq -er '
+    [.check_runs[] |
+      select(.name == "lint / Lint Code Base" or
+        .name == "lint / Shell Unit Tests") |
+      .details_url |
+      capture("/actions/runs/(?<run>[1-9][0-9]*)/job/[1-9][0-9]*$").run] |
+    unique | if length == 1 then .[0] else error("multiple workflow runs") end
+  ' "$response"); then
+    echo "[ERROR] First-repository lint checks do not share one workflow run for ${slug}" >&2
+    rm -f "$response"
+    return 1
+  fi
+  rm -f "$response"
+
+  run_response=$(mktemp "$work/first-repo-lint-run.XXXXXX")
+  set +e
+  gh api "repos/${slug}/actions/runs/${run_id}" >"$run_response"
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$run_response"
+    return "$rc"
+  fi
+  if ! jq -e --arg run "$run_id" --arg head "$head" --arg branch "$branch" \
+    --arg slug "$slug" --arg reusable "$reusable" --arg revision "$pin_revision" '
+    type == "object" and (.id | tostring) == $run and
+    .name == "Super-Linter" and .path == ".github/workflows/super-linter.yml" and
+    .event == "pull_request" and .head_branch == $branch and .head_sha == $head and
+    .head_commit.id == $head and
+    (.head_repository.id | type == "number" and . >= 1 and . == floor) and
+    .head_repository.id == .repository.id and
+    .head_repository.full_name == $slug and .repository.full_name == $slug and
+    .status == "completed" and .conclusion == "success" and
+    (.referenced_workflows | type == "array" and length == 1) and
+    .referenced_workflows[0].path == $reusable and
+    .referenced_workflows[0].sha == $revision
+  ' "$run_response" >/dev/null; then
+    echo "[ERROR] First-repository lint workflow run is not an exact trusted receipt for ${slug}" >&2
+    rm -f "$run_response"
+    return 1
+  fi
+  rm -f "$run_response"
 }
 
 reconcile_required_checks_to() {
@@ -1676,6 +1812,38 @@ bootstrap_one() {
     return 1
   fi
   if [ "$first_repo" = true ]; then
+    if [ "$manages_lint_caller" = true ]; then
+      if first_repo_lint_checks_are_successful "$slug" "$branch" "$verified_head"; then
+        rc=0
+      else
+        rc=$?
+      fi
+      if [ "$rc" -eq 76 ]; then
+        echo "[DEFER] Waiting for authentic Super-Linter checks on ${name} PR #${pr_number}"
+        return 76
+      fi
+      [ "$rc" -eq 0 ] || return "$rc"
+    fi
+
+    assert_source_current
+    current_base_sha=$(gh api \
+      "repos/${slug}/git/ref/heads/${default_branch}" --jq '.object.sha')
+    if [ "$current_base_sha" != "$base_sha" ]; then
+      echo "[ERROR] First-repository protected main changed before merge for ${name}" >&2
+      return 1
+    fi
+    reconcile_bootstrap_prs "$slug" "$branch"
+    if [ "$bootstrap_pr_number" != "$pr_number" ] ||
+      [ "$bootstrap_pr_head_oid" != "$verified_head" ]; then
+      echo "[ERROR] First-repository exact-caller PR owner changed before merge for ${name}" >&2
+      return 1
+    fi
+    current_branch_head=$(gh api \
+      "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
+    if [ "$current_branch_head" != "$verified_head" ]; then
+      echo "[ERROR] First-repository exact-caller head changed before merge for ${name}" >&2
+      return 1
+    fi
     jq -n --argjson pr "$pr_number" --arg head "$verified_head" \
       '{pull_request: $pr, head: $head}' >"$work/linked-transition-${name}.json"
   elif [ "$actual_linked_blob" != "$expected_linked_blob" ]; then

--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -478,7 +478,7 @@ reconcile_first_repo_controls() {
 }
 
 first_repo_lint_checks_are_successful() {
-  local slug="$1" branch="$2" head="$3"
+  local slug="$1" pr_number="$2" branch="$3" head="$4" base="$5"
   local response run_response required_count run_id rc
   local run_prefix="https://github.com/${slug}/actions/runs/"
   local reusable="${repository}/.github/workflows/super-linter.yml@${pin_revision}"
@@ -585,7 +585,8 @@ first_repo_lint_checks_are_successful() {
     rm -f "$run_response"
     return "$rc"
   fi
-  if ! jq -e --arg run "$run_id" --arg head "$head" --arg branch "$branch" \
+  if ! jq -e --arg run "$run_id" --argjson pr "$pr_number" \
+    --arg head "$head" --arg branch "$branch" --arg base "$base" \
     --arg slug "$slug" --arg reusable "$reusable" --arg revision "$pin_revision" '
     type == "object" and (.id | tostring) == $run and
     .name == "Super-Linter" and .path == ".github/workflows/super-linter.yml" and
@@ -595,6 +596,10 @@ first_repo_lint_checks_are_successful() {
     .head_repository.id == .repository.id and
     .head_repository.full_name == $slug and .repository.full_name == $slug and
     .status == "completed" and .conclusion == "success" and
+    (.pull_requests | type == "array") and
+    any(.pull_requests[];
+      .number == $pr and .head.sha == $head and .head.ref == $branch and
+      .base.ref == $base) and
     (.referenced_workflows | type == "array" and length == 1) and
     .referenced_workflows[0].path == $reusable and
     .referenced_workflows[0].sha == $revision
@@ -1447,6 +1452,10 @@ bootstrap_one() {
     { [ "$manages_lint_caller" = false ] || [ -z "$actual_lint_blob" ]; }; then
     first_repo=true
   fi
+  if [ "$first_repo" = true ] && [ "$manages_lint_caller" != true ]; then
+    echo "[ERROR] First governed repository ${name} must install the Super-Linter caller" >&2
+    return 1
+  fi
   if [ "$actual_blob" = "$expected_blob" ] &&
     [ "$lint_caller_exact" = true ] &&
     [ "$actual_linked_blob" = "$expected_linked_blob" ]; then
@@ -1812,18 +1821,17 @@ bootstrap_one() {
     return 1
   fi
   if [ "$first_repo" = true ]; then
-    if [ "$manages_lint_caller" = true ]; then
-      if first_repo_lint_checks_are_successful "$slug" "$branch" "$verified_head"; then
-        rc=0
-      else
-        rc=$?
-      fi
-      if [ "$rc" -eq 76 ]; then
-        echo "[DEFER] Waiting for authentic Super-Linter checks on ${name} PR #${pr_number}"
-        return 76
-      fi
-      [ "$rc" -eq 0 ] || return "$rc"
+    if first_repo_lint_checks_are_successful \
+      "$slug" "$pr_number" "$branch" "$verified_head" "$default_branch"; then
+      rc=0
+    else
+      rc=$?
     fi
+    if [ "$rc" -eq 76 ]; then
+      echo "[DEFER] Waiting for authentic Super-Linter checks on ${name} PR #${pr_number}"
+      return 76
+    fi
+    [ "$rc" -eq 0 ] || return "$rc"
 
     assert_source_current
     current_base_sha=$(gh api \

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -265,8 +265,53 @@ case "$1 $endpoint" in
       printf '{"strict":true,"contexts":["Check linked issues","Example CI","lint / Lint Code Base"]}\n'
     fi
     ;;
-  'api repos/f5-sales-demo/example/commits/'*'/check-runs')
-    if [ "${FAKE_LEGACY_LINKED_CHECK:-}" = 1 ]; then
+  'api repos/f5-sales-demo/example/commits/'*'/check-runs'*)
+    if [ "${FAKE_FIRST_REPO:-}" = 1 ]; then
+      if [ "${FAKE_FAST_FAIL:-}" = 1 ]; then
+        touch "$FAKE_STATE/advance-main"
+      fi
+      case "${FAKE_FIRST_REPO_LINT_MODE:-success}" in
+      absent)
+        printf '{"total_count":0,"check_runs":[]}\n'
+        ;;
+      malformed)
+        printf '{"total_count":2,"check_runs":"invalid"}\n'
+        ;;
+      *)
+        lint_status=completed
+        lint_conclusion=success
+        app_id=15368
+        app_slug=github-actions
+        case "${FAKE_FIRST_REPO_LINT_MODE:-success}" in
+        pending)
+          lint_status=in_progress
+          lint_conclusion=null
+          ;;
+        failed) lint_conclusion=failure ;;
+        spoofed)
+          app_id=99999
+          app_slug=untrusted-check-writer
+          ;;
+        success | wrong-run) ;;
+        *) exit 64 ;;
+        esac
+        jq -cn --arg sha "$BRANCH_HEAD" --arg status "$lint_status" \
+          --arg conclusion "$lint_conclusion" \
+          --argjson app_id "$app_id" --arg app_slug "$app_slug" '
+          {total_count:2,check_runs:[
+            {id:10001,name:"lint / Lint Code Base",head_sha:$sha,
+             status:$status,
+             conclusion:(if $conclusion == "null" then null else $conclusion end),
+             details_url:"https://github.com/f5-sales-demo/example/actions/runs/1001/job/10001",
+             app:{id:$app_id,slug:$app_slug},pull_requests:[]},
+            {id:10002,name:"lint / Shell Unit Tests",head_sha:$sha,
+             status:"completed",conclusion:"success",
+             details_url:"https://github.com/f5-sales-demo/example/actions/runs/1001/job/10002",
+             app:{id:$app_id,slug:$app_slug},pull_requests:[]}
+          ]}'
+        ;;
+      esac
+    elif [ "${FAKE_LEGACY_LINKED_CHECK:-}" = 1 ]; then
       jq -cn --arg sha "$BRANCH_HEAD" \
         '{check_runs:[{name:"check / Check linked issues",head_sha:$sha,status:"completed",conclusion:"success",details_url:"https://github.com/f5-sales-demo/example/actions/runs/999/job/1000",app:{id:15368,slug:"github-actions"}}]}'
     else
@@ -276,6 +321,24 @@ case "$1 $endpoint" in
   'api repos/f5-sales-demo/example/actions/runs/999')
     jq -cn --arg sha "$BRANCH_HEAD" \
       '{path:".github/workflows/require-linked-issue.yml",event:"pull_request_target",head_sha:$sha,status:"completed",conclusion:"success"}'
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/1001')
+    run_path=.github/workflows/super-linter.yml
+    if [ "${FAKE_FIRST_REPO_LINT_MODE:-success}" = wrong-run ]; then
+      run_path=.github/workflows/untrusted.yml
+    fi
+    jq -cn --arg sha "$BRANCH_HEAD" --arg branch "$EXPECTED_BRANCH" \
+      --arg path "$run_path" --arg revision "$PIN_SHA" \
+      --arg slug f5-sales-demo/example '
+      {id:1001,name:"Super-Linter",path:$path,event:"pull_request",head_sha:$sha,
+       head_branch:$branch,head_commit:{id:$sha},
+       head_repository:{id:123,full_name:$slug},
+       repository:{id:123,full_name:$slug},
+       status:"completed",conclusion:"success",
+       referenced_workflows:[{
+         path:("f5-sales-demo/docs-control/.github/workflows/super-linter.yml@" + $revision),
+         sha:$revision
+       }]}'
     ;;
   'api repos/f5-sales-demo/example/actions/workflows/require-linked-issue.yml/dispatches')
     input=""
@@ -850,11 +913,50 @@ run_bootstrap() {
     FAKE_FIRST_REPO="${FAKE_FIRST_REPO:-}" \
     FAKE_FIRST_REPO_PARTIAL="${FAKE_FIRST_REPO_PARTIAL:-}" \
     FAKE_PROTECTED_EMPTY_CALLERS="${FAKE_PROTECTED_EMPTY_CALLERS:-}" \
+    FAKE_FIRST_REPO_LINT_MODE="${FAKE_FIRST_REPO_LINT_MODE:-}" \
+    FAKE_FAST_FAIL="${FAKE_FAST_FAIL:-}" \
     FAKE_BAD_RECOVER_LINKED="${FAKE_BAD_RECOVER_LINKED:-}" \
     FAKE_FAIL_SECOND_BOOTSTRAP="${FAKE_FAIL_SECOND_BOOTSTRAP:-}" \
     REPO_SETTINGS_TOKEN=settings-token \
     "$SOURCE"
 }
+
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+for lint_mode in absent pending failed malformed spoofed wrong-run; do
+  state="$WORK/state-first-repo-${lint_mode}-lint"
+  mkdir -p "$state"
+  : >"$WORK/gh.log"
+  FAKE_FIRST_REPO=1
+  FAKE_FIRST_REPO_LINT_MODE="$lint_mode"
+  FAKE_FAST_FAIL=1
+  FAKE_MERGE_LANDS=1
+  set +e
+  run_bootstrap "$state" >"$WORK/first-repo-${lint_mode}-lint.out" \
+    2>"$WORK/first-repo-${lint_mode}-lint.err"
+  rc=$?
+  set -e
+  unset FAKE_FIRST_REPO FAKE_FIRST_REPO_LINT_MODE FAKE_FAST_FAIL FAKE_MERGE_LANDS
+  case "$lint_mode" in
+  absent | pending) expected_error='Waiting for authentic Super-Linter checks' ;;
+  failed) expected_error='First-repository lint checks did not succeed' ;;
+  malformed) expected_error='First-repository lint check response is malformed' ;;
+  spoofed) expected_error='First-repository lint checks are not authentic exact-head receipts' ;;
+  wrong-run) expected_error='First-repository lint workflow run is not an exact trusted receipt' ;;
+  esac
+  if [ "$rc" = 0 ] || grep -qE '^pr merge |require-linked-issue.yml/dispatches' \
+    "$WORK/gh.log" || ! grep -q "$expected_error" \
+    "$WORK/first-repo-${lint_mode}-lint.out" \
+    "$WORK/first-repo-${lint_mode}-lint.err"; then
+    echo "[FAIL] first-repository ${lint_mode} lint receipt did not fail closed"
+    cat "$WORK/first-repo-${lint_mode}-lint.err"
+    sed 's/^/  log: /' "$WORK/gh.log"
+    exit 1
+  fi
+done
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB
+echo "[OK] absent, pending, failed, malformed, spoofed, and untrusted first-repository lint receipts fail closed"
 
 state="$WORK/state-stale"
 mkdir -p "$state"
@@ -1672,23 +1774,30 @@ DOWNSTREAM_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
 FAKE_FIRST_REPO=1
+FAKE_FIRST_REPO_LINT_MODE=success
 FAKE_MERGE_LANDS=1
 set +e
 run_bootstrap "$state" >"$WORK/first-repo.out" 2>"$WORK/first-repo.err"
 rc=$?
 set -e
-unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO FAKE_MERGE_LANDS
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO \
+  FAKE_FIRST_REPO_LINT_MODE FAKE_MERGE_LANDS
 protection_line=$(grep -n 'branches/main/protection --method PUT' "$WORK/gh.log" |
   head -1 | cut -d: -f1 || true)
+check_line=$(grep -n '/check-runs' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
+run_line=$(grep -n 'actions/runs/1001' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
 merge_line=$(grep -n '^pr merge ' "$WORK/gh.log" | head -1 | cut -d: -f1 || true)
 dispatch_line=$(grep -n 'require-linked-issue.yml/dispatches --method POST' "$WORK/gh.log" |
   head -1 | cut -d: -f1 || true)
 final_context_line=$(grep -n 'required_status_checks --method PATCH' "$WORK/gh.log" |
   tail -1 | cut -d: -f1 || true)
-if [ "$rc" != 0 ] || [ -z "$protection_line" ] || [ -z "$merge_line" ] ||
+if [ "$rc" != 0 ] || [ -z "$protection_line" ] || [ -z "$check_line" ] ||
+  [ -z "$run_line" ] || [ -z "$merge_line" ] ||
   [ -z "$dispatch_line" ] || [ -z "$final_context_line" ] ||
-  [ "$protection_line" -ge "$merge_line" ] || [ "$merge_line" -ge "$dispatch_line" ] ||
+  [ "$protection_line" -ge "$check_line" ] || [ "$check_line" -ge "$run_line" ] ||
+  [ "$run_line" -ge "$merge_line" ] || [ "$merge_line" -ge "$dispatch_line" ] ||
   [ "$dispatch_line" -ge "$final_context_line" ] ||
+  ! grep -q -- "--match-head-commit $BRANCH_HEAD" "$WORK/gh.log" ||
   ! grep -q 'repos/f5-sales-demo/example --method PATCH' "$WORK/gh.log" ||
   [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 1 ] ||
   ! jq -e '.required_status_checks.contexts | index("Check linked issues") == null' \
@@ -1701,7 +1810,7 @@ if [ "$rc" != 0 ] || [ -z "$protection_line" ] || [ -z "$merge_line" ] ||
   sed 's/^/  log: /' "$WORK/gh.log"
   exit 1
 fi
-echo "[OK] first governed repository installs three exact callers before restoring protection"
+echo "[OK] first repository verifies authentic exact-head lint before merge and protection restoration"
 
 state="$WORK/state-resume-first-repo-protection"
 mkdir -p "$state"

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -292,7 +292,7 @@ case "$1 $endpoint" in
           app_id=99999
           app_slug=untrusted-check-writer
           ;;
-        success | wrong-run) ;;
+        success | wrong-pr | wrong-run) ;;
         *) exit 64 ;;
         esac
         jq -cn --arg sha "$BRANCH_HEAD" --arg status "$lint_status" \
@@ -324,17 +324,21 @@ case "$1 $endpoint" in
     ;;
   'api repos/f5-sales-demo/example/actions/runs/1001')
     run_path=.github/workflows/super-linter.yml
+    pr_number=42
     if [ "${FAKE_FIRST_REPO_LINT_MODE:-success}" = wrong-run ]; then
       run_path=.github/workflows/untrusted.yml
+    elif [ "${FAKE_FIRST_REPO_LINT_MODE:-success}" = wrong-pr ]; then
+      pr_number=43
     fi
     jq -cn --arg sha "$BRANCH_HEAD" --arg branch "$EXPECTED_BRANCH" \
       --arg path "$run_path" --arg revision "$PIN_SHA" \
-      --arg slug f5-sales-demo/example '
+      --arg slug f5-sales-demo/example --argjson pr "$pr_number" '
       {id:1001,name:"Super-Linter",path:$path,event:"pull_request",head_sha:$sha,
        head_branch:$branch,head_commit:{id:$sha},
        head_repository:{id:123,full_name:$slug},
        repository:{id:123,full_name:$slug},
        status:"completed",conclusion:"success",
+       pull_requests:[{number:$pr,head:{sha:$sha,ref:$branch},base:{ref:"main"}}],
        referenced_workflows:[{
          path:("f5-sales-demo/docs-control/.github/workflows/super-linter.yml@" + $revision),
          sha:$revision
@@ -924,7 +928,7 @@ run_bootstrap() {
 DOWNSTREAM_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
-for lint_mode in absent pending failed malformed spoofed wrong-run; do
+for lint_mode in absent pending failed malformed spoofed wrong-pr wrong-run; do
   state="$WORK/state-first-repo-${lint_mode}-lint"
   mkdir -p "$state"
   : >"$WORK/gh.log"
@@ -943,6 +947,7 @@ for lint_mode in absent pending failed malformed spoofed wrong-run; do
   failed) expected_error='First-repository lint checks did not succeed' ;;
   malformed) expected_error='First-repository lint check response is malformed' ;;
   spoofed) expected_error='First-repository lint checks are not authentic exact-head receipts' ;;
+  wrong-pr) expected_error='First-repository lint workflow run is not an exact trusted receipt' ;;
   wrong-run) expected_error='First-repository lint workflow run is not an exact trusted receipt' ;;
   esac
   if [ "$rc" = 0 ] || grep -qE '^pr merge |require-linked-issue.yml/dispatches' \
@@ -1766,6 +1771,31 @@ if [ "$rc" = 0 ] ||
   exit 1
 fi
 echo "[OK] unprotected partial caller set fails before bootstrap mutation"
+
+state="$WORK/state-first-repo-without-governed-lint"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
+FAKE_FIRST_REPO=1
+FAKE_SKIP_LINT_CALLER=1
+FAKE_FORBID_LINT_READ=1
+set +e
+TEST_GOVERNANCE_CONFIG="$WORK/governance-skip-lint.json" run_bootstrap "$state" \
+  >"$WORK/first-repo-without-governed-lint.out" \
+  2>"$WORK/first-repo-without-governed-lint.err"
+rc=$?
+set -e
+unset DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO FAKE_SKIP_LINT_CALLER \
+  FAKE_FORBID_LINT_READ TEST_GOVERNANCE_CONFIG
+if [ "$rc" = 0 ] ||
+  grep -qE 'repos/f5-sales-demo/example --method PATCH|branches/main/protection --method PUT|git/refs --method POST|contents/.* --method PUT|^pr (create|merge)' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] first repository without governed lint entered a bootstrap mutation"
+  cat "$WORK/first-repo-without-governed-lint.err"
+  exit 1
+fi
+echo "[OK] first repository without governed Super-Linter fails before mutation"
 
 state="$WORK/state-first-repo"
 mkdir -p "$state"


### PR DESCRIPTION
## Summary

Require an authentic successful Super-Linter receipt on the exact first-repository bootstrap PR head before the transitional merge path can run.

## Related Issue

Closes #1211

## Changes

- Validate exactly the governed lint / Lint Code Base and lint / Shell Unit Tests check runs.
- Bind both checks to the exact head, GitHub Actions app, workflow run, pull-request number, base branch, downstream repository, and immutable governed Super-Linter pin.
- Re-prove source, protected-main base, PR ownership, and branch head immediately before the existing head-bound auto-merge.
- Fail closed for absent, pending, failed, malformed, spoofed, wrong-PR, wrong-workflow, and unmanaged first-repository lint evidence.
- Preserve lint opt-outs for already-governed repositories while requiring the governed lint caller for a first repository.

## Verification evidence

- bash tests/test-bootstrap-downstream-callers.sh — passed, including exact PR/base and unmanaged first-repository regressions.
- all other tests/test-*.sh — passed.
- pre-commit run --all-files — all hooks passed.
- git diff --check origin/main...HEAD — passed.
- bash scripts/agy-pre-push-review.sh — PII head scope clean; both Antigravity passes approved da4b164 with no critical or high findings.

Required GitHub CI remains authoritative; auto-merge is enabled and gated on the required contexts.

## Checklist

- [x] Linked to a GitHub issue
- [x] Feature-complete and verified
- [x] Tests written first and passing
- [x] Verified locally with evidence above
- [ ] Required CI complete
- [x] Follows project conventions