### PR TITLE
fix(governance): require pull requests on main

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -36,7 +36,21 @@
         "contexts": ["Check linked issues", "lint / Lint Code Base", "lint / Shell Unit Tests"],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,

--- a/docs/ar/configuration.mdx
+++ b/docs/ar/configuration.mdx
@@ -4,7 +4,7 @@ description: مرجع التكوين المركزي repo-settings.json للإن�
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- يجب أن تكون الفروع محدثة قبل الدمج
 - `required_status_checks.contexts` -- أسماء الفحوصات التي يجب أن تجتازها المستودعات الفرعية (على سبيل المثال، `Check linked issues` و `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- أسماء الفحوصات التي يجب أن يجتازها docs-control نفسه (على سبيل المثال، `Check linked issues` و `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- لا يلزم الحصول على موافقة مراجعة PR
+- `required_pull_request_reviews` -- يتطلب دخول جميع التغييرات عبر طلب سحب (pull request) بينما
+  `required_approving_review_count: 0` يجعل الموافقة البشرية اختيارية؛ وتبقى قوائم الإلغاء والتجاوز
+  فارغة
 - `restrictions: null` -- لا توجد قيود دفع باستثناء حماية الفروع
 
 #### `contexts` مقابل `self_contexts`

--- a/docs/de/configuration.mdx
+++ b/docs/de/configuration.mdx
@@ -4,7 +4,7 @@ description: Zentrale repo-settings.json-Konfigurationsreferenz für Durchsetzun
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ Die zentrale Konfigurationsdatei steuert das gesamte Durchsetzungs-, Synchronisi
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ Hauptfelder:
 - `required_status_checks.strict: true` -- Branches müssen vor dem Zusammenführen auf dem neuesten Stand sein
 - `required_status_checks.contexts` -- die Namen der Prüfungen, die nachgelagerte Repositories bestehen müssen (z. B. `Check linked issues` und `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- die Namen der Prüfungen, die docs-control selbst bestehen muss (z. B. `Check linked issues` und `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- keine PR-Review-Genehmigung erforderlich
+- `required_pull_request_reviews` -- erfordert, dass alle Änderungen über einen Pull Request eingehen, während
+  `required_approving_review_count: 0` die menschliche Genehmigung optional hält; Verwerfungs- und Umgehungslisten
+  bleiben leer
 - `restrictions: null` -- keine Push-Einschränkungen über den Branch-Schutz hinaus
 
 #### `contexts` vs. `self_contexts`

--- a/docs/en/configuration.mdx
+++ b/docs/en/configuration.mdx
@@ -46,7 +46,21 @@ The central configuration file drives all enforcement, sync, and dispatch behavi
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -119,7 +133,9 @@ Key fields:
 - `required_status_checks.strict: true` -- branches must be up-to-date before merging
 - `required_status_checks.contexts` -- the check names downstream repositories must pass (for example, `Check linked issues` and `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- the check names docs-control itself must pass (for example, `Check linked issues` and `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- no PR review approval required
+- `required_pull_request_reviews` -- requires all changes to enter through a pull request while
+  `required_approving_review_count: 0` keeps human approval optional; dismissal and bypass lists
+  remain empty
 - `restrictions: null` -- no push restrictions beyond branch protection
 
 #### `contexts` vs `self_contexts`

--- a/docs/es/configuration.mdx
+++ b/docs/es/configuration.mdx
@@ -4,7 +4,7 @@ description: Referencia de configuración central repo-settings.json para la apl
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ El archivo de configuración central impulsa todo el comportamiento de aplicaci�
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ Campos clave:
 - `required_status_checks.strict: true` -- las ramas deben estar actualizadas antes de fusionarse
 - `required_status_checks.contexts` -- los nombres de las comprobaciones que deben pasar los repositorios descendentes (por ejemplo, `Check linked issues` y `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- los nombres de las comprobaciones que debe pasar el propio docs-control (por ejemplo, `Check linked issues` y `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- no se requiere aprobación de revisión de PR
+- `required_pull_request_reviews` -- requiere que todos los cambios ingresen a través de un pull request mientras que
+  `required_approving_review_count: 0` mantiene opcional la aprobación humana; las listas de desestimación y exención
+  permanecen vacías
 - `restrictions: null` -- sin restricciones de push más allá de la protección de ramas
 
 #### `contexts` frente a `self_contexts`

--- a/docs/fr/configuration.mdx
+++ b/docs/fr/configuration.mdx
@@ -4,7 +4,7 @@ description: Référence de configuration centrale repo-settings.json pour l'app
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ Le fichier de configuration central pilote tout le comportement d'application, d
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ Champs clés :
 - `required_status_checks.strict: true` -- les branches doivent être à jour avant la fusion
 - `required_status_checks.contexts` -- les noms de vérification que les dépôts en aval doivent valider (par exemple, `Check linked issues` et `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- les noms de vérification que docs-control lui-même doit valider (par exemple, `Check linked issues` et `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- aucune approbation de revue de PR n'est requise
+- `required_pull_request_reviews` -- exige que toutes les modifications passent par une pull request tandis que
+  `required_approving_review_count: 0` maintient l'approbation humaine optionnelle ; les listes de rejet et de contournement
+  restent vides
 - `restrictions: null` -- aucune restriction de push au-delà de la protection des branches
 
 #### `contexts` par rapport à `self_contexts`

--- a/docs/hi/configuration.mdx
+++ b/docs/hi/configuration.mdx
@@ -4,7 +4,7 @@ description: प्रवर्तन, सिंक, Antigravity AI स्वच
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- मर्ज करने से पहले शाखाओं का अद्यतन होना आवश्यक है
 - `required_status_checks.contexts` -- जाँच के नाम जिन्हें डाउनस्ट्रीम रिपॉजिटरी को पास करना होगा (उदाहरण के लिए, `Check linked issues` और `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- जाँच के नाम जिन्हें docs-control को स्वयं पास करना होगा (उदाहरण के लिए, `Check linked issues` और `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- कोई PR समीक्षा स्वीकृति आवश्यक नहीं है
+- `required_pull_request_reviews` -- सभी परिवर्तनों को एक Pull Request के माध्यम से प्रवेश करने की आवश्यकता है जबकि
+  `required_approving_review_count: 0` मानवीय स्वीकृति को वैकल्पिक रखता है; खारिज करने और बायपास करने की सूचियां
+  खाली रहती हैं
 - `restrictions: null` -- शाखा सुरक्षा से परे कोई पुश प्रतिबंध नहीं है
 
 #### `contexts` बनाम `self_contexts`

--- a/docs/it/configuration.mdx
+++ b/docs/it/configuration.mdx
@@ -4,7 +4,7 @@ description: Riferimento di configurazione centrale repo-settings.json per l'app
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ Il file di configurazione centrale guida tutto il comportamento di applicazione,
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ Campi chiave:
 - `required_status_checks.strict: true` -- i branch devono essere aggiornati prima dell'unione
 - `required_status_checks.contexts` -- i nomi dei controlli che i repository a valle devono superare (ad esempio, `Check linked issues` e `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- i nomi dei controlli che docs-control stesso deve superare (ad esempio, `Check linked issues` e `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- nessuna approvazione di revisione PR richiesta
+- `required_pull_request_reviews` -- richiede che tutte le modifiche entrino tramite una pull request mentre
+  `required_approving_review_count: 0` mantiene l'approvazione umana opzionale; le liste di licenziamento e bypass
+  rimangono vuote
 - `restrictions: null` -- nessuna restrizione di push oltre alla protezione del branch
 
 #### `contexts` rispetto a `self_contexts`

--- a/docs/ja/configuration.mdx
+++ b/docs/ja/configuration.mdx
@@ -4,7 +4,7 @@ description: 強制、同期、Antigravity AI 自動化、およびディスパ�
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- ブランチはマージ前に最新の状態である必要があります
 - `required_status_checks.contexts` -- ダウンストリームリポジトリが合格する必要があるチェック名（例: `Check linked issues` および `lint / Shell Unit Tests`）
 - `required_status_checks.self_contexts` -- docs-control 自体が合格する必要があるチェック名（例: `Check linked issues` および `Shell Unit Tests`）
-- `required_pull_request_reviews: null` -- PR レビューの承認は不要です
+- `required_pull_request_reviews` -- すべての変更がプルリクエスト経由で入力されることを要求しますが、
+  `required_approving_review_count: 0` により手動承認はオプションのままとなり、却下およびバイパスリストは
+  空のままです
 - `restrictions: null` -- ブランチ保護以外のプッシュ制限はありません
 
 #### `contexts` と `self_contexts`

--- a/docs/ko/configuration.mdx
+++ b/docs/ko/configuration.mdx
@@ -4,7 +4,7 @@ description: 강제 적용, 동기화, Antigravity AI 자동화 및 디스패치
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -103,7 +117,7 @@ i18n:
 
 - `delete_branch_on_merge: true` -- 병합된 PR 브랜치를 자동으로 정리합니다.
 - `allow_update_branch: true` -- PR에서 "Update branch" 버튼을 활성화합니다.
-- `homepage: ""` -- 런타임 시 `https://f5-sales-demo.github.io/{repo}/`로 자동 계산됩니다.
+- `homepage: ""` -- 런타임 시 `https://f5-sales-demo.github.io/{repo}/` 값으로 자동 계산됩니다.
 
 ### `actions_permissions`
 
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- 병합하기 전에 브랜치가 최신 상태여야 합니다.
 - `required_status_checks.contexts` -- 다운스트림 리포지토리가 통과해야 하는 검사 이름(예: `Check linked issues` 및 `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- docs-control 자체가 통과해야 하는 검사 이름(예: `Check linked issues` 및 `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- PR 검토 승인이 필요하지 않습니다.
+- `required_pull_request_reviews` -- 모든 변경 사항이 풀 리퀘스트를 통해 입력되도록 요구하지만,
+  `required_approving_review_count: 0`으로 인해 사람의 승인은 선택 사항으로 유지되며 해제 및 우회 목록은
+  비어 있습니다.
 - `restrictions: null` -- 브랜치 보호 이외의 푸시 제한이 없습니다.
 
 #### `contexts` 대 `self_contexts`

--- a/docs/pt-br/configuration.mdx
+++ b/docs/pt-br/configuration.mdx
@@ -4,7 +4,7 @@ description: Referência de configuração central do repo-settings.json para im
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ O arquivo de configuração central orienta todo o comportamento de imposição,
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ Campos principais:
 - `required_status_checks.strict: true` -- as ramificações devem estar atualizadas antes da mesclagem
 - `required_status_checks.contexts` -- os nomes das verificações que os repositórios downstream devem aprovar (por exemplo, `Check linked issues` e `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- os nomes das verificações que o próprio docs-control deve aprovar (por exemplo, `Check linked issues` e `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- nenhuma aprovação de revisão de PR é necessária
+- `required_pull_request_reviews` -- exige que todas as alterações entrem por meio de um pull request, enquanto
+  `required_approving_review_count: 0` mantém a aprovação humana opcional; as listas de dispensa e imune
+  permanecem vazias
 - `restrictions: null` -- sem restrições de envio além da proteção de ramificação
 
 #### `contexts` vs `self_contexts`

--- a/docs/th/configuration.mdx
+++ b/docs/th/configuration.mdx
@@ -4,7 +4,7 @@ description: เอกสารอ้างอิงการกำหนดค�
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- แบรนช์ต้องเป็นปัจจุบันก่อนที่จะรวม
 - `required_status_checks.contexts` -- ชื่อการตรวจสอบที่คลังเก็บบริวารต้องผ่าน (เช่น `Check linked issues` และ `lint / Shell Unit Tests`)
 - `required_status_checks.self_contexts` -- ชื่อการตรวจสอบที่ docs-control เองต้องผ่าน (เช่น `Check linked issues` และ `Shell Unit Tests`)
-- `required_pull_request_reviews: null` -- ไม่จำเป็นต้องได้รับการอนุมัติการรีวิว PR
+- `required_pull_request_reviews` -- กำหนดให้การเปลี่ยนแปลงทั้งหมดต้องเข้าผ่าน Pull Request ในขณะที่
+  `required_approving_review_count: 0` ทำให้การอนุมัติโดยมนุษย์เป็นตัวเลือกเพิ่มเติม รายการการยกเลิกและการข้าม
+  ยังคงว่างเปล่า
 - `restrictions: null` --ไม่มีข้อจำกัดในการพุชนอกเหนือจากการปกป้องแบรนช์
 
 #### `contexts` กับ `self_contexts`

--- a/docs/zh-cn/configuration.mdx
+++ b/docs/zh-cn/configuration.mdx
@@ -4,7 +4,7 @@ description: 中央 repo-settings.json 配置参考，用于强制执行、同�
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- 合并前分支必须是最新的
 - `required_status_checks.contexts` -- 下游仓库必须通过的检查名称（例如 `Check linked issues` 和 `lint / Shell Unit Tests`）
 - `required_status_checks.self_contexts` -- docs-control 本身必须通过的检查名称（例如 `Check linked issues` 和 `Shell Unit Tests`）
-- `required_pull_request_reviews: null` -- 不需要 PR 审查批准
+- `required_pull_request_reviews` -- 要求所有更改都必须通过 Pull Request 提交，同时
+  `required_approving_review_count: 0` 保持人工批准为可选；驳回和绕过列表
+  保持为空
 - `restrictions: null` -- 除分支保护外没有推送限制
 
 #### `contexts` 与 `self_contexts`

--- a/docs/zh-tw/configuration.mdx
+++ b/docs/zh-tw/configuration.mdx
@@ -4,7 +4,7 @@ description: 中央 repo-settings.json 設定參考，用於強制執行、同�
 sidebar:
   order: 3
 i18n:
-  sourceHash: "6604310303ba"
+  sourceHash: "c71bd436ec77"
   translator: "machine"
 ---
 
@@ -49,7 +49,21 @@ i18n:
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -122,7 +136,9 @@ i18n:
 - `required_status_checks.strict: true` -- 合併前分支必須是最新的
 - `required_status_checks.contexts` -- 下游儲存庫必須通過的檢查名稱（例如 `Check linked issues` 和 `lint / Shell Unit Tests`）
 - `required_status_checks.self_contexts` -- docs-control 本身必須通過的檢查名稱（例如 `Check linked issues` 和 `Shell Unit Tests`）
-- `required_pull_request_reviews: null` -- 不需要 PR 審查核准
+- `required_pull_request_reviews` -- 要求所有變更都必須透過 Pull Request 提交，同時
+  `required_approving_review_count: 0` 保持人工核準為選擇性；駁回和繞過清單
+  保持為空
 - `restrictions: null` -- 除分支保護外沒有推送限制
 
 #### `contexts` 與 `self_contexts`

--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -84,7 +84,14 @@ if ! jq -e '
   (.repository.delete_branch_on_merge == true) and
   ([.branch_protection[] | select(.branch == "main")][0] |
     (.enforce_admins | type == "boolean") and
-    (.required_pull_request_reviews == null) and
+    (.required_pull_request_reviews == {
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+      required_approving_review_count: 0,
+      require_last_push_approval: false,
+      dismissal_restrictions: {users: [], teams: []},
+      bypass_pull_request_allowances: {users: [], teams: [], apps: []}
+    }) and
     (.restrictions == null) and
     (.required_linear_history | type == "boolean") and
     (.allow_force_pushes | type == "boolean") and
@@ -337,41 +344,114 @@ first_transition_protection_for_repo() {
 }
 
 normalize_desired_bootstrap_protection() {
-  jq -ce '{
-    enforce_admins: .enforce_admins,
-    required_status_checks: {
-      strict: .required_status_checks.strict,
-      contexts: (.required_status_checks.contexts | unique | sort)
-    },
-    required_pull_request_reviews: .required_pull_request_reviews,
-    restrictions: .restrictions,
-    required_linear_history: .required_linear_history,
-    allow_force_pushes: .allow_force_pushes,
-    allow_deletions: .allow_deletions,
-    block_creations: .block_creations,
-    required_conversation_resolution: .required_conversation_resolution,
-    lock_branch: .lock_branch,
-    allow_fork_syncing: .allow_fork_syncing
-  }'
+  jq -ce '
+    def names($key):
+      map(if type == "string" then . else error("invalid " + $key) end) | sort;
+    {
+      enforce_admins: .enforce_admins,
+      required_status_checks:
+        (if .required_status_checks == null then null else {
+          strict: .required_status_checks.strict,
+          contexts: (.required_status_checks.contexts | names("contexts"))
+        } end),
+      required_pull_request_reviews:
+        (if .required_pull_request_reviews == null then null else {
+          dismiss_stale_reviews:
+            (.required_pull_request_reviews.dismiss_stale_reviews // false),
+          require_code_owner_reviews:
+            (.required_pull_request_reviews.require_code_owner_reviews // false),
+          required_approving_review_count:
+            (.required_pull_request_reviews.required_approving_review_count // 0),
+          require_last_push_approval:
+            (.required_pull_request_reviews.require_last_push_approval // false),
+          dismissal_restrictions: {
+            users: ((.required_pull_request_reviews.dismissal_restrictions.users // []) |
+              names("users")),
+            teams: ((.required_pull_request_reviews.dismissal_restrictions.teams // []) |
+              names("teams"))
+          },
+          bypass_pull_request_allowances: {
+            users: ((.required_pull_request_reviews.bypass_pull_request_allowances.users // []) |
+              names("users")),
+            teams: ((.required_pull_request_reviews.bypass_pull_request_allowances.teams // []) |
+              names("teams")),
+            apps: ((.required_pull_request_reviews.bypass_pull_request_allowances.apps // []) |
+              names("apps"))
+          }
+        } end),
+      restrictions:
+        (if .restrictions == null then null else {
+          users: ((.restrictions.users // []) | names("users")),
+          teams: ((.restrictions.teams // []) | names("teams")),
+          apps: ((.restrictions.apps // []) | names("apps"))
+        } end),
+      required_linear_history: .required_linear_history,
+      allow_force_pushes: .allow_force_pushes,
+      allow_deletions: .allow_deletions,
+      block_creations: .block_creations,
+      required_conversation_resolution: .required_conversation_resolution,
+      lock_branch: .lock_branch,
+      allow_fork_syncing: .allow_fork_syncing
+    }
+  '
 }
 
 normalize_current_bootstrap_protection() {
-  jq -ce '{
-    enforce_admins: .enforce_admins.enabled,
-    required_status_checks: {
-      strict: .required_status_checks.strict,
-      contexts: (.required_status_checks.contexts | unique | sort)
-    },
-    required_pull_request_reviews: .required_pull_request_reviews,
-    restrictions: .restrictions,
-    required_linear_history: .required_linear_history.enabled,
-    allow_force_pushes: .allow_force_pushes.enabled,
-    allow_deletions: .allow_deletions.enabled,
-    block_creations: .block_creations.enabled,
-    required_conversation_resolution: .required_conversation_resolution.enabled,
-    lock_branch: .lock_branch.enabled,
-    allow_fork_syncing: .allow_fork_syncing.enabled
-  }'
+  jq -ce '
+    def identities($key):
+      map(
+        if type == "string" then .
+        elif $key == "users" then .login
+        else .slug
+        end
+      ) | sort;
+    {
+      enforce_admins: .enforce_admins.enabled,
+      required_status_checks:
+        (if .required_status_checks == null then null else {
+          strict: .required_status_checks.strict,
+          contexts: (.required_status_checks.contexts | sort)
+        } end),
+      required_pull_request_reviews:
+        (if .required_pull_request_reviews == null then null else {
+          dismiss_stale_reviews:
+            (.required_pull_request_reviews.dismiss_stale_reviews // false),
+          require_code_owner_reviews:
+            (.required_pull_request_reviews.require_code_owner_reviews // false),
+          required_approving_review_count:
+            (.required_pull_request_reviews.required_approving_review_count // 0),
+          require_last_push_approval:
+            (.required_pull_request_reviews.require_last_push_approval // false),
+          dismissal_restrictions: {
+            users: ((.required_pull_request_reviews.dismissal_restrictions.users // []) |
+              identities("users")),
+            teams: ((.required_pull_request_reviews.dismissal_restrictions.teams // []) |
+              identities("teams"))
+          },
+          bypass_pull_request_allowances: {
+            users: ((.required_pull_request_reviews.bypass_pull_request_allowances.users // []) |
+              identities("users")),
+            teams: ((.required_pull_request_reviews.bypass_pull_request_allowances.teams // []) |
+              identities("teams")),
+            apps: ((.required_pull_request_reviews.bypass_pull_request_allowances.apps // []) |
+              identities("apps"))
+          }
+        } end),
+      restrictions:
+        (if .restrictions == null then null else {
+          users: ((.restrictions.users // []) | identities("users")),
+          teams: ((.restrictions.teams // []) | identities("teams")),
+          apps: ((.restrictions.apps // []) | identities("apps"))
+        } end),
+      required_linear_history: .required_linear_history.enabled,
+      allow_force_pushes: .allow_force_pushes.enabled,
+      allow_deletions: .allow_deletions.enabled,
+      block_creations: .block_creations.enabled,
+      required_conversation_resolution: .required_conversation_resolution.enabled,
+      lock_branch: .lock_branch.enabled,
+      allow_fork_syncing: .allow_fork_syncing.enabled
+    }
+  '
 }
 
 reconcile_first_repo_controls() {

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -51,7 +51,21 @@ cat >"$WORK/repo-settings.json" <<'EOF'
         ],
         "self_contexts": ["Check linked issues", "Lint Code Base", "Shell Unit Tests"]
       },
-      "required_pull_request_reviews": null,
+      "required_pull_request_reviews": {
+        "dismiss_stale_reviews": false,
+        "require_code_owner_reviews": false,
+        "required_approving_review_count": 0,
+        "require_last_push_approval": false,
+        "dismissal_restrictions": {
+          "users": [],
+          "teams": []
+        },
+        "bypass_pull_request_allowances": {
+          "users": [],
+          "teams": [],
+          "apps": []
+        }
+      },
       "restrictions": null,
       "required_linear_history": false,
       "allow_force_pushes": false,
@@ -581,7 +595,14 @@ case "$1 $endpoint" in
         .enforce_admins == true and
         .required_status_checks.strict == true and
         .required_status_checks.contexts == ["Example CI", "lint / Lint Code Base"] and
-        .required_pull_request_reviews == null and .restrictions == null and
+        .required_pull_request_reviews == {
+          dismiss_stale_reviews: false,
+          require_code_owner_reviews: false,
+          required_approving_review_count: 0,
+          require_last_push_approval: false,
+          dismissal_restrictions: {users: [], teams: []},
+          bypass_pull_request_allowances: {users: [], teams: [], apps: []}
+        } and .restrictions == null and
         .allow_force_pushes == false and .allow_deletions == false
       ' "$input" >/dev/null || exit 65
       cp "$input" "$FAKE_STATE/transition-protection.json"
@@ -594,7 +615,16 @@ case "$1 $endpoint" in
         $desired[0] | {
           enforce_admins:{enabled:.enforce_admins},
           required_status_checks:.required_status_checks,
-          required_pull_request_reviews:.required_pull_request_reviews,
+          required_pull_request_reviews:(.required_pull_request_reviews + {
+            url:"https://api.github.test/protection/required_pull_request_reviews",
+            dismissal_restrictions:(.required_pull_request_reviews.dismissal_restrictions + {
+              url:"https://api.github.test/protection/dismissal_restrictions"
+            }),
+            bypass_pull_request_allowances:
+              (.required_pull_request_reviews.bypass_pull_request_allowances + {
+                url:"https://api.github.test/protection/bypass_pull_request_allowances"
+              })
+          }),
           restrictions:.restrictions,
           required_linear_history:{enabled:.required_linear_history},
           allow_force_pushes:{enabled:.allow_force_pushes},
@@ -605,7 +635,7 @@ case "$1 $endpoint" in
           allow_fork_syncing:{enabled:.allow_fork_syncing}
         }'
     else
-      printf '%s\n' '{"enforce_admins":{"enabled":true},"required_status_checks":{"strict":true,"contexts":["Check linked issues","Example CI","lint / Lint Code Base"]},"required_pull_request_reviews":null,"restrictions":null,"required_linear_history":{"enabled":false},"allow_force_pushes":{"enabled":false},"allow_deletions":{"enabled":false},"block_creations":{"enabled":false},"required_conversation_resolution":{"enabled":false},"lock_branch":{"enabled":false},"allow_fork_syncing":{"enabled":false}}'
+      printf '%s\n' '{"enforce_admins":{"enabled":true},"required_status_checks":{"strict":true,"contexts":["Check linked issues","Example CI","lint / Lint Code Base"]},"required_pull_request_reviews":{"url":"https://api.github.test/protection/required_pull_request_reviews","dismiss_stale_reviews":false,"require_code_owner_reviews":false,"required_approving_review_count":0,"require_last_push_approval":false,"dismissal_restrictions":{"url":"https://api.github.test/protection/dismissal_restrictions","users":[],"teams":[]},"bypass_pull_request_allowances":{"url":"https://api.github.test/protection/bypass_pull_request_allowances","users":[],"teams":[],"apps":[]}},"restrictions":null,"required_linear_history":{"enabled":false},"allow_force_pushes":{"enabled":false},"allow_deletions":{"enabled":false},"block_creations":{"enabled":false},"required_conversation_resolution":{"enabled":false},"lock_branch":{"enabled":false},"allow_fork_syncing":{"enabled":false}}'
     fi
     ;;
   'api repos/f5-sales-demo/example')
@@ -1560,6 +1590,21 @@ if [ "$rc" = 0 ] || [ -s "$WORK/gh.log" ]; then
 fi
 echo "[OK] invalid required-check configuration is rejected before network access"
 
+jq '.branch_protection[0].required_pull_request_reviews = null' \
+  "$WORK/repo-settings.json" >"$WORK/repo-settings-null-pr-requirement.json"
+: >"$WORK/gh.log"
+set +e
+TEST_REPO_SETTINGS_CONFIG="$WORK/repo-settings-null-pr-requirement.json" \
+  run_bootstrap "$state" >/dev/null 2>&1
+rc=$?
+set -e
+unset TEST_REPO_SETTINGS_CONFIG
+if [ "$rc" = 0 ] || [ -s "$WORK/gh.log" ]; then
+  echo "[FAIL] null pull-request requirement was not rejected before network access"
+  exit 1
+fi
+echo "[OK] null pull-request requirement is rejected before network access"
+
 state="$WORK/state-internal-preflight-superseded"
 mkdir -p "$state"
 : >"$WORK/gh.log"
@@ -1866,7 +1911,7 @@ if [ "$rc" != 0 ] ||
   cat "$WORK/resume-first-repo-protection.err"
   exit 1
 fi
-echo "[OK] exact first-repository protection receipt resumes without replacement"
+echo "[OK] first-repository protection ignores response metadata and resumes without replacement"
 
 state="$WORK/state-recover-first-repo"
 mkdir -p "$state"

--- a/tests/test-governed-workflow-pins.sh
+++ b/tests/test-governed-workflow-pins.sh
@@ -94,6 +94,19 @@ check "protected main requires up-to-date status checks before delayed auto-merg
   jq -e '.branch_protection[] | select(.branch == "main") | .required_status_checks.strict == true' \
   "$REPO_ROOT/.github/config/repo-settings.json"
 
+check "protected main requires pull requests without a review bypass" \
+  jq -e '
+    .branch_protection[] | select(.branch == "main") |
+    .required_pull_request_reviews == {
+      dismiss_stale_reviews: false,
+      require_code_owner_reviews: false,
+      required_approving_review_count: 0,
+      require_last_push_approval: false,
+      dismissal_restrictions: {users: [], teams: []},
+      bypass_pull_request_allowances: {users: [], teams: [], apps: []}
+    }
+  ' "$REPO_ROOT/.github/config/repo-settings.json"
+
 check "roll-forward workflow invokes the updater for reusable implementation changes" \
   python3 - "$REPO_ROOT" "$UPDATER_WORKFLOW" <<'PY'
 from pathlib import Path


### PR DESCRIPTION
## Summary

Require every governed repository to merge through a pull request while keeping human approvals optional, and make first-repository bootstrap compare GitHub branch-protection responses without API-only metadata drift.

## Related Issue

Closes #1192

## Changes

- Replace the null review rule with a zero-approval pull-request requirement and empty bypass lists.
- Validate the exact bootstrap protection contract before any network access.
- Normalize desired and current review restrictions, identities, and response-only URL fields.
- Add red/green regression coverage for null protection and metadata-bearing GitHub responses.
- Update English configuration documentation and all 12 Antigravity-generated locale counterparts.
- Repair the pre-existing Korean protected-URL translation defect found by deterministic validation.

## Verification evidence

- `bash tests/test-bootstrap-downstream-callers.sh` — passed the full transition, rate-limit, recovery, and metadata matrix.
- All 33 `tests/test-*.sh` suites — passed on the current main base.
- `pre-commit run --all-files` — passed every configured hook.
- `bash scripts/validate-translations.sh --base origin/main --head HEAD` — passed all 12 locales.
- `bash scripts/check-pii.sh --scope head --mode enforce --format text` — clean.
- `bash scripts/agy-pre-push-review.sh` — exact head `7f993f5205d649d64397de744e794a0b6c05f723` passed with no critical or high finding.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (owned by required CI and auto-merge after publication)
- [x] Follows project conventions