### PR TITLE
fix: make Antigravity review resilient

### DIFF
--- a/scripts/agy-review.sh
+++ b/scripts/agy-review.sh
@@ -120,7 +120,6 @@ if [ "$mode" = code ]; then
     bash scripts/check-pii.sh --scope head --mode enforce
   fi
   target_description="branch range ${base_sha}...${head_sha}"
-  target_instructions="Inspect git diff --find-renames ${base_sha}...${head_sha}, commit messages, and relevant source and tests."
 else
   document_path=$(cd "$(dirname "$document_file")" 2>/dev/null && pwd -P)/$(basename "$document_file") || {
     echo "[review] document not found: $document_file" >&2
@@ -148,6 +147,19 @@ cleanup() {
   rm -rf -- "$work"
 }
 trap cleanup EXIT
+
+if [ "$mode" = code ]; then
+  review_target="$work/code-review-target.txt"
+  {
+    printf 'Review target: committed branch range %s...%s\n\n' "$base_sha" "$head_sha"
+    printf '%s\n' 'Commit metadata (hash and message only):'
+    git log --format='commit %H%n%B' "${base_sha}..${head_sha}"
+    printf '\n%s\n' 'Committed diff:'
+    git --no-pager diff --no-color --find-renames "${base_sha}...${head_sha}"
+  } >"$review_target"
+  relative_review_target=${review_target#"$repo_root"/}
+  target_instructions="Read $relative_review_target completely. It contains the exact committed diff and commit metadata for the review target. Use read-only file inspection for any relevant source and tests. Do not run terminal commands or reconstruct the target with git."
+fi
 
 invoke_agy() {
   local prompt_file=$1 stream_file=$2 result_file=$3

--- a/tests/test-agy-pre-push-review.sh
+++ b/tests/test-agy-pre-push-review.sh
@@ -47,6 +47,13 @@ printf '%s\n' "$count" >"$FAKE_AGY_COUNT"
     "${AGY_REVIEW_ACTIVE:-}" "${AGY_PRE_PUSH_REVIEW_ACTIVE:-}" \
     "${GATEWAY_TOKEN:-}" "${GITHUB_TOKEN:-}"
 } >>"$FAKE_AGY_CALLS"
+if [ -n "${FAKE_AGY_BUNDLE_CAPTURE:-}" ]; then
+  for review_bundle in "$PWD"/.agy-review.*/code-review-target.txt; do
+    if [ -f "$review_bundle" ]; then
+      cp "$review_bundle" "$FAKE_AGY_BUNDLE_CAPTURE"
+    fi
+  done
+fi
 if [ "${FAKE_AGY_MALFORMED_CALL:-0}" -eq "$count" ]; then
   printf 'not-json\n'
 elif [ "${FAKE_AGY_BLOCK_CALL:-0}" -eq "$count" ]; then
@@ -72,7 +79,8 @@ run_review() {
 
 echo "Antigravity local review tests"
 setup_repo
-if run_review "$WORK/bin:$PATH" env GATEWAY_TOKEN=private GITHUB_TOKEN=private &&
+if run_review "$WORK/bin:$PATH" env GATEWAY_TOKEN=private GITHUB_TOKEN=private \
+  FAKE_AGY_BUNDLE_CAPTURE="$WORK/review-bundle" &&
   [ "$(cat "$WORK/count")" -eq 2 ] &&
   [ "$(grep -c -- '--sandbox' "$WORK/calls")" -eq 2 ] &&
   [ "$(grep -c -- 'Gemini 3.6 Flash (High)' "$WORK/calls")" -eq 2 ] &&
@@ -84,8 +92,13 @@ if run_review "$WORK/bin:$PATH" env GATEWAY_TOKEN=private GITHUB_TOKEN=private &
   grep -q 'Do not execute repository test' "$WORK/calls" &&
   grep -q 'consumer_shell_tests.profiles' "$WORK/calls" &&
   grep -q 'second independent Antigravity verifier' "$WORK/calls" &&
+  grep -q 'code-review-target.txt' "$WORK/calls" &&
+  grep -q 'Do not run terminal commands' "$WORK/calls" &&
+  ! grep -q 'Inspect git diff --find-renames' "$WORK/calls" &&
+  grep -q '^commit ' "$WORK/review-bundle" &&
+  grep -q '^+change$' "$WORK/review-bundle" &&
   grep -q 'gate passed' "$WORK/output"; then
-  pass "two schema-validated Flash passes run without inherited credentials"
+  pass "two schema-validated Flash passes review a precomputed bundle without inherited credentials"
 else
   fail "clean branch receives two independent Antigravity passes" "$(cat "$WORK/output")"
 fi


### PR DESCRIPTION
## Summary

- Precompute the exact committed review range and commit metadata inside the governed temporary review directory.
- Direct both Antigravity passes to use the immutable bundle and read-only source inspection without invoking the unstable sandbox command channel.
- Preserve sandboxing, credential stripping, schema validation, two-pass verification, PII enforcement, cleanup, and fail-closed behavior.

## Verification

- bash tests/test-agy-pre-push-review.sh — 7 passed
- shellcheck -e SC2317 scripts/agy-review.sh tests/test-agy-pre-push-review.sh — passed
- bash tests/test-review-layer-routing.sh — passed
- bash tests/test-agent-guidance.sh — passed
- bash tests/test-governed-script-source.sh — passed
- bash tests/test-sync-managed-files.sh — passed
- Live repaired review of the xcsh #2970 branch — both independent passes approved
- PATH=/home/robin/.local/bin:$PATH bash scripts/agy-pre-push-review.sh — passed

Closes #1237
