### PR TITLE
fix(automation): verify Antigravity CI behavior

### DIFF
--- a/.github/workflows/antigravity-fleet-watcher.yml
+++ b/.github/workflows/antigravity-fleet-watcher.yml
@@ -1,6 +1,6 @@
 ---
 # GitHub Free-compatible fleet watcher. It uses scheduled/manual Actions, ordinary
-# organization variables, artifacts, comments, and a GitHub App; no rulesets,
+# organization variables, existing governance PATs, artifacts, and comments; no rulesets,
 # merge queues, audit streams, or environment-required reviewers are involved.
 name: Antigravity Fleet Watcher
 
@@ -31,33 +31,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Scope GitHub App token to governed repositories
-        id: inventory
-        run: |
-          set -euo pipefail
-          repositories=$(jq -r '.[]' .github/config/downstream-repos.json | {
-            printf '%s\n' docs-control
-            cat
-          } | paste -sd, -)
-          echo "repositories=$repositories" >>"$GITHUB_OUTPUT"
-
-      - name: Mint fleet read token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.inventory.outputs.repositories }}
-          permission-actions: read
-          permission-contents: read
-          permission-issues: read
-          permission-pull-requests: read
-
       - name: Collect terminal heads and dispatch queue
         id: collect
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REVIEW_ENABLED: ${{ vars.ANTIGRAVITY_REVIEW_ENABLED }}
           TRANSLATIONS_ENABLED: ${{ vars.TRANSLATIONS_ENABLED }}
         run: |
@@ -334,29 +311,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Scope GitHub App token to governed repositories
-        id: inventory
-        run: |
-          set -euo pipefail
-          repositories=$(jq -r '.[]' .github/config/downstream-repos.json | {
-            printf '%s\n' docs-control
-            cat
-          } | paste -sd, -)
-          echo "repositories=$repositories" >>"$GITHUB_OUTPUT"
-
-      - name: Mint fleet publisher token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.inventory.outputs.repositories }}
-          permission-actions: write
-          permission-contents: read
-          permission-issues: write
-          permission-pull-requests: read
-
       - name: Download exact-head receipts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -376,7 +330,7 @@ jobs:
           INPUT_DIR: ${{ runner.temp }}/fleet-watch
           TRIAGE_RESULT: ${{ needs.triage.result }}
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
           script: |
             const fs = require('fs');
             const path = require('path');

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -88,6 +88,14 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
+          test -n "${ANTIGRAVITY_TOKEN:-}" || {
+            echo "[review] ANTIGRAVITY_TOKEN is required" >&2
+            exit 1
+          }
+          test -n "${GCP_PROJECT_ID:-}" || {
+            echo "[review] GCP_PROJECT_ID is required" >&2
+            exit 1
+          }
           mkdir "$RUNNER_TEMP/review-artifact"
           dbus-run-session -- bash -euo pipefail <<'INNER'
           eval "$(printf '' | gnome-keyring-daemon --unlock --daemonize)"
@@ -151,9 +159,11 @@ jobs:
       contents: read
       pull-requests: write # publish an exact-head review comment
     env:
+      AGY_VERSION: "1.1.10"
       BASE_SHA: ${{ inputs.expected_base_sha }}
       HEAD_SHA: ${{ inputs.expected_head_sha }}
       PR_NUMBER: ${{ inputs.pr_number }}
+      WORKFLOW_SHA: ${{ github.workflow_sha }}
 
     steps:
       - name: Download review receipt
@@ -168,12 +178,14 @@ jobs:
         run: |
           set -euo pipefail
           report="$RUNNER_TEMP/review-artifact/report.json"
-          jq -e --arg repository "$GITHUB_REPOSITORY" --arg base "$BASE_SHA" --arg head "$HEAD_SHA" '
+          jq -e --arg repository "$GITHUB_REPOSITORY" --arg base "$BASE_SHA" \
+            --arg head "$HEAD_SHA" --arg workflow "$WORKFLOW_SHA" --arg version "$AGY_VERSION" '
             .receipt.repository == $repository and
             .receipt.base_sha == $base and
             .receipt.head_sha == $head and
+            .receipt.workflow_sha == $workflow and
+            .receipt.agy_version == $version and
             .receipt.model == "Gemini 3.6 Flash (High)" and
-            (.receipt.agy_version | type == "string") and
             (.receipt.tool_status | type == "number") and
             (.reviewer.findings | type == "array") and
             (.verifier.findings | type == "array")

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -99,6 +99,14 @@ jobs:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
           set -euo pipefail
+          test -n "${ANTIGRAVITY_TOKEN:-}" || {
+            echo "[i18n] ANTIGRAVITY_TOKEN is required" >&2
+            exit 1
+          }
+          test -n "${GCP_PROJECT_ID:-}" || {
+            echo "[i18n] GCP_PROJECT_ID is required" >&2
+            exit 1
+          }
           dbus-run-session -- bash -euo pipefail <<'INNER'
           eval "$(printf '' | gnome-keyring-daemon --unlock --daemonize)"
           export SSH_AUTH_SOCK GNOME_KEYRING_CONTROL GNOME_KEYRING_PID
@@ -118,7 +126,8 @@ jobs:
             "Edit only corresponding Markdown or MDX files under the 12 locale directories." \
             "Do not run repository code, commit, push, contact GitHub, or read credentials." \
             "Preserve code, MDX structure, documentation-safe examples, and exact source hashes.")
-          agy --new-project --sandbox --mode accept-edits --disable-slash-commands \
+          env -u GH_TOKEN -u GITHUB_TOKEN -u GATEWAY_TOKEN -u GATEWAY_URL \
+            agy --new-project --sandbox --mode accept-edits --disable-slash-commands \
             --add-dir /opt/agy-translation-contract \
             --model "Gemini 3.6 Flash (High)" \
             --print-timeout 25m --print "$prompt"
@@ -141,14 +150,9 @@ jobs:
               echo "[i18n] out-of-scope path: $path" >&2
               exit 1
             }
+            git add -A -- "$path"
           done <"$RUNNER_TEMP/status.txt"
-          git add -A -- docs/fr docs/es docs/de docs/pt-br docs/ja docs/ko docs/zh-cn docs/zh-tw docs/ar docs/it docs/hi docs/th \
-            src/content/docs/fr src/content/docs/es src/content/docs/de src/content/docs/pt-br \
-            src/content/docs/ja src/content/docs/ko src/content/docs/zh-cn src/content/docs/zh-tw \
-            src/content/docs/ar src/content/docs/it src/content/docs/hi src/content/docs/th 2>/dev/null || true
-          while IFS= read -r entry; do
-            mode=${entry%% *}
-            path=${entry#*$'\t'}
+          while IFS=$'\t' read -r mode path; do
             [ "$mode" = "100644" ] || {
               echo "[i18n] prohibited file mode $mode for $path" >&2
               exit 1
@@ -187,9 +191,11 @@ jobs:
       contents: read
       pull-requests: read # verify the exact pull-request head before publication
     env:
+      AGY_VERSION: "1.1.10"
       BASE_SHA: ${{ inputs.expected_base_sha }}
       HEAD_SHA: ${{ inputs.expected_head_sha }}
       PR_NUMBER: ${{ inputs.pr_number }}
+      WORKFLOW_SHA: ${{ github.workflow_sha }}
 
     steps:
       - name: Checkout trusted validator
@@ -239,9 +245,11 @@ jobs:
           set -euo pipefail
           receipt="$RUNNER_TEMP/translation-artifact/receipt.json"
           patch="$RUNNER_TEMP/translation-artifact/translations.patch"
-          jq -e --arg repository "$GITHUB_REPOSITORY" --arg base "$BASE_SHA" --arg head "$HEAD_SHA" '
+          jq -e --arg repository "$GITHUB_REPOSITORY" --arg base "$BASE_SHA" \
+            --arg head "$HEAD_SHA" --arg workflow "$WORKFLOW_SHA" --arg version "$AGY_VERSION" '
             .repository == $repository and .base_sha == $base and .head_sha == $head and
             (.head_ref | type == "string" and length > 0) and
+            .workflow_sha == $workflow and .agy_version == $version and
             .model == "Gemini 3.6 Flash (High)"
           ' "$receipt" >/dev/null
           HEAD_REF=$(jq -r .head_ref "$receipt")

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -22,9 +22,7 @@ on:
         required: true
       GCP_PROJECT_ID:
         required: true
-      AUTOMATION_APP_ID:
-        required: true
-      AUTOMATION_APP_PRIVATE_KEY:
+      REPO_SYNC_TOKEN:
         required: true
 
 permissions: {}
@@ -213,17 +211,6 @@ jobs:
             .trusted-base/scripts/validate-translations.sh \
             /opt/agy-publication-validator/validate-translations.sh
 
-      - name: Mint narrow publication token
-        id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
-        with:
-          app-id: ${{ secrets.AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-contents: write
-          permission-pull-requests: read
-
       - name: Download translation patch
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -235,12 +222,12 @@ jobs:
         with:
           ref: ${{ inputs.expected_head_sha }}
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.REPO_SYNC_TOKEN }}
           persist-credentials: false
 
       - name: Validate, commit, and publish translations
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
         run: |
           set -euo pipefail
           receipt="$RUNNER_TEMP/translation-artifact/receipt.json"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Lifecycle: linked issue → branch → required local `agy` review → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The Antigravity CI reviewer and translation-freshness gate remain **suspended** — see CONTRIBUTING.md.
+- Lifecycle: linked issue → branch → required local `agy` review → PR → required CI (Lint Code Base, Shell Unit Tests, linked-issue check) → auto-merge when every check is green → remote branch auto-deleted. The advisory Antigravity CI reviewer and translator run behind organisation switches and are never required merge contexts — see CONTRIBUTING.md.
 
 ## Review routing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,26 +192,24 @@ work but do not review code, specs, plans, pull requests, or CI failures.
 | ----- | --------------- | --------- |
 | **Local document review** | A spec or implementation plan | Antigravity advisory gate |
 | **Local Antigravity review** | The committed branch diff before a PR push | Required workflow step |
-| **CI Antigravity review** | The exact pull-request head | Advisory after the controlled pilot |
+| **CI Antigravity review** | The exact pull-request head | Advisory automation |
 
 ### CI review
 
-The Gemini Antigravity reviewer remains disabled and fail-closed behind
-`ANTIGRAVITY_REVIEW_ENABLED` until docs-control#1016 is resolved.
-It is advisory and must not be added to required status contexts. Automated branches that bypass
-the linked-issue check are reserved for machine-generated work; the authoritative prefix list lives
-in `require-linked-issue.yml` and must never be used for human or agent work.
+The Gemini Antigravity reviewer is fail-closed behind the organisation variable
+`ANTIGRAVITY_REVIEW_ENABLED`. Its immutable runtime, exact-head and workflow receipts, separated
+model and publication credentials, and rejection paths are covered by executable security UAT.
+It is advisory and must not be added to required status contexts. Automated branches that bypass the
+linked-issue check are reserved for machine-generated work; the authoritative prefix list lives in
+`require-linked-issue.yml` and must never be used for human or agent work.
 
-#### Restoring Antigravity review
+#### Operating Antigravity review
 
-Keep the source gate in place. After docs-control#1016 is verified, create the organisation Actions
-variable `ANTIGRAVITY_REVIEW_ENABLED` with value `false`, remove any same-named repository variables,
-and keep the reusable and governed `workflow_dispatch` callers enabled. The scheduled/manual
-docs-control watcher dispatches only exact same-repository heads from trusted default-branch workflow
-definitions. Pilot with selected visibility and the literal value `true`; after a real pull request
-completes safely, expand visibility to every governed repository. Future toggles change only the
-organisation variable, never workflow state. The Antigravity CI review is advisory and must not be
-added to required status contexts.
+Keep the source gate in place, remove any same-named repository variables, and keep the reusable and
+governed `workflow_dispatch` callers enabled. The scheduled/manual docs-control watcher dispatches
+only exact same-repository heads from trusted default-branch workflow definitions. Future toggles
+change only the organisation variable, never workflow state. The Antigravity CI review is advisory
+and must not be added to required status contexts.
 
 ### Local review before a pull-request push
 
@@ -253,18 +251,19 @@ Local hooks validate translation structure and hashes but do not invoke a model.
 generation belongs to the governed Antigravity workflow so Claude and Codex never generate locale
 content and developer workstations do not duplicate automation work.
 
-GitHub Actions translation remains held until the security boundary in docs-control#1016 is fixed.
-Both the governed caller and reusable workflow fail closed unless the organisation variable
-`TRANSLATIONS_ENABLED` is the literal string `true`. The workflow files must remain enabled once the
-security fix lands; the organisation variable is the only runtime switch. Repository variables with
-the same name are forbidden because they override the organisation value.
+GitHub Actions translation is fail-closed unless the organisation variable `TRANSLATIONS_ENABLED`
+is the literal string `true`. Its immutable runtime, exact-head and workflow receipts, isolated model
+credentials, 12-locale validation, allowlisted patch, and guarded publication are covered by
+executable security UAT. The workflow files remain enabled; the organisation variable is the only
+runtime switch. Repository variables with the same name are forbidden because they override the
+organisation value.
 
 How the translation pipeline operates:
 
 | Part | Where | How it Works |
 | ---- | ----- | ------------ |
 | Local Translation | Pre-commit locale/hash validation | **Deterministic only.** Never invokes a model. |
-| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on a GitHub Actions runner | **Security hold.** After docs-control#1016, the organisation variable controls execution. |
+| Automated Translation | `.github/workflows/antigravity-translate.yml` — invokes `agy` on a GitHub Actions runner | The organisation variable controls execution. |
 | Freshness Audit | `.github/workflows/translation-audit.yml` — compares each translation's `i18n.sourceHash` against English source SHA-256 | **Advisory when enabled.** It shares the Actions switch but is not a required context. |
 | Required Context | `audit / Translation freshness` in branch protection | **Not required.** Requiring a check while its job can skip would deadlock pull requests. |
 
@@ -293,7 +292,8 @@ boundary; configure no reviewers, wait timer, or deployment rule on it.
 
 3. Set selected visibility for a pilot same-repository documentation pull request. Set each desired
    variable to `true`, then require a completed Antigravity review and 12 validated locale outputs.
-   If the pilot fails, set the relevant variable to `false` before cancelling in-flight runs.
+   Verify the exact pilot scope with `--visibility selected --selected-repo <repository>`. If the
+   pilot fails, set the relevant variable to `false` before cancelling in-flight runs.
 
 4. Expand visibility to all governed repositories after the pilot. Future suspension changes only
    the organisation variable value and cancels any already-running jobs; workflow states remain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,7 +221,9 @@ bash scripts/agy-review.sh document --kind plan --file path/to/plan.md
 ```
 
 The command runs independent reviewer and verifier sessions, validates structured output, and fails
-closed. Do not substitute Claude, Codex, a model-invocable review skill, or a PR-diff plugin.
+closed. Each phase emits an immediate start marker, a periodic stderr heartbeat, and a completion
+marker so automation can distinguish a live silent model call from a finished review. Do not
+substitute Claude, Codex, a model-invocable review skill, or a PR-diff plugin.
 
 Branch review is mandatory before every push that opens or updates a pull request:
 
@@ -274,9 +276,12 @@ variables. Unset, `false`, or any other value disables the corresponding automat
 literal string `true` enables it.
 
 The implementation uses GitHub Free features only: scheduled/manual Actions, ordinary organisation
-variables, GitHub App tokens, artifacts, pull-request comments, and classic branch protection. Do
-not add organisation rulesets, merge queues, audit-log streaming, or environment required reviewers.
-The `antigravity-automation` environment on the public docs-control repository is only a secret
+variables, the existing `REPO_SETTINGS_TOKEN` and `REPO_SYNC_TOKEN` governance PATs, artifacts,
+pull-request comments, and classic branch protection. It does not require a GitHub App. Keep
+`REPO_SETTINGS_TOKEN` limited to watcher collection/publication and `REPO_SYNC_TOKEN` limited to
+translation publication; Antigravity model jobs receive neither token. Do not add organisation
+rulesets, merge queues, audit-log streaming, or environment required reviewers. The
+`antigravity-automation` environment on the public docs-control repository is only a secret
 boundary; configure no reviewers, wait timer, or deployment rule on it.
 
 1. Verify docs-control#1016 in the live workflow bytes, not merely by issue state. The installer must

--- a/scripts/agy-review.sh
+++ b/scripts/agy-review.sh
@@ -98,6 +98,13 @@ done
   echo "[review] output schema is unavailable: $schema" >&2
   exit 1
 }
+heartbeat_seconds=${AGY_REVIEW_HEARTBEAT_SECONDS:-30}
+case "$heartbeat_seconds" in
+'' | 0 | *[!0-9]*)
+  echo "[review] AGY_REVIEW_HEARTBEAT_SECONDS must be a positive integer" >&2
+  exit 2
+  ;;
+esac
 
 target_description=""
 target_instructions=""
@@ -142,8 +149,18 @@ else
 fi
 
 work=$(mktemp -d "$repo_root/.agy-review.XXXXXX")
+agy_pid=""
+heartbeat_pid=""
 # shellcheck disable=SC2329 # invoked through the EXIT trap below
 cleanup() {
+  if [ -n "$heartbeat_pid" ]; then
+    kill "$heartbeat_pid" 2>/dev/null || true
+    wait "$heartbeat_pid" 2>/dev/null || true
+  fi
+  if [ -n "$agy_pid" ]; then
+    kill "$agy_pid" 2>/dev/null || true
+    wait "$agy_pid" 2>/dev/null || true
+  fi
   rm -rf -- "$work"
 }
 trap cleanup EXIT
@@ -162,16 +179,35 @@ if [ "$mode" = code ]; then
 fi
 
 invoke_agy() {
-  local prompt_file=$1 stream_file=$2 result_file=$3
-  if ! env -u GH_TOKEN -u GITHUB_TOKEN -u REPO_SETTINGS_TOKEN -u REPO_SYNC_TOKEN \
+  local phase=$1 prompt_file=$2 stream_file=$3 result_file=$4
+  local agy_status=0 started_at=$SECONDS
+  printf '[review] %s started; waiting for Antigravity (heartbeat every %ss)\n' \
+    "$phase" "$heartbeat_seconds" >&2
+  env -u GH_TOKEN -u GITHUB_TOKEN -u REPO_SETTINGS_TOKEN -u REPO_SYNC_TOKEN \
     -u GATEWAY_TOKEN -u GATEWAY_URL AGY_REVIEW_ACTIVE=1 \
     agy --new-project --sandbox --mode plan --disable-slash-commands \
     --model "Gemini 3.6 Flash (High)" \
     --output-format stream-json --json-schema "$schema" \
-    --print-timeout 25m --print "$(<"$prompt_file")" >"$stream_file"; then
+    --print-timeout 25m --print "$(<"$prompt_file")" >"$stream_file" &
+  agy_pid=$!
+  (
+    while sleep "$heartbeat_seconds"; do
+      kill -0 "$agy_pid" 2>/dev/null || exit 0
+      printf '[review] %s still running (%ss elapsed)\n' \
+        "$phase" "$((SECONDS - started_at))" >&2
+    done
+  ) &
+  heartbeat_pid=$!
+  wait "$agy_pid" || agy_status=$?
+  agy_pid=""
+  kill "$heartbeat_pid" 2>/dev/null || true
+  wait "$heartbeat_pid" 2>/dev/null || true
+  heartbeat_pid=""
+  if [ "$agy_status" -ne 0 ]; then
     echo "[review] Antigravity execution failed" >&2
     return 1
   fi
+  printf '[review] %s completed; validating structured output\n' "$phase" >&2
   if ! jq -s -e '
     [.[] | select(.event == "result")] as $results |
     if ($results | length) != 1 then error("expected one result event")
@@ -197,7 +233,7 @@ Paths in consumer_shell_tests.profiles are resolved under the named downstream r
 
 Review correctness, security, data loss, concurrency, rollback, maintainability, and privacy. Perform a dedicated semantic PII audit over changed inputs, schemas, fixtures, generated files, filenames, media metadata, logs, telemetry, errors, persistence, exports, and deletion. Never repeat a matched personal or infrastructure value; report only category, path, line, and redacted evidence. Classify confirmed PII and reproducible security/correctness defects as high or critical. Report only findings supported by repository evidence. Return only schema-valid JSON.
 EOF
-invoke_agy "$work/reviewer.prompt" "$work/reviewer.stream" "$work/reviewer.json"
+invoke_agy reviewer "$work/reviewer.prompt" "$work/reviewer.stream" "$work/reviewer.json"
 
 cat >"$work/verifier.prompt" <<EOF
 Act as a second independent Antigravity verifier for $target_description.
@@ -209,7 +245,7 @@ Do not execute repository test or lint suites, package builds, network commands,
 
 Paths in consumer_shell_tests.profiles are resolved under the named downstream repository checkout by scripts/run-consumer-shell-tests.sh, not under docs-control. Verify profile ownership and rollout evidence; local absence alone is not a defect.
 EOF
-invoke_agy "$work/verifier.prompt" "$work/verifier.stream" "$work/verifier.json"
+invoke_agy verifier "$work/verifier.prompt" "$work/verifier.stream" "$work/verifier.json"
 
 jq -n --slurpfile reviewer "$work/reviewer.json" --slurpfile verifier "$work/verifier.json" '{
   reviewer: $reviewer[0],

--- a/scripts/verify-antigravity-controls.sh
+++ b/scripts/verify-antigravity-controls.sh
@@ -8,6 +8,8 @@ repos_file="$repo_root/.github/config/downstream-repos.json"
 review_enabled=false
 translations_enabled=false
 workflow_state=held
+visibility=all
+selected_repos=()
 
 usage() {
   cat <<'EOF'
@@ -19,12 +21,15 @@ Options:
   --review-enabled <true|false>   Expected organization review switch (default: false)
   --translations-enabled <value> Expected organization translation switch (default: false)
   --workflow-state <held|active>  Held source or fully active topology (default: held)
+  --visibility <all|selected>     Expected organization-variable visibility (default: all)
+  --selected-repo <name>         Exact selected repository; repeat for multiple repositories
 EOF
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-  --org | --repos-file | --review-enabled | --translations-enabled | --workflow-state)
+  --org | --repos-file | --review-enabled | --translations-enabled | --workflow-state | \
+    --visibility | --selected-repo)
     [ "$#" -ge 2 ] || {
       echo "[ERROR] $1 requires a value" >&2
       exit 2
@@ -35,6 +40,8 @@ while [ "$#" -gt 0 ]; do
     --review-enabled) review_enabled="$2" ;;
     --translations-enabled) translations_enabled="$2" ;;
     --workflow-state) workflow_state="$2" ;;
+    --visibility) visibility="$2" ;;
+    --selected-repo) selected_repos+=("$2") ;;
     esac
     shift 2
     ;;
@@ -64,6 +71,18 @@ if [ "$workflow_state" != held ] && [ "$workflow_state" != active ]; then
   echo "[ERROR] --workflow-state must be held or active" >&2
   exit 2
 fi
+if [ "$visibility" != all ] && [ "$visibility" != selected ]; then
+  echo "[ERROR] --visibility must be all or selected" >&2
+  exit 2
+fi
+if [ "$visibility" = selected ] && [ "${#selected_repos[@]}" -eq 0 ]; then
+  echo "[ERROR] --visibility selected requires at least one --selected-repo" >&2
+  exit 2
+fi
+if [ "$visibility" = all ] && [ "${#selected_repos[@]}" -ne 0 ]; then
+  echo "[ERROR] --selected-repo requires --visibility selected" >&2
+  exit 2
+fi
 if ! command -v gh >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
   echo "[ERROR] gh and jq are required" >&2
   exit 1
@@ -75,6 +94,22 @@ if ! jq -e '
 ' "$repos_file" >/dev/null 2>&1; then
   echo "[ERROR] governed repository inventory must be a non-empty unique JSON array" >&2
   exit 1
+fi
+if [ "${#selected_repos[@]}" -ne 0 ]; then
+  for repo in "${selected_repos[@]}"; do
+    if ! printf '%s' "$repo" | grep -qE '^[A-Za-z0-9_.-]+$' ||
+      { [ "$repo" != docs-control ] &&
+        ! jq -e --arg repo "$repo" 'any(.[]; . == $repo)' "$repos_file" >/dev/null; }; then
+      echo "[ERROR] invalid selected governed repository: $repo" >&2
+      exit 2
+    fi
+  done
+  selected_unique=$(printf '%s\n' "${selected_repos[@]}" | LC_ALL=C sort -u)
+  if [ "$(printf '%s\n' "$selected_unique" | sed '/^$/d' | wc -l | tr -d ' ')" \
+    -ne "${#selected_repos[@]}" ]; then
+    echo "[ERROR] --selected-repo values must be unique" >&2
+    exit 2
+  fi
 fi
 
 work=$(mktemp -d)
@@ -117,17 +152,37 @@ read_api() {
 }
 
 verify_org_variable() {
-  local name="$1" expected="$2" payload=""
+  local name="$1" expected="$2" payload="" selection="" actual_selected expected_selected
   read_api payload "orgs/$org/actions/variables/$name"
-  if ! jq -e --arg name "$name" --arg expected "$expected" '
-    .name == $name and .value == $expected and .visibility == "all"
+  if ! jq -e --arg name "$name" --arg expected "$expected" --arg visibility "$visibility" '
+    .name == $name and .value == $expected and .visibility == $visibility
   ' <<<"$payload" >/dev/null; then
     actual=$(jq -r '[.value // "<missing>", .visibility // "<missing>"] | join(" visibility=")' \
       <<<"$payload" 2>/dev/null || echo '<malformed>')
-    echo "[ERROR] $name must equal $expected with visibility=all; found $actual" >&2
+    echo "[ERROR] $name must equal $expected with visibility=$visibility; found $actual" >&2
     exit 1
   fi
-  printf '[OK] organisation variable %s=%s visibility=all\n' "$name" "$expected"
+  if [ "$visibility" = selected ]; then
+    read_api selection "orgs/$org/actions/variables/$name/repositories?per_page=100" \
+      --paginate --slurp
+    if ! jq -e 'type == "array" and all(.[]; (.repositories // []) | type == "array")' \
+      <<<"$selection" >/dev/null; then
+      echo "[ERROR] malformed selected repositories for $name" >&2
+      exit 1
+    fi
+    actual_selected=$(jq -r '[.[] | .repositories[]?.name] | unique | sort | .[]' \
+      <<<"$selection")
+    expected_selected=$(printf '%s\n' "${selected_repos[@]}" | LC_ALL=C sort -u)
+    if [ "$actual_selected" != "$expected_selected" ]; then
+      echo "[ERROR] $name selected repositories differ from the expected pilot set" >&2
+      exit 1
+    fi
+    selected_list=$(printf '%s\n' "$expected_selected" | paste -sd, -)
+    printf '[OK] organisation variable %s=%s visibility=selected repositories=%s\n' \
+      "$name" "$expected" "$selected_list"
+  else
+    printf '[OK] organisation variable %s=%s visibility=all\n' "$name" "$expected"
+  fi
 }
 
 workflow_count=0

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -1,0 +1,909 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+if (!process.argv[2]) throw new Error('repository root is required');
+const root = path.resolve(process.argv[2]);
+
+const reviewWorkflow = path.join(root, '.github/workflows/antigravity-review.yml');
+const translationWorkflow = path.join(root, '.github/workflows/antigravity-translate.yml');
+const repositoryName = ['f5-sales-demo', 'example'].join('/');
+const temporaryDirectories = [];
+const require = createRequire(import.meta.url);
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+
+process.on('exit', () => {
+  for (const directory of temporaryDirectories) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function temporaryDirectory(prefix) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function extractStepBlock(workflowPath, stepName, key = 'run') {
+  const lines = fs.readFileSync(workflowPath, 'utf8').split('\n');
+  const step = lines.indexOf(`      - name: ${stepName}`);
+  if (step === -1) throw new Error(`step not found: ${stepName}`);
+  const end = lines.findIndex((line, index) => index > step && /^ {6}- name: /.test(line));
+  const stepLines = lines.slice(step, end === -1 ? undefined : end);
+  const marker = stepLines.findIndex((line) => line === `        ${key}: |` || line === `          ${key}: |`);
+  if (marker === -1) throw new Error(`${key} block not found for step: ${stepName}`);
+  const indentation = stepLines[marker].search(/\S/) + 2;
+  return stepLines
+    .slice(marker + 1)
+    .map((line) => (line.length >= indentation ? line.slice(indentation) : ''))
+    .join('\n');
+}
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, { mode: 0o755 });
+}
+
+function runShell(script, { cwd, env = {} }) {
+  const environment = { ...process.env };
+  for (const [name, value] of Object.entries(env)) {
+    if (value === null) delete environment[name];
+    else environment[name] = value;
+  }
+  return spawnSync('bash', ['-c', `set -euo pipefail\n${script}`], {
+    cwd,
+    encoding: 'utf8',
+    env: environment,
+  });
+}
+
+function run(command, args, { cwd, env = {} } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  assert.equal(result.status, 0, `${command} ${args.join(' ')} failed:\n${result.stdout}${result.stderr}`);
+  return result.stdout.trim();
+}
+
+function git(cwd, ...args) {
+  return run('git', args, { cwd });
+}
+
+function initializeGitRepository(directory) {
+  fs.mkdirSync(directory, { recursive: true });
+  git(directory, 'init', '-q');
+  git(directory, 'config', 'user.email', 'fixture@example.com');
+  git(directory, 'config', 'user.name', 'Fixture');
+}
+
+function sha256Prefix(file) {
+  return createHash('sha256').update(fs.readFileSync(file)).digest('hex').slice(0, 12);
+}
+
+function repositoryIdentity() {
+  return { ['full' + '_name']: repositoryName };
+}
+
+function writeFakeGh(bin, pull) {
+  const pullPath = path.join(bin, 'pull.json');
+  fs.writeFileSync(pullPath, `${JSON.stringify(pull)}\n`);
+  writeExecutable(path.join(bin, 'gh'), `#!/usr/bin/env bash\nset -euo pipefail\ncat ${JSON.stringify(pullPath)}\n`);
+}
+
+function validReviewReport({ base, head, workflow }) {
+  return {
+    receipt: {
+      repository: 'f5-sales-demo/example',
+      base_sha: base,
+      head_sha: head,
+      workflow_sha: workflow,
+      agy_version: '1.1.10',
+      model: 'Gemini 3.6 Flash (High)',
+      tool_status: 0,
+    },
+    reviewer: { verdict: 'pass', summary: 'clean', findings: [], next_steps: [] },
+    verifier: { verdict: 'pass', summary: 'verified', findings: [], next_steps: [] },
+  };
+}
+
+function runReviewReceiptValidation({ report, pull }) {
+  const work = temporaryDirectory('agy-review-receipt-');
+  const bin = path.join(work, 'bin');
+  const artifact = path.join(work, 'review-artifact');
+  fs.mkdirSync(bin);
+  fs.mkdirSync(artifact);
+  fs.writeFileSync(path.join(artifact, 'report.json'), `${JSON.stringify(report)}\n`);
+  writeFakeGh(bin, pull);
+  return runShell(extractStepBlock(reviewWorkflow, 'Validate receipt and exact current head'), {
+    cwd: work,
+    env: {
+      AGY_VERSION: '1.1.10',
+      BASE_SHA: pull.base.sha,
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      HEAD_SHA: pull.head.sha,
+      PATH: `${bin}:${process.env.PATH}`,
+      PR_NUMBER: '42',
+      RUNNER_TEMP: work,
+      WORKFLOW_SHA: 'workflow-current',
+    },
+  });
+}
+
+function runTranslationReceiptValidation({ receipt, pull }) {
+  const work = temporaryDirectory('agy-translation-receipt-');
+  const bin = path.join(work, 'bin');
+  const artifact = path.join(work, 'translation-artifact');
+  fs.mkdirSync(bin);
+  fs.mkdirSync(artifact);
+  fs.writeFileSync(path.join(artifact, 'receipt.json'), `${JSON.stringify(receipt)}\n`);
+  fs.writeFileSync(path.join(artifact, 'translations.patch'), '');
+  writeFakeGh(bin, pull);
+  return runShell(extractStepBlock(translationWorkflow, 'Validate, commit, and publish translations'), {
+    cwd: work,
+    env: {
+      AGY_VERSION: '1.1.10',
+      BASE_SHA: pull.base.sha,
+      GH_TOKEN: 'fixture-token',
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      HEAD_SHA: pull.head.sha,
+      PATH: `${bin}:${process.env.PATH}`,
+      PR_NUMBER: '42',
+      RUNNER_TEMP: work,
+      WORKFLOW_SHA: 'workflow-current',
+    },
+  });
+}
+
+function initializeExactHeadFixture() {
+  const work = temporaryDirectory('agy-exact-head-');
+  const repository = path.join(work, 'repository');
+  const remote = path.join(work, 'remote.git');
+  initializeGitRepository(repository);
+  run('git', ['init', '--bare', '-q', remote], { cwd: work });
+  fs.mkdirSync(path.join(repository, 'scripts'));
+  fs.mkdirSync(path.join(repository, '.agents/skills/i18n-translate'), { recursive: true });
+  fs.mkdirSync(path.join(repository, 'docs/en'), { recursive: true });
+  writeExecutable(path.join(repository, 'scripts/agy-review.sh'), '#!/usr/bin/env bash\necho trusted-review-tool\n');
+  fs.writeFileSync(path.join(repository, 'scripts/agy-review-output.schema.json'), '{}\n');
+  writeExecutable(
+    path.join(repository, 'scripts/validate-translations.sh'),
+    '#!/usr/bin/env bash\necho trusted-validator\n',
+  );
+  fs.writeFileSync(path.join(repository, '.agents/skills/i18n-translate/SKILL.md'), 'trusted translation contract\n');
+  fs.writeFileSync(path.join(repository, 'docs/en/page.mdx'), '---\ntitle: Page\n---\n\nBase.\n');
+  git(repository, 'add', '.');
+  git(repository, 'commit', '-qm', 'base');
+  const base = git(repository, 'rev-parse', 'HEAD');
+  git(repository, 'remote', 'add', 'origin', remote);
+  git(repository, 'push', '-q', 'origin', 'HEAD:refs/heads/main');
+
+  fs.writeFileSync(path.join(repository, 'scripts/agy-review.sh'), '#!/usr/bin/env bash\necho untrusted-head-tool\n');
+  fs.writeFileSync(
+    path.join(repository, 'scripts/validate-translations.sh'),
+    '#!/usr/bin/env bash\necho untrusted-head-validator\n',
+  );
+  fs.writeFileSync(path.join(repository, '.agents/skills/i18n-translate/SKILL.md'), 'untrusted head contract\n');
+  fs.appendFileSync(path.join(repository, 'docs/en/page.mdx'), '\nChanged English.\n');
+  git(repository, 'add', '.');
+  git(repository, 'commit', '-qm', 'head');
+  const head = git(repository, 'rev-parse', 'HEAD');
+  git(repository, 'push', '-q', 'origin', 'HEAD:refs/heads/feature/1246-uat');
+  git(repository, 'push', '-q', 'origin', 'HEAD:refs/pull/42/head');
+  git(repository, 'checkout', '-q', '--detach', base);
+  return {
+    base,
+    head,
+    repository,
+    pull: {
+      base: { ref: 'main', sha: base },
+      head: {
+        ref: 'feature/1246-uat',
+        repo: repositoryIdentity(),
+        sha: head,
+      },
+    },
+  };
+}
+
+function runReviewerPreparation(fixture, pull = fixture.pull) {
+  const runner = temporaryDirectory('agy-review-prepare-');
+  const bin = path.join(runner, 'bin');
+  fs.mkdirSync(bin);
+  writeFakeGh(bin, pull);
+  const result = runShell(extractStepBlock(reviewWorkflow, 'Fetch exact pull-request head as data'), {
+    cwd: fixture.repository,
+    env: {
+      BASE_SHA: fixture.base,
+      GH_TOKEN: 'read-only-fixture',
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      HEAD_SHA: fixture.head,
+      PATH: `${bin}:${process.env.PATH}`,
+      PR_NUMBER: '42',
+      RUNNER_TEMP: runner,
+    },
+  });
+  return { result, runner };
+}
+
+function testReviewerPreparation() {
+  const fixture = initializeExactHeadFixture();
+  const { result, runner } = runReviewerPreparation(fixture);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(git(fixture.repository, 'rev-parse', 'HEAD'), fixture.head);
+  assert.match(fs.readFileSync(path.join(runner, 'agy-review-tool/agy-review.sh'), 'utf8'), /trusted-review-tool/);
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(runner, 'agy-review-tool/agy-review.sh'), 'utf8'),
+    /untrusted-head-tool/,
+  );
+
+  const forkFixture = initializeExactHeadFixture();
+  const fork = structuredClone(forkFixture.pull);
+  fork.head.repo.full_name = 'outsider/fork';
+  assert.notEqual(runReviewerPreparation(forkFixture, fork).result.status, 0);
+
+  const staleFixture = initializeExactHeadFixture();
+  const stale = structuredClone(staleFixture.pull);
+  stale.head.sha = 'd'.repeat(40);
+  assert.notEqual(runReviewerPreparation(staleFixture, stale).result.status, 0);
+}
+
+function runTranslationPreparation(fixture, pull = fixture.pull) {
+  const runner = temporaryDirectory('agy-translation-prepare-');
+  const bin = path.join(runner, 'bin');
+  const installed = path.join(runner, 'installed');
+  fs.mkdirSync(bin);
+  fs.mkdirSync(installed);
+  writeFakeGh(bin, pull);
+  writeExecutable(
+    path.join(bin, 'sudo'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+test "$1" = install
+shift
+if [ "\${1:-}" = -d ]; then
+  exit 0
+fi
+previous=""
+for argument in "$@"; do
+  source_path=$previous
+  previous=$argument
+done
+cp "$source_path" "$FAKE_INSTALL_DIR/$(basename "$previous")"
+`,
+  );
+  const githubEnvironment = path.join(runner, 'github.env');
+  const result = runShell(extractStepBlock(translationWorkflow, 'Prepare exact pull-request snapshot'), {
+    cwd: fixture.repository,
+    env: {
+      BASE_SHA: fixture.base,
+      FAKE_INSTALL_DIR: installed,
+      GH_TOKEN: 'read-only-fixture',
+      GITHUB_ENV: githubEnvironment,
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      HEAD_SHA: fixture.head,
+      PATH: `${bin}:${process.env.PATH}`,
+      PR_NUMBER: '42',
+      RUNNER_TEMP: runner,
+    },
+  });
+  return { githubEnvironment, installed, result };
+}
+
+function testTranslationPreparation() {
+  const fixture = initializeExactHeadFixture();
+  const prepared = runTranslationPreparation(fixture);
+  assert.equal(prepared.result.status, 0, prepared.result.stderr);
+  assert.equal(git(fixture.repository, 'rev-parse', 'HEAD'), fixture.head);
+  assert.match(fs.readFileSync(path.join(prepared.installed, 'SKILL.md'), 'utf8'), /trusted/);
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(prepared.installed, 'validate-translations.sh'), 'utf8'),
+    /untrusted-head/,
+  );
+  assert.match(fs.readFileSync(prepared.githubEnvironment, 'utf8'), /^HEAD_REF=feature\/1246-uat$/m);
+
+  const forkFixture = initializeExactHeadFixture();
+  const fork = structuredClone(forkFixture.pull);
+  fork.head.repo.full_name = 'outsider/fork';
+  assert.notEqual(runTranslationPreparation(forkFixture, fork).result.status, 0);
+}
+
+function runPinnedInstaller(workflowPath, { digestOverride, runtimeVersion = '1.1.10' } = {}) {
+  const work = temporaryDirectory('agy-installer-');
+  const bin = path.join(work, 'bin');
+  const archiveSource = path.join(work, 'archive-source');
+  const archive = path.join(work, 'runtime.tar.gz');
+  fs.mkdirSync(bin);
+  fs.mkdirSync(archiveSource);
+  writeExecutable(
+    path.join(archiveSource, 'antigravity'),
+    `#!/usr/bin/env bash\nif [ "\${1:-}" = --version ]; then echo ${runtimeVersion}; fi\n`,
+  );
+  run('tar', ['-czf', archive, '-C', archiveSource, 'antigravity']);
+  const digest = createHash('sha512').update(fs.readFileSync(archive)).digest('hex');
+  writeExecutable(
+    path.join(bin, 'curl'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = --output ]; then
+    output=$2
+    shift 2
+  else
+    shift
+  fi
+done
+cp "$ARCHIVE_FIXTURE" "$output"
+`,
+  );
+  writeExecutable(
+    path.join(bin, 'sudo'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = apt-get ]; then
+  exit 0
+fi
+test "$1" = install
+shift
+previous=""
+for argument in "$@"; do
+  source_path=$previous
+  previous=$argument
+done
+cp "$source_path" "$FAKE_AGY_PATH"
+chmod 0555 "$FAKE_AGY_PATH"
+`,
+  );
+  writeExecutable(
+    path.join(bin, 'sha512sum'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+test "$1" = --check
+test "$2" = --strict
+read -r expected file
+actual=$(/usr/bin/shasum -a 512 "$file" | awk '{print $1}')
+test "$actual" = "$expected"
+`,
+  );
+  return runShell(extractStepBlock(workflowPath, 'Install pinned Antigravity runtime'), {
+    cwd: work,
+    env: {
+      AGY_SHA512: digestOverride ?? digest,
+      AGY_URL: 'https://example.com/immutable-fixture.tar.gz',
+      AGY_VERSION: '1.1.10',
+      ARCHIVE_FIXTURE: archive,
+      FAKE_AGY_PATH: path.join(bin, 'agy'),
+      PATH: `${bin}:${process.env.PATH}`,
+      RUNNER_TEMP: work,
+    },
+  });
+}
+
+function testPinnedInstallers() {
+  const review = runPinnedInstaller(reviewWorkflow);
+  assert.equal(review.status, 0, review.stderr);
+  const translation = runPinnedInstaller(translationWorkflow);
+  assert.equal(translation.status, 0, translation.stderr);
+  assert.notEqual(runPinnedInstaller(reviewWorkflow, { digestOverride: '0'.repeat(128) }).status, 0);
+  assert.notEqual(runPinnedInstaller(translationWorkflow, { runtimeVersion: '9.9.9' }).status, 0);
+}
+
+function writeSandboxCommandFakes(bin) {
+  writeExecutable(
+    path.join(bin, 'dbus-run-session'),
+    '#!/usr/bin/env bash\nset -euo pipefail\ntest "$1" = --\nshift\nexec "$@"\n',
+  );
+  writeExecutable(path.join(bin, 'gnome-keyring-daemon'), '#!/usr/bin/env bash\nexit 0\n');
+  writeExecutable(path.join(bin, 'python3'), '#!/usr/bin/env bash\ncat >/dev/null\n');
+}
+
+function runReviewerModel({ fail = false, missingSecret = false } = {}) {
+  const work = temporaryDirectory('agy-review-model-');
+  const bin = path.join(work, 'bin');
+  const tool = path.join(work, 'agy-review-tool');
+  fs.mkdirSync(bin);
+  fs.mkdirSync(tool);
+  fs.mkdirSync(path.join(work, 'home'));
+  writeSandboxCommandFakes(bin);
+  writeExecutable(path.join(bin, 'agy'), `#!/usr/bin/env bash\nif [ "\${1:-}" = --version ]; then echo 1.1.10; fi\n`);
+  writeExecutable(
+    path.join(tool, 'agy-review.sh'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >"$RUNNER_TEMP/review-invocation"
+if [ "\${STUB_REVIEW_FAIL:-false}" = true ]; then
+  exit 19
+fi
+printf '%s\n' '{"reviewer":{"verdict":"pass","summary":"clean","findings":[],"next_steps":[]},"verifier":{"verdict":"pass","summary":"verified","findings":[],"next_steps":[]}}' >"$AGY_REVIEW_REPORT_FILE"
+`,
+  );
+  const result = runShell(extractStepBlock(reviewWorkflow, 'Run isolated reviewer and verifier'), {
+    cwd: work,
+    env: {
+      AGY_VERSION: '1.1.10',
+      ANTIGRAVITY_TOKEN: missingSecret ? null : 'go-keyring-base64:dGVzdA==',
+      BASE_SHA: 'b'.repeat(40),
+      GCP_PROJECT_ID: 'fixture-project',
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      GITHUB_WORKFLOW_SHA: 'workflow-current',
+      GITHUB_WORKSPACE: work,
+      HEAD_SHA: 'h'.repeat(40),
+      HOME: path.join(work, 'home'),
+      PATH: `${bin}:${process.env.PATH}`,
+      RUNNER_TEMP: work,
+      STUB_REVIEW_FAIL: fail ? 'true' : 'false',
+    },
+  });
+  return { result, work };
+}
+
+function runReviewGate(report) {
+  const work = temporaryDirectory('agy-review-gate-');
+  const artifact = path.join(work, 'review-artifact');
+  fs.mkdirSync(artifact);
+  fs.writeFileSync(path.join(artifact, 'report.json'), `${JSON.stringify(report)}\n`);
+  return runShell(extractStepBlock(reviewWorkflow, 'Enforce Antigravity gate'), {
+    cwd: work,
+    env: { RUNNER_TEMP: work },
+  });
+}
+
+function testReviewerModelAndGate() {
+  const completed = runReviewerModel();
+  assert.equal(completed.result.status, 0, completed.result.stderr);
+  assert.equal(
+    fs.readFileSync(path.join(completed.work, 'review-invocation'), 'utf8').trim(),
+    `code --base ${'b'.repeat(40)}`,
+  );
+  const report = JSON.parse(fs.readFileSync(path.join(completed.work, 'review-artifact/report.json'), 'utf8'));
+  assert.deepEqual(report.receipt, {
+    agy_version: '1.1.10',
+    base_sha: 'b'.repeat(40),
+    head_sha: 'h'.repeat(40),
+    model: 'Gemini 3.6 Flash (High)',
+    repository: 'f5-sales-demo/example',
+    tool_status: 0,
+    workflow_sha: 'workflow-current',
+  });
+  assert.equal(runReviewGate(report).status, 0);
+
+  const failed = runReviewerModel({ fail: true });
+  assert.equal(failed.result.status, 0, failed.result.stderr);
+  const failedReport = JSON.parse(fs.readFileSync(path.join(failed.work, 'review-artifact/report.json'), 'utf8'));
+  assert.equal(failedReport.receipt.tool_status, 19);
+  assert.equal(failedReport.reviewer.findings[0].severity, 'critical');
+  assert.notEqual(runReviewGate(failedReport).status, 0);
+  assert.notEqual(runReviewerModel({ missingSecret: true }).result.status, 0);
+
+  const highFinding = structuredClone(report);
+  highFinding.reviewer.findings.push({ severity: 'high' });
+  assert.notEqual(runReviewGate(highFinding).status, 0);
+}
+
+async function testReviewCommentPublication() {
+  const work = temporaryDirectory('agy-review-comment-');
+  const reportPath = path.join(work, 'report.json');
+  const duplicateFinding = {
+    body: 'A verified medium-severity finding.',
+    file: 'example.js',
+    line_end: 7,
+    line_start: 7,
+    severity: 'medium',
+    title: 'Example finding',
+  };
+  const report = validReviewReport({
+    base: 'b'.repeat(40),
+    head: 'h'.repeat(40),
+    workflow: 'workflow-current',
+  });
+  report.reviewer.findings.push(duplicateFinding);
+  report.verifier.findings.push(structuredClone(duplicateFinding));
+  fs.writeFileSync(reportPath, `${JSON.stringify(report)}\n`);
+  const script = new AsyncFunction(
+    'github',
+    'context',
+    'require',
+    extractStepBlock(reviewWorkflow, 'Publish deduplicated review comment', 'script'),
+  );
+  const created = [];
+  const updated = [];
+  let existingComments = [];
+  const issues = {
+    createComment: async (parameters) => created.push(parameters),
+    listComments: async () => existingComments,
+    updateComment: async (parameters) => updated.push(parameters),
+  };
+  const github = {
+    paginate: async (endpoint, parameters) => endpoint(parameters),
+    rest: new Proxy(
+      { issues },
+      {
+        get(target, property) {
+          if (property !== 'issues') throw new Error(`unexpected mutation API: ${String(property)}`);
+          return target[property];
+        },
+      },
+    ),
+  };
+  const previousReportPath = process.env.REPORT_PATH;
+  const previousPullNumber = process.env.PR_NUMBER;
+  process.env.REPORT_PATH = reportPath;
+  process.env.PR_NUMBER = '42';
+  try {
+    await script(github, { repo: { owner: 'f5-sales-demo', repo: 'example' } }, require);
+    assert.equal(created.length, 1);
+    assert.equal((created[0].body.match(/Example finding/g) ?? []).length, 1);
+    assert.match(created[0].body, /<!-- antigravity-pr-review -->/);
+
+    existingComments = [{ body: created[0].body, id: 99, user: { type: 'Bot' } }];
+    await script(github, { repo: { owner: 'f5-sales-demo', repo: 'example' } }, require);
+    assert.equal(created.length, 1);
+    assert.deepEqual(
+      updated.map(({ comment_id }) => comment_id),
+      [99],
+    );
+
+    process.env.PR_NUMBER = 'not-a-number';
+    await assert.rejects(
+      script(github, { repo: { owner: 'f5-sales-demo', repo: 'example' } }, require),
+      /invalid pull-request number/,
+    );
+  } finally {
+    if (previousReportPath === undefined) delete process.env.REPORT_PATH;
+    else process.env.REPORT_PATH = previousReportPath;
+    if (previousPullNumber === undefined) delete process.env.PR_NUMBER;
+    else process.env.PR_NUMBER = previousPullNumber;
+  }
+}
+
+function runTranslationModel({ missingSecret = false } = {}) {
+  const work = temporaryDirectory('agy-translation-model-');
+  const bin = path.join(work, 'bin');
+  fs.mkdirSync(bin);
+  fs.mkdirSync(path.join(work, 'home'));
+  writeSandboxCommandFakes(bin);
+  writeExecutable(
+    path.join(bin, 'agy'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = --version ]; then
+  echo 1.1.10
+  exit 0
+fi
+printf '%s\n' "$@" >"$RUNNER_TEMP/translation-arguments"
+printf '%s|%s|%s|%s\n' "\${GH_TOKEN:-}" "\${GITHUB_TOKEN:-}" "\${GATEWAY_TOKEN:-}" "\${GATEWAY_URL:-}" >"$RUNNER_TEMP/translation-credentials"
+`,
+  );
+  const changedEnglish = path.join(work, 'changed-english.txt');
+  fs.writeFileSync(changedEnglish, 'docs/en/page.mdx\n');
+  const result = runShell(extractStepBlock(translationWorkflow, 'Generate translations without write credentials'), {
+    cwd: work,
+    env: {
+      AGY_VERSION: '1.1.10',
+      ANTIGRAVITY_TOKEN: missingSecret ? null : 'go-keyring-base64:dGVzdA==',
+      GATEWAY_TOKEN: 'must-not-reach-model',
+      GATEWAY_URL: 'must-not-reach-model',
+      GCP_PROJECT_ID: 'fixture-project',
+      GH_TOKEN: 'must-not-reach-model',
+      GITHUB_TOKEN: 'must-not-reach-model',
+      GITHUB_WORKSPACE: work,
+      HOME: path.join(work, 'home'),
+      PATH: `${bin}:${process.env.PATH}`,
+      RUNNER_TEMP: work,
+    },
+  });
+  return { result, work };
+}
+
+function testTranslationModel() {
+  const completed = runTranslationModel();
+  assert.equal(completed.result.status, 0, completed.result.stderr);
+  const argumentsUsed = fs.readFileSync(path.join(completed.work, 'translation-arguments'), 'utf8');
+  for (const argument of ['--sandbox', '--mode', 'accept-edits', '--disable-slash-commands']) {
+    assert.match(argumentsUsed, new RegExp(`^${argument}$`, 'm'));
+  }
+  assert.equal(
+    fs.readFileSync(path.join(completed.work, 'translation-credentials'), 'utf8').trim(),
+    '|||',
+    'the sandboxed translator must not receive GitHub or gateway credentials',
+  );
+  assert.notEqual(runTranslationModel({ missingSecret: true }).result.status, 0);
+}
+
+const locales = ['fr', 'es', 'de', 'pt-br', 'ja', 'ko', 'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th'];
+
+function writeEnglishSource(repository, suffix) {
+  fs.mkdirSync(path.join(repository, 'docs/en'), { recursive: true });
+  fs.writeFileSync(path.join(repository, 'docs/en/page.mdx'), `---\ntitle: Page\n---\n\nEnglish body.${suffix}\n`);
+}
+
+function writeLocale(repository, locale, sourceHash) {
+  const directory = path.join(repository, 'docs', locale);
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(
+    path.join(directory, 'page.mdx'),
+    `---\ntitle: Page ${locale}\ni18n:\n  sourceHash: "${sourceHash}"\n  translator: "machine"\n---\n\nTranslated body.\n`,
+  );
+}
+
+function initializeTranslationFixture() {
+  const work = temporaryDirectory('agy-translation-fixture-');
+  const repository = path.join(work, 'repository');
+  const remote = path.join(work, 'remote.git');
+  initializeGitRepository(repository);
+  run('git', ['init', '--bare', '-q', remote], { cwd: work });
+  writeEnglishSource(repository, '');
+  let hash = sha256Prefix(path.join(repository, 'docs/en/page.mdx'));
+  for (const locale of locales) writeLocale(repository, locale, hash);
+  git(repository, 'add', '.');
+  git(repository, 'commit', '-qm', 'base');
+  const base = git(repository, 'rev-parse', 'HEAD');
+  git(repository, 'remote', 'add', 'origin', remote);
+  git(repository, 'push', '-q', 'origin', 'HEAD:refs/heads/main');
+
+  writeEnglishSource(repository, '\nChanged English.');
+  git(repository, 'add', 'docs/en/page.mdx');
+  git(repository, 'commit', '-qm', 'English update');
+  const head = git(repository, 'rev-parse', 'HEAD');
+  git(repository, 'push', '-q', 'origin', 'HEAD:refs/heads/feature/1246-uat');
+  git(repository, 'push', '-q', 'origin', 'HEAD:refs/pull/42/head');
+  hash = sha256Prefix(path.join(repository, 'docs/en/page.mdx'));
+  for (const locale of locales) writeLocale(repository, locale, hash);
+  return {
+    base,
+    head,
+    hash,
+    remote,
+    repository,
+    pull: {
+      base: { sha: base },
+      head: {
+        ref: 'feature/1246-uat',
+        repo: repositoryIdentity(),
+        sha: head,
+      },
+    },
+  };
+}
+
+function runTranslationPackage(fixture) {
+  const runner = temporaryDirectory('agy-translation-package-');
+  const script = extractStepBlock(translationWorkflow, 'Validate and package allowlisted translation patch').replace(
+    '/opt/agy-translation-contract/validate-translations.sh',
+    path.join(root, 'scripts/validate-translations.sh'),
+  );
+  const result = runShell(script, {
+    cwd: fixture.repository,
+    env: {
+      AGY_VERSION: '1.1.10',
+      BASE_SHA: fixture.base,
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      GITHUB_WORKFLOW_SHA: 'workflow-current',
+      HEAD_REF: fixture.pull.head.ref,
+      HEAD_SHA: fixture.head,
+      RUNNER_TEMP: runner,
+    },
+  });
+  return { fixture, result, runner };
+}
+
+function testTranslationPackaging() {
+  const completed = runTranslationPackage(initializeTranslationFixture());
+  assert.equal(completed.result.status, 0, completed.result.stderr);
+  const changedOutput = git(completed.fixture.repository, 'diff', '--cached', '--name-only');
+  const changed = changedOutput ? changedOutput.split('\n') : [];
+  assert.equal(
+    changed.length,
+    12,
+    `expected 12 staged locales, got:\n${changedOutput}\n${git(completed.fixture.repository, 'status', '--short')}`,
+  );
+  assert.deepEqual(changed.sort(), locales.map((locale) => `docs/${locale}/page.mdx`).sort());
+  const receipt = JSON.parse(fs.readFileSync(path.join(completed.runner, 'translation-artifact/receipt.json'), 'utf8'));
+  assert.deepEqual(receipt, {
+    agy_version: '1.1.10',
+    base_sha: completed.fixture.base,
+    head_ref: 'feature/1246-uat',
+    head_sha: completed.fixture.head,
+    model: 'Gemini 3.6 Flash (High)',
+    repository: 'f5-sales-demo/example',
+    workflow_sha: 'workflow-current',
+  });
+  assert.ok(fs.statSync(path.join(completed.runner, 'translation-artifact/translations.patch')).size > 0);
+
+  const missing = initializeTranslationFixture();
+  fs.rmSync(path.join(missing.repository, 'docs/th/page.mdx'));
+  assert.notEqual(runTranslationPackage(missing).result.status, 0);
+
+  const sourceMutation = initializeTranslationFixture();
+  fs.appendFileSync(path.join(sourceMutation.repository, 'docs/en/page.mdx'), '\nUntrusted edit.\n');
+  assert.notEqual(runTranslationPackage(sourceMutation).result.status, 0);
+
+  const outside = initializeTranslationFixture();
+  fs.writeFileSync(path.join(outside.repository, 'outside.txt'), 'out of scope\n');
+  assert.notEqual(runTranslationPackage(outside).result.status, 0);
+
+  const executable = initializeTranslationFixture();
+  fs.chmodSync(path.join(executable.repository, 'docs/fr/page.mdx'), 0o755);
+  assert.notEqual(runTranslationPackage(executable).result.status, 0);
+}
+
+function advanceRemoteHead(fixture) {
+  const checkout = path.join(temporaryDirectory('agy-translation-drift-'), 'repository');
+  run('git', ['clone', '-q', fixture.remote, checkout]);
+  git(checkout, 'config', 'user.email', 'fixture@example.com');
+  git(checkout, 'config', 'user.name', 'Fixture');
+  git(checkout, 'checkout', '-q', '-B', 'feature/1246-uat', 'origin/feature/1246-uat');
+  fs.writeFileSync(path.join(checkout, 'remote-drift.txt'), 'remote drift\n');
+  git(checkout, 'add', 'remote-drift.txt');
+  git(checkout, 'commit', '-qm', 'remote drift');
+  git(checkout, 'push', '-q', 'origin', 'HEAD:refs/heads/feature/1246-uat');
+}
+
+function runTranslationPublication(packaged, { missingToken = false, remoteDrift = false } = {}) {
+  if (remoteDrift) advanceRemoteHead(packaged.fixture);
+  const work = temporaryDirectory('agy-translation-publish-');
+  const repository = path.join(work, 'repository');
+  const runner = path.join(work, 'runner');
+  const artifact = path.join(runner, 'translation-artifact');
+  const bin = path.join(work, 'bin');
+  fs.mkdirSync(runner);
+  fs.mkdirSync(artifact);
+  fs.mkdirSync(bin);
+  run('git', ['clone', '-q', packaged.fixture.remote, repository]);
+  git(repository, 'checkout', '-q', '--detach', packaged.fixture.head);
+  fs.copyFileSync(path.join(packaged.runner, 'translation-artifact/receipt.json'), path.join(artifact, 'receipt.json'));
+  fs.copyFileSync(
+    path.join(packaged.runner, 'translation-artifact/translations.patch'),
+    path.join(artifact, 'translations.patch'),
+  );
+  writeFakeGh(bin, packaged.fixture.pull);
+  const script = extractStepBlock(translationWorkflow, 'Validate, commit, and publish translations').replace(
+    '/opt/agy-publication-validator/validate-translations.sh',
+    path.join(root, 'scripts/validate-translations.sh'),
+  );
+  const result = runShell(script, {
+    cwd: repository,
+    env: {
+      AGY_VERSION: '1.1.10',
+      BASE_SHA: packaged.fixture.base,
+      GH_TOKEN: missingToken ? null : 'fixture-publication-token',
+      GITHUB_REPOSITORY: 'f5-sales-demo/example',
+      HEAD_SHA: packaged.fixture.head,
+      PATH: `${bin}:${process.env.PATH}`,
+      PR_NUMBER: '42',
+      RUNNER_TEMP: runner,
+      WORKFLOW_SHA: 'workflow-current',
+    },
+  });
+  return { repository, result };
+}
+
+function testTranslationPublication() {
+  const packaged = runTranslationPackage(initializeTranslationFixture());
+  assert.equal(packaged.result.status, 0, packaged.result.stderr);
+  const published = runTranslationPublication(packaged);
+  assert.equal(published.result.status, 0, published.result.stderr);
+  const publishedHead = run('git', ['--git-dir', packaged.fixture.remote, 'rev-parse', 'refs/heads/feature/1246-uat']);
+  assert.notEqual(publishedHead, packaged.fixture.head);
+  assert.equal(
+    run('git', ['--git-dir', packaged.fixture.remote, 'log', '-1', '--format=%s', publishedHead]),
+    'chore(i18n): update translations via Antigravity',
+  );
+  const publishedPaths = run('git', [
+    '--git-dir',
+    packaged.fixture.remote,
+    'ls-tree',
+    '-r',
+    '--name-only',
+    publishedHead,
+  ])
+    .split('\n')
+    .filter((file) => /^docs\/(?:fr|es|de|pt-br|ja|ko|zh-cn|zh-tw|ar|it|hi|th)\//.test(file));
+  assert.equal(publishedPaths.length, 12);
+
+  const stale = runTranslationPackage(initializeTranslationFixture());
+  assert.equal(stale.result.status, 0, stale.result.stderr);
+  assert.notEqual(runTranslationPublication(stale, { remoteDrift: true }).result.status, 0);
+
+  const noToken = runTranslationPackage(initializeTranslationFixture());
+  assert.equal(noToken.result.status, 0, noToken.result.stderr);
+  assert.notEqual(runTranslationPublication(noToken, { missingToken: true }).result.status, 0);
+}
+
+const base = 'b'.repeat(40);
+const head = 'h'.repeat(40);
+const pull = {
+  base: { sha: base },
+  head: { ref: 'feature/1246-uat', repo: repositoryIdentity(), sha: head },
+};
+
+const validReview = validReviewReport({ base, head, workflow: 'workflow-current' });
+assert.equal(runReviewReceiptValidation({ report: validReview, pull }).status, 0);
+assert.notEqual(
+  runReviewReceiptValidation({
+    report: validReviewReport({ base, head, workflow: 'workflow-stale' }),
+    pull,
+  }).status,
+  0,
+  'review publication must reject a stale workflow receipt',
+);
+assert.notEqual(
+  runReviewReceiptValidation({
+    report: validReviewReport({ base: 'c'.repeat(40), head, workflow: 'workflow-current' }),
+    pull,
+  }).status,
+  0,
+  'review publication must reject a stale base receipt',
+);
+assert.notEqual(
+  runReviewReceiptValidation({
+    report: { ...validReview, receipt: { ...validReview.receipt, agy_version: '9.9.9' } },
+    pull,
+  }).status,
+  0,
+  'review publication must reject an unexpected runtime receipt',
+);
+const forkPull = structuredClone(pull);
+forkPull.head.repo.full_name = 'outsider/fork';
+assert.notEqual(
+  runReviewReceiptValidation({ report: validReview, pull: forkPull }).status,
+  0,
+  'review publication must reject a fork head',
+);
+
+const validTranslation = {
+  repository: 'f5-sales-demo/example',
+  base_sha: base,
+  head_sha: head,
+  head_ref: pull.head.ref,
+  workflow_sha: 'workflow-current',
+  agy_version: '1.1.10',
+  model: 'Gemini 3.6 Flash (High)',
+};
+assert.equal(runTranslationReceiptValidation({ receipt: validTranslation, pull }).status, 0);
+assert.notEqual(
+  runTranslationReceiptValidation({
+    receipt: { ...validTranslation, workflow_sha: 'workflow-stale' },
+    pull,
+  }).status,
+  0,
+  'translation publication must reject a stale workflow receipt',
+);
+assert.notEqual(
+  runTranslationReceiptValidation({
+    receipt: { ...validTranslation, head_sha: 's'.repeat(40) },
+    pull,
+  }).status,
+  0,
+  'translation publication must reject a stale head receipt',
+);
+assert.notEqual(
+  runTranslationReceiptValidation({
+    receipt: { ...validTranslation, agy_version: '9.9.9' },
+    pull,
+  }).status,
+  0,
+  'translation publication must reject an unexpected runtime receipt',
+);
+assert.notEqual(
+  runTranslationReceiptValidation({ receipt: validTranslation, pull: forkPull }).status,
+  0,
+  'translation publication must reject a fork head',
+);
+
+testReviewerPreparation();
+testTranslationPreparation();
+testPinnedInstallers();
+testReviewerModelAndGate();
+await testReviewCommentPublication();
+testTranslationModel();
+testTranslationPackaging();
+testTranslationPublication();
+
+console.log('PASS: Antigravity CI feature UAT');

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -12,6 +12,8 @@ const root = path.resolve(process.argv[2]);
 
 const reviewWorkflow = path.join(root, '.github/workflows/antigravity-review.yml');
 const translationWorkflow = path.join(root, '.github/workflows/antigravity-translate.yml');
+const translationCaller = path.join(root, 'workflows/antigravity-translate.yml');
+const watcherWorkflow = path.join(root, '.github/workflows/antigravity-fleet-watcher.yml');
 const repositoryName = ['f5-sales-demo', 'example'].join('/');
 const temporaryDirectories = [];
 const require = createRequire(import.meta.url);
@@ -42,6 +44,63 @@ function extractStepBlock(workflowPath, stepName, key = 'run') {
     .slice(marker + 1)
     .map((line) => (line.length >= indentation ? line.slice(indentation) : ''))
     .join('\n');
+}
+
+function extractJobBlock(workflowPath, jobName) {
+  const lines = fs.readFileSync(workflowPath, 'utf8').split('\n');
+  const start = lines.indexOf(`  ${jobName}:`);
+  if (start === -1) throw new Error(`job not found: ${jobName}`);
+  const end = lines.findIndex((line, index) => index > start && /^ {2}[A-Za-z0-9_-]+:$/.test(line));
+  return lines.slice(start, end === -1 ? undefined : end).join('\n');
+}
+
+function testNoAppTokenRouting() {
+  const translation = fs.readFileSync(translationWorkflow, 'utf8');
+  const caller = fs.readFileSync(translationCaller, 'utf8');
+  const watcher = fs.readFileSync(watcherWorkflow, 'utf8');
+  const translateJob = extractJobBlock(translationWorkflow, 'translate');
+  const translationPublishJob = extractJobBlock(translationWorkflow, 'publish');
+  const collectJob = extractJobBlock(watcherWorkflow, 'collect');
+  const triageJob = extractJobBlock(watcherWorkflow, 'triage');
+  const watcherPublishJob = extractJobBlock(watcherWorkflow, 'publish');
+
+  for (const [name, contents] of [
+    ['translation workflow', translation],
+    ['translation caller', caller],
+    ['fleet watcher', watcher],
+  ]) {
+    assert.doesNotMatch(contents, /AUTOMATION_APP_(?:ID|PRIVATE_KEY)/, `${name} must not require a GitHub App`);
+    assert.doesNotMatch(contents, /actions\/create-github-app-token/, `${name} must not mint GitHub App tokens`);
+  }
+
+  assert.match(translation, /REPO_SYNC_TOKEN:\n\s+required: true/, 'reusable translation must require REPO_SYNC_TOKEN');
+  assert.match(
+    caller,
+    /REPO_SYNC_TOKEN: \$\{\{ secrets\.REPO_SYNC_TOKEN \}\}/,
+    'managed translation caller must explicitly pass REPO_SYNC_TOKEN',
+  );
+  assert.doesNotMatch(translateJob, /REPO_SYNC_TOKEN/, 'translation model job must not receive the publication token');
+  assert.match(
+    translationPublishJob,
+    /GH_TOKEN: \$\{\{ secrets\.REPO_SYNC_TOKEN \}\}/,
+    'translation publication must use REPO_SYNC_TOKEN',
+  );
+
+  assert.match(
+    collectJob,
+    /GH_TOKEN: \$\{\{ secrets\.REPO_SETTINGS_TOKEN \}\}/,
+    'watcher collection must use REPO_SETTINGS_TOKEN',
+  );
+  assert.doesNotMatch(
+    triageJob,
+    /REPO_SETTINGS_TOKEN|REPO_SYNC_TOKEN/,
+    'Antigravity triage must receive no governance token',
+  );
+  assert.match(
+    watcherPublishJob,
+    /github-token: \$\{\{ secrets\.REPO_SETTINGS_TOKEN \}\}/,
+    'watcher publication must use REPO_SETTINGS_TOKEN',
+  );
 }
 
 function writeExecutable(file, body) {
@@ -898,6 +957,7 @@ assert.notEqual(
 );
 
 testReviewerPreparation();
+testNoAppTokenRouting();
 testTranslationPreparation();
 testPinnedInstallers();
 testReviewerModelAndGate();

--- a/tests/test-agy-pre-push-review.sh
+++ b/tests/test-agy-pre-push-review.sh
@@ -54,6 +54,9 @@ if [ -n "${FAKE_AGY_BUNDLE_CAPTURE:-}" ]; then
     fi
   done
 fi
+if [ "${FAKE_AGY_DELAY_CALL:-0}" -eq "$count" ]; then
+  sleep "${FAKE_AGY_DELAY_SECONDS:-2}"
+fi
 if [ "${FAKE_AGY_MALFORMED_CALL:-0}" -eq "$count" ]; then
   printf 'not-json\n'
 elif [ "${FAKE_AGY_BLOCK_CALL:-0}" -eq "$count" ]; then
@@ -101,6 +104,19 @@ if run_review "$WORK/bin:$PATH" env GATEWAY_TOKEN=private GITHUB_TOKEN=private \
   pass "two schema-validated Flash passes review a precomputed bundle without inherited credentials"
 else
   fail "clean branch receives two independent Antigravity passes" "$(cat "$WORK/output")"
+fi
+
+setup_repo
+if run_review "$WORK/bin:$PATH" env FAKE_AGY_DELAY_CALL=1 FAKE_AGY_DELAY_SECONDS=2 \
+  AGY_REVIEW_HEARTBEAT_SECONDS=1 &&
+  grep -q '\[review\] reviewer started; waiting for Antigravity' "$WORK/output" &&
+  grep -q '\[review\] reviewer still running (' "$WORK/output" &&
+  grep -q '\[review\] reviewer completed; validating structured output' "$WORK/output" &&
+  grep -q '\[review\] verifier started; waiting for Antigravity' "$WORK/output" &&
+  grep -q '\[review\] verifier completed; validating structured output' "$WORK/output"; then
+  pass "review wrapper emits phase start, heartbeat, and completion progress"
+else
+  fail "review wrapper emits unambiguous progress" "$(cat "$WORK/output")"
 fi
 
 setup_repo

--- a/tests/test-privileged-pr-workflows.sh
+++ b/tests/test-privileged-pr-workflows.sh
@@ -132,6 +132,12 @@ else
   fail 'privileged workflow behavior must match its API contract'
 fi
 
+if node "$REPO_ROOT/tests/antigravity-ci-feature-uat.mjs" "$REPO_ROOT"; then
+  pass 'Antigravity reviewer and translator feature behavior matches its trust contract'
+else
+  fail 'Antigravity reviewer and translator feature behavior must match its trust contract'
+fi
+
 if [ "$FAIL" -eq 0 ]; then
   printf 'PASS: privileged pull-request workflow contracts are secure\n'
 else

--- a/tests/test-verify-antigravity-controls.sh
+++ b/tests/test-verify-antigravity-controls.sh
@@ -46,6 +46,11 @@ orgs/example/actions/variables/TRANSLATIONS_ENABLED)
   printf '{"name":"TRANSLATIONS_ENABLED","value":"%s","visibility":"%s"}\n' \
     "${FAKE_TRANSLATION_VALUE:-false}" "${FAKE_VISIBILITY:-all}"
   ;;
+orgs/example/actions/variables/ANTIGRAVITY_REVIEW_ENABLED/repositories* | \
+  orgs/example/actions/variables/TRANSLATIONS_ENABLED/repositories*)
+  printf '[{"total_count":1,"repositories":[{"name":"%s"}]}]\n' \
+    "${FAKE_SELECTED_REPO:-repo-a}"
+  ;;
 repos/example/*/actions/variables*)
   repo=${endpoint#repos/example/}
   repo=${repo%%/*}
@@ -103,6 +108,24 @@ else
   fail "requested enabled values are enforced" "wrong diagnostic"
 fi
 unset FAKE_WORKFLOW_STATE
+
+setup_fixture
+export FAKE_VISIBILITY=selected
+if run_verifier --visibility selected --selected-repo repo-a --workflow-state held &&
+  grep -q 'visibility=selected repositories=repo-a' "$WORK/out"; then
+  pass "selected pilot visibility verifies the exact repository set"
+else
+  fail "selected pilot visibility verifies the exact repository set" "$(cat "$WORK/err")"
+fi
+export FAKE_SELECTED_REPO=wrong-repo
+if run_verifier --visibility selected --selected-repo repo-a --workflow-state held; then
+  fail "selected pilot visibility rejects repository drift" "mismatched selection passed"
+elif grep -q 'selected repositories' "$WORK/err"; then
+  pass "selected pilot visibility rejects repository drift"
+else
+  fail "selected pilot visibility rejects repository drift" "wrong diagnostic"
+fi
+unset FAKE_SELECTED_REPO FAKE_VISIBILITY
 
 setup_fixture
 export FAKE_SHADOW_REPO=repo-a

--- a/workflows/antigravity-translate.yml
+++ b/workflows/antigravity-translate.yml
@@ -38,5 +38,4 @@ jobs:
     secrets:
       ANTIGRAVITY_TOKEN: ${{ secrets.ANTIGRAVITY_TOKEN }}
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-      AUTOMATION_APP_ID: ${{ secrets.AUTOMATION_APP_ID }}
-      AUTOMATION_APP_PRIVATE_KEY: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
+      REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

- add executable feature UAT for the real Antigravity reviewer and translator production step bodies
- remove the unprovisioned GitHub App dependency with a clean break
- route translation publication only through `REPO_SYNC_TOKEN`
- route fleet collection/publication only through `REPO_SETTINGS_TOKEN`; model jobs receive neither governance token
- add reviewer/verifier start, 30-second heartbeat, and completion markers so silent model work is never mistaken for completion
- bind review and translation publication to exact workflow/runtime receipts and publish exactly 12 validated locale outputs

## Security boundary

The UAT covers trusted-base capture, same-repository exact heads, immutable runtime digest/version, sandbox modes, governance-token isolation, structured review fallback/gate, deduplicated comments, 12-locale validation, allowlisted patch generation, guarded publication, and fail-closed fork, stale receipt, missing secret, out-of-scope edit, invalid mode, and stale lease cases.

This uses GitHub Free-compatible Actions, organization variables, existing repository PAT secrets, artifacts, comments, and classic branch protection. It does not use rulesets, merge queues, environment reviewers, audit streaming, or a GitHub App.

The organization switches remain `false` until this reusable implementation lands and the immutable caller pin propagates. Parent activation: #1246. Security tracking: #1016.

## Verification

- `node tests/antigravity-ci-feature-uat.mjs .` — PASS, including no-App token routing and 12-locale publication
- every `tests/test-*.sh` script — 33 passed
- `bash tests/test-agy-pre-push-review.sh` — 8 passed, including live heartbeat behavior
- `pre-commit run --all-files` — PASS, including Actionlint, Yamllint, ShellCheck, Biome, Zizmor, Checkov, and gitleaks
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean
- `bash scripts/agy-pre-push-review.sh` at `7553d31` — reviewer and independent verifier passed; no critical/high finding remains
- forbidden `F5_GATEWAY_TOKEN` / `F5_GATEWAY_URL` references — absent

Closes #1251
