### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,17 +1,17 @@
 {
-  "source_commit": "8fa31156566112a0955c5569db9766099ff480e4",
+  "source_commit": "ef1b2abadd3fd4fb43588a19145fe9d196dc1006",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
       "dest": ".github/workflows/github-pages-deploy.yml",
-      "sha": "eefff014a22259f4fd2a6b320b140b490dae2157",
+      "sha": "b5910dfeed608af9b7cf764b9f6a4c9d42d96b9d",
       "size": 855,
       "mode": "100644"
     },
     ".github/workflows/enforce-repo-settings.yml": {
       "src": "workflows/enforce-repo-settings.yml",
       "dest": ".github/workflows/enforce-repo-settings.yml",
-      "sha": "d84a21bf7a3161264394e094c8bc5e549fe5b7b9",
+      "sha": "7d832a7cc46df9468d07561afd0b252954f91a9a",
       "size": 11734,
       "mode": "100644"
     },
@@ -25,28 +25,28 @@
     ".github/workflows/super-linter.yml": {
       "src": "workflows/super-linter.yml",
       "dest": ".github/workflows/super-linter.yml",
-      "sha": "cdc9899279d26e9ba39997cfc199458b398dffc8",
+      "sha": "53eb902659e71a1a85e7abf8e688c938c33b5095",
       "size": 913,
       "mode": "100644"
     },
     ".github/workflows/translation-audit.yml": {
       "src": "workflows/translation-audit.yml",
       "dest": ".github/workflows/translation-audit.yml",
-      "sha": "ca38eeee2f1fbc62c258b8239c6419bf42d23763",
+      "sha": "0109e607a14071198468f5e79ba0813b1f9fdbcc",
       "size": 1697,
       "mode": "100644"
     },
     ".github/workflows/antigravity-review.yml": {
       "src": "workflows/antigravity-review.yml",
       "dest": ".github/workflows/antigravity-review.yml",
-      "sha": "0af47756a47528cf90b8923cc673eadb3fc5f593",
+      "sha": "e694282b23124cbb92327383ce8b24d889c9b05e",
       "size": 1309,
       "mode": "100644"
     },
     ".github/workflows/antigravity-translate.yml": {
       "src": "workflows/antigravity-translate.yml",
       "dest": ".github/workflows/antigravity-translate.yml",
-      "sha": "912dd4a152e615172f74bc58a47a535fc76abfd1",
+      "sha": "2ffb88c2fe021fcdf3416e4c5a9ebf8f206465fa",
       "size": 1475,
       "mode": "100644"
     },
@@ -186,7 +186,7 @@
     ".github/workflows/auto-merge.yml": {
       "src": "workflows/auto-merge.yml",
       "dest": ".github/workflows/auto-merge.yml",
-      "sha": "889f0cc0968bd7868fd3564427b81adde09c8cf9",
+      "sha": "4ba0c889313092f48c7230a8224c911babf1e174",
       "size": 3093,
       "mode": "100644"
     },


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.