### PR TITLE
fix(governance): exclude generated codespell paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -222,9 +222,10 @@ repos:
         types: [text]
         # codespell's own `skip` list only applies during its directory
         # traversal; when pre-commit passes explicit file paths it is bypassed.
-        # Filter translation docs and source catalogs here so their
-        # foreign-language words never reach codespell. See issues #579 and #934.
-        exclude: ^(docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations|research/benchmarks/uat-matrix/corpora/i18n\.yaml$)
+        # Filter generated artifacts, translation docs, and source catalogs
+        # here so generated identifiers and foreign-language words never reach
+        # codespell. See issues #579, #934, and #1234.
+        exclude: ^(dist/|build/|release/|vendor/|docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/|README\.(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)\.md$|src/i18n/.*translations|research/benchmarks/uat-matrix/corpora/i18n\.yaml$)
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -160,15 +160,15 @@ else
 fi
 
 # pre-commit passes explicit paths, bypassing .codespellrc's skip list. Its
-# hook-level regex must filter translated docs, root translated READMEs, and
-# translated source catalogs while leaving English docs and i18n
-# implementation code checked.
+# hook-level regex must filter generated artifacts, translated docs, root
+# translated READMEs, and translated source catalogs while leaving authored
+# English docs and i18n implementation code checked.
 CODESPELL_EXCLUDE=$(awk '
   /- id: codespell$/ { in_codespell = 1; next }
   in_codespell && /exclude:/ { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }
 ' "$REPO_ROOT/.pre-commit-config.yaml")
 
-for path in docs/fr/guide.md README.de.md README.zh-tw.md src/i18n/mega-menu-translations.ts research/benchmarks/uat-matrix/corpora/i18n.yaml; do
+for path in dist/index.js build/output.js release/bundle.js vendor/library.js docs/fr/guide.md README.de.md README.zh-tw.md src/i18n/mega-menu-translations.ts research/benchmarks/uat-matrix/corpora/i18n.yaml; do
   if [[ "$path" =~ $CODESPELL_EXCLUDE ]]; then
     pass "5.x codespell pre-commit excludes '$path'"
   else


### PR DESCRIPTION
## Summary

Align the managed local codespell hook with the generated-artifact exclusions already enforced by the reusable Super-Linter workflow.

## Related Issue

Closes #1234

## Changes

- Exclude `dist/`, `build/`, `release/`, and `vendor/` from explicit codespell hook paths.
- Add regression coverage for generated paths while retaining checks for authored English content.

## Verification evidence

- Red test: `bash tests/test-linter-configs.sh` reported all four generated paths as not excluded before the config change.
- Green test: `bash tests/test-linter-configs.sh` — `168 passed, 0 failed`.
- `pre-commit run codespell --all-files` — passed.
- `pre-commit run --all-files` — every hook passed.
- `bash scripts/agy-pre-push-review.sh` — Antigravity gate passed with no critical or high findings.
- [Required CI run](https://github.com/f5-sales-demo/docs-control/actions/runs/30974628315) — `Lint Code Base` and `Shell Unit Tests` passed.
- [Linked-issue run](https://github.com/f5-sales-demo/docs-control/actions/runs/30974828134) — passed for exact PR head `3752a67f3cc667fc9f16b76800834bcc29149a30`.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] CI watched to green (not just queued)
- [x] Follows project conventions