### PR TITLE
fix(governance): classify XC configs for kubeconform

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: "2021"
+      classify_xc_minimum_configs:
+        description: Classify the provider's F5 XC minimum configs as non-Kubernetes YAML
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -328,6 +333,11 @@ jobs:
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false
           LINTER_RULES_PATH: "."
+          # F5 XC API objects also use top-level apiVersion and kind fields.
+          # Super-Linter otherwise misclassifies their native YAML sources as
+          # Kubernetes. Limit this option to Kubeconform so YAML and security
+          # validators still inspect every minimum configuration.
+          KUBERNETES_KUBECONFORM_OPTIONS: ${{ inputs.classify_xc_minimum_configs && '-ignore-filename-pattern=(^|/)tools/minimum-configs/' || '' }}
           # tree-sitter-<grammar>/src/{parser,scanner}.c are either machine-
           # generated (parser.c from `tree-sitter generate`) or hand-written
           # to upstream tree-sitter conventions that do not match

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -435,6 +435,57 @@ for v in POWERSHELL HTML CPP DOCKERFILE_HADOLINT BASH_EXEC EDITORCONFIG PROTOBUF
   fi
 done
 
+if printf '%s' "$WORKFLOW_CALL_BLOCK" |
+  grep -qE '^[[:space:]]+classify_xc_minimum_configs:' &&
+  printf '%s' "$WORKFLOW_CALL_BLOCK" |
+  grep -A4 'classify_xc_minimum_configs:' |
+    grep -qE '^[[:space:]]+type:[[:space:]]+boolean$' &&
+  printf '%s' "$WORKFLOW_CALL_BLOCK" |
+  grep -A5 'classify_xc_minimum_configs:' |
+    grep -qE '^[[:space:]]+default:[[:space:]]+false$'; then
+  pass "5e.5 reusable workflow declares fail-closed XC YAML classification"
+else
+  fail "5e.5 reusable workflow declares fail-closed XC YAML classification" \
+    "the boolean input must default to false"
+fi
+
+KUBECONFORM_OPTIONS=$(grep -E \
+  '^[[:space:]]*KUBERNETES_KUBECONFORM_OPTIONS:' "$SL_YML" || true)
+if printf '%s' "$KUBECONFORM_OPTIONS" |
+  grep -Fq "inputs.classify_xc_minimum_configs && '-ignore-filename-pattern=(^|/)tools/minimum-configs/' || ''"; then
+  pass "5e.6 XC classification affects only Kubeconform's filename set"
+else
+  fail "5e.6 XC classification affects only Kubeconform's filename set" \
+    "the fixed minimum-config path must be routed through KUBERNETES_KUBECONFORM_OPTIONS"
+fi
+
+FILTER_REGEX=$(grep -E '^[[:space:]]*FILTER_REGEX_EXCLUDE:' "$SL_YML" | head -1)
+if ! printf '%s' "$FILTER_REGEX" | grep -Fq 'tools/minimum-configs'; then
+  pass "5e.7 XC minimum configs remain visible to non-Kubernetes validators"
+else
+  fail "5e.7 XC minimum configs remain visible to non-Kubernetes validators" \
+    "the global filter must not exclude the F5 XC YAML sources"
+fi
+
+if ! grep -qE \
+  '^[[:space:]]*VALIDATE_KUBERNETES_KUBECONFORM:[[:space:]]+false' "$SL_YML" &&
+  ! printf '%s' "$KUBECONFORM_OPTIONS" | grep -Fq 'ignore-missing-schemas'; then
+  pass "5e.8 Kubeconform remains fail-closed for Kubernetes manifests"
+else
+  fail "5e.8 Kubeconform remains fail-closed for Kubernetes manifests" \
+    "do not disable Kubeconform or allow missing Kubernetes schemas"
+fi
+
+MANAGED_LINT_CALLER="$REPO_ROOT/workflows/super-linter.yml"
+if grep -Fq \
+  "classify_xc_minimum_configs: \${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}" \
+  "$MANAGED_LINT_CALLER"; then
+  pass "5e.9 managed caller enables classification only for the provider"
+else
+  fail "5e.9 managed caller enables classification only for the provider" \
+    "the exact repository predicate must supply the reusable-workflow input"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5f: the repo-hygiene gate never executes PR-head code.
 #             The Lint Code Base job holds

--- a/workflows/super-linter.yml
+++ b/workflows/super-linter.yml
@@ -17,6 +17,8 @@ jobs:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@41ef88197c4b7834eb294c798744828c89b90ce5
+    with:
+      classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
     permissions:
       contents: read # checkout repository content in the reusable workflow
       packages: read # pull lint tooling from GitHub Packages


### PR DESCRIPTION
## Summary

Corrects Super-Linter's content-based misclassification of native F5 XC API YAML as Kubernetes manifests. The reusable workflow accepts a fail-closed boolean, and the managed caller activates the fixed Kubeconform filename pattern only for `f5-sales-demo/terraform-provider-xcsh`.

The path is not added to the global Super-Linter filter: YAML, gitleaks, zizmor, and every non-Kubernetes validator continue to inspect the minimum configurations. Kubeconform remains enabled and missing schemas remain fatal for actual Kubernetes manifests.

## Related issue

Closes #1247

Refs f5-sales-demo/terraform-provider-xcsh#1547

## Verification

- `bash tests/test-linter-configs.sh` — 173 passed, 0 failed
- `bash tests/test-consumer-shell-tests.sh` — 25 passed, 0 failed
- `bash tests/test-lint-mdx-prose.sh` — passed
- `actionlint .github/workflows/super-linter.yml workflows/super-linter.yml` — passed
- `zizmor .github/workflows/super-linter.yml workflows/super-linter.yml` — no findings
- `pre-commit run --all-files` — passed
- committed-tree PII enforcement — clean
- `bash scripts/agy-pre-push-review.sh` — no critical or high findings

## Safety properties

- No global file exclusion
- No validator disable
- No `ignore-missing-schemas`
- No caller-controlled regex
- Provider-only activation through an exact repository predicate