### PR TITLE
fix: add Dependabot cooldown to managed configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -956,18 +956,18 @@ jobs:
               done
 
               # Build dependabot.yml content
-              DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
 
               if [ "$HAS_NPM" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      # First-party @${OWNER}/* packages: track latest daily, all update types\n      # (auto-merged once CI is green) so internal deps never drift behind.\n      f5-internal:\n        patterns:\n          - \"@${OWNER}/*\"\n        update-types:\n          - \"major\"\n          - \"minor\"\n          - \"patch\"\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      # First-party @${OWNER}/* packages: track latest daily, all update types\n      # (auto-merged once CI is green) so internal deps never drift behind.\n      f5-internal:\n        patterns:\n          - \"@${OWNER}/*\"\n        update-types:\n          - \"major\"\n          - \"minor\"\n          - \"patch\"\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
               fi
 
               if [ "$HAS_PIP" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+                DEPBOT="${DEPBOT}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
               fi
 
               if [ "$HAS_DOCKER" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+                DEPBOT="${DEPBOT}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
               fi
 
               DEPBOT="${DEPBOT}\n"

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -971,6 +971,62 @@ else
 fi
 
 echo ""
+echo "=== Section 9: generated Dependabot updates enforce cooldown ==="
+
+awk '
+  /# --- Dynamic dependabot.yml generation/ { found=1 }
+  found { sub(/^              /, ""); print }
+  found && /printf .%b. .*DEPBOT.*generated_dependabot.yml/ { exit }
+' "$SYNC" >"$WORK/dependabot-generator.sh"
+
+if [ -s "$WORK/dependabot-generator.sh" ]; then
+  pass "9.1 located the production Dependabot generator"
+else
+  fail "9.1 located the production Dependabot generator" \
+    "the workflow generator could not be extracted"
+fi
+
+DEPENDABOT_FIXTURE="$WORK/dependabot-fixture"
+mkdir -p "$DEPENDABOT_FIXTURE"
+touch "$DEPENDABOT_FIXTURE/package.json" \
+  "$DEPENDABOT_FIXTURE/requirements.txt" \
+  "$DEPENDABOT_FIXTURE/Dockerfile"
+
+if [ -s "$WORK/dependabot-generator.sh" ] &&
+  (cd "$DEPENDABOT_FIXTURE" && OWNER=f5-sales-demo bash "$WORK/dependabot-generator.sh") &&
+  python3 - /tmp/generated_dependabot.yml <<'PY'; then
+import sys
+
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as generated:
+    config = yaml.safe_load(generated)
+
+updates = config.get("updates", [])
+expected = {"github-actions", "npm", "pip", "docker"}
+actual = {update.get("package-ecosystem") for update in updates}
+assert actual == expected, (actual, expected)
+assert all(update.get("cooldown", {}).get("default-days") == 7 for update in updates)
+PY
+  pass "9.2 every generated ecosystem has a seven-day default cooldown"
+else
+  fail "9.2 every generated ecosystem has a seven-day default cooldown" \
+    "the generated YAML is incomplete or has an unsafe cooldown"
+fi
+
+if command -v zizmor >/dev/null 2>&1; then
+  cp /tmp/generated_dependabot.yml "$WORK/dependabot.yml"
+  if zizmor --no-config --no-ignores "$WORK/dependabot.yml" >/dev/null 2>&1; then
+    pass "9.3 generated Dependabot configuration passes Zizmor"
+  else
+    fail "9.3 generated Dependabot configuration passes Zizmor" \
+      "Zizmor reported a security finding"
+  fi
+else
+  echo "  SKIP: zizmor CLI not installed in this environment"
+fi
+
+echo ""
 echo "════════════════════════════════════════════"
 echo "  Results: $PASS passed, $FAIL failed ($TESTS_RUN total)"
 echo "════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Add the explicit seven-day Dependabot cooldown now required by Zizmor to the canonical configuration and every dynamically generated ecosystem entry.

## Related Issue

Closes #1222

## Changes

- set `cooldown.default-days: 7` for GitHub Actions, npm, pip, and Docker update entries
- exercise the production generator across all detected ecosystems
- verify the generated file with Zizmor using configuration and ignores disabled

## Verification evidence

- `bash tests/test-sync-managed-files.sh` — 72 passed, 0 failed
- `zizmor --no-config --no-ignores .github/dependabot.yml` — no findings
- `pre-commit run --all-files` — all applicable hooks passed
- `bash scripts/agy-pre-push-review.sh` — PII clean; Antigravity gate passed with no critical or high finding

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Regression coverage is present and passing
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions