### PR TITLE
fix: isolate Dependabot generator fixtures

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -488,6 +488,27 @@ jobs:
             '
           }
 
+          render_dependabot_config() {
+            local output_file="$1"
+            local depbot
+
+            depbot="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
+
+            if [ "$HAS_NPM" = true ]; then
+              depbot="${depbot}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      # First-party @${OWNER}/* packages: track latest daily, all update types\n      # (auto-merged once CI is green) so internal deps never drift behind.\n      f5-internal:\n        patterns:\n          - \"@${OWNER}/*\"\n        update-types:\n          - \"major\"\n          - \"minor\"\n          - \"patch\"\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
+            fi
+
+            if [ "$HAS_PIP" = true ]; then
+              depbot="${depbot}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
+            fi
+
+            if [ "$HAS_DOCKER" = true ]; then
+              depbot="${depbot}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
+            fi
+
+            printf '%b\n' "$depbot" >"$output_file"
+          }
+
           select_owned_stale_issues() {
             jq -r '
               if type != "array" or
@@ -955,24 +976,8 @@ jobs:
                 fi
               done
 
-              # Build dependabot.yml content
-              DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
-
-              if [ "$HAS_NPM" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"daily\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      # First-party @${OWNER}/* packages: track latest daily, all update types\n      # (auto-merged once CI is green) so internal deps never drift behind.\n      f5-internal:\n        patterns:\n          - \"@${OWNER}/*\"\n        update-types:\n          - \"major\"\n          - \"minor\"\n          - \"patch\"\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
-              fi
-
-              if [ "$HAS_PIP" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
-              fi
-
-              if [ "$HAS_DOCKER" = true ]; then
-                DEPBOT="${DEPBOT}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\"\n    cooldown:\n      default-days: 7"
-              fi
-
-              DEPBOT="${DEPBOT}\n"
               # Write generated dependabot.yml to temp file (preserves trailing newline)
-              printf '%b' "$DEPBOT" > /tmp/generated_dependabot.yml
+              render_dependabot_config /tmp/generated_dependabot.yml
 
               # Compare with current dependabot.yml in target repo (local disk,
               # no API call -- file was checked out by actions/checkout@v6).

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -971,30 +971,38 @@ else
 fi
 
 echo ""
-echo "=== Section 9: generated Dependabot updates enforce cooldown ==="
+echo "=== Section 9: generated Dependabot updates are worktree-isolated ==="
 
 awk '
-  /# --- Dynamic dependabot.yml generation/ { found=1 }
-  found { sub(/^              /, ""); print }
-  found && /printf .%b. .*DEPBOT.*generated_dependabot.yml/ { exit }
-' "$SYNC" >"$WORK/dependabot-generator.sh"
+  /^          render_dependabot_config\(\)/ { found=1 }
+  found {
+    line=$0
+    sub(/^          /, "")
+    print
+    if (line == "          }") exit
+  }
+' "$SYNC" >"$WORK/render-dependabot-config.sh"
 
-if [ -s "$WORK/dependabot-generator.sh" ]; then
-  pass "9.1 located the production Dependabot generator"
+if [ -s "$WORK/render-dependabot-config.sh" ]; then
+  pass "9.1 located the bounded production Dependabot renderer"
 else
-  fail "9.1 located the production Dependabot generator" \
-    "the workflow generator could not be extracted"
+  fail "9.1 located the bounded production Dependabot renderer" \
+    "the workflow renderer could not be extracted"
 fi
 
-DEPENDABOT_FIXTURE="$WORK/dependabot-fixture"
-mkdir -p "$DEPENDABOT_FIXTURE"
-touch "$DEPENDABOT_FIXTURE/package.json" \
-  "$DEPENDABOT_FIXTURE/requirements.txt" \
-  "$DEPENDABOT_FIXTURE/Dockerfile"
+GENERATED_DEPENDABOT="$WORK/dependabot.yml"
 
-if [ -s "$WORK/dependabot-generator.sh" ] &&
-  (cd "$DEPENDABOT_FIXTURE" && OWNER=f5-sales-demo bash "$WORK/dependabot-generator.sh") &&
-  python3 - /tmp/generated_dependabot.yml <<'PY'; then
+if [ -s "$WORK/render-dependabot-config.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$WORK/render-dependabot-config.sh"
+  OWNER=f5-sales-demo
+  HAS_NPM=true
+  HAS_PIP=true
+  HAS_DOCKER=true
+  render_dependabot_config "$GENERATED_DEPENDABOT"
+fi
+
+if [ -f "$GENERATED_DEPENDABOT" ] && python3 - "$GENERATED_DEPENDABOT" <<'PY'; then
 import sys
 
 import yaml
@@ -1015,8 +1023,7 @@ else
 fi
 
 if command -v zizmor >/dev/null 2>&1; then
-  cp /tmp/generated_dependabot.yml "$WORK/dependabot.yml"
-  if zizmor --no-config --no-ignores "$WORK/dependabot.yml" >/dev/null 2>&1; then
+  if zizmor --no-config --no-ignores "$GENERATED_DEPENDABOT" >/dev/null 2>&1; then
     pass "9.3 generated Dependabot configuration passes Zizmor"
   else
     fail "9.3 generated Dependabot configuration passes Zizmor" \
@@ -1024,6 +1031,14 @@ if command -v zizmor >/dev/null 2>&1; then
   fi
 else
   echo "  SKIP: zizmor CLI not installed in this environment"
+fi
+
+GLOBAL_DEPENDABOT_FIXTURE="/tmp/generated_"'dependabot.yml'
+if ! grep -Fq "$GLOBAL_DEPENDABOT_FIXTURE" "$0"; then
+  pass "9.4 concurrent tests never share a global generated fixture"
+else
+  fail "9.4 concurrent tests never share a global generated fixture" \
+    "the test still reads or writes ${GLOBAL_DEPENDABOT_FIXTURE}"
 fi
 
 echo ""


### PR DESCRIPTION
Closes #1223

## Summary

- extract the governed Dependabot renderer behind an explicit output-path interface
- keep production behavior unchanged while rendering tests into their private `mktemp` workspace
- preserve four-ecosystem cooldown parsing and current zizmor validation without a shared `/tmp/generated_dependabot.yml` race

## Verification evidence

- `bash tests/test-sync-managed-files.sh` — 73 passed, 0 failed
- complete `tests/test-*.sh` matrix — 33 test scripts passed
- `pre-commit run --all-files` — all applicable hooks passed
- `zizmor 1.29.0 --no-config --no-ignores <private fixture>` — no findings through the focused regression
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean
- `bash scripts/agy-pre-push-review.sh` — Antigravity gate passed with no critical or high finding

## Checklist

- [x] Linked to a detailed issue
- [x] Feature-complete and verified locally
- [x] Regression coverage exercises the production renderer
- [x] No compatibility path or deferred implementation added
- [x] Exact committed head reviewed by Antigravity before push