### PR TITLE
fix(governance): classify managed devcontainer tests

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -80,13 +80,15 @@
     "profiles": {
       "devcontainer": {
         "unit": [
+          { "path": "tests/test-agy-pre-push-review.sh", "args": [] },
           { "path": "tests/test-check-pii.sh", "args": [] },
           { "path": "tests/test-check-repo-hygiene.sh", "args": [] },
           { "path": "tests/test-fetch-governed.sh", "args": [] },
           { "path": "tests/test-hook-neutralization.sh", "args": ["--unit-only"] },
           { "path": "tests/test-inlined-helpers-match.sh", "args": [] },
           { "path": "tests/test-lint-mdx-prose.sh", "args": [] },
-          { "path": "tests/test-review-plugin-removal.sh", "args": [] }
+          { "path": "tests/test-review-plugin-removal.sh", "args": [] },
+          { "path": "tests/test-validate-translations.sh", "args": [] }
         ],
         "environment": [
           {

--- a/tests/test-consumer-shell-tests.sh
+++ b/tests/test-consumer-shell-tests.sh
@@ -183,13 +183,15 @@ assert_contains "malformed repository" "repository-name failure is explicit"
 if jq -e '
   .consumer_shell_tests.profiles.devcontainer as $p |
   ($p.unit | map(.path)) == [
+    "tests/test-agy-pre-push-review.sh",
     "tests/test-check-pii.sh",
     "tests/test-check-repo-hygiene.sh",
     "tests/test-fetch-governed.sh",
     "tests/test-hook-neutralization.sh",
     "tests/test-inlined-helpers-match.sh",
     "tests/test-lint-mdx-prose.sh",
-    "tests/test-review-plugin-removal.sh"
+    "tests/test-review-plugin-removal.sh",
+    "tests/test-validate-translations.sh"
   ] and
   ($p.unit[] | select(.path == "tests/test-hook-neutralization.sh") | .args) == ["--unit-only"] and
   ($p.environment | map(.path)) == [


### PR DESCRIPTION
Closes #1232

## Summary

- classify the newly governed Antigravity pre-push and translation-validator tests in the `devcontainer` unit profile
- update the canonical production-profile assertion so inventory drift remains fail-closed

## Verification

- `bash tests/test-consumer-shell-tests.sh` — 25 passed
- exact selector against devcontainer PR #1658 — both newly admitted suites passed; existing hook-neutralization test is GNU/Linux-specific locally (`stat -c`) and the prior CI run failed before execution at inventory validation
- `pre-commit run --files .github/config/repo-settings.json tests/test-consumer-shell-tests.sh` — passed
- `bash scripts/agy-pre-push-review.sh` — PII clean; Antigravity gate passed with no critical/high findings

## Rollout

After merge, rerun downstream enforcement so devcontainer receives a fresh managed PR/check run. No required context is bypassed.