### PR TITLE
fix(governance): make kubeconform option shell-safe

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -336,8 +336,10 @@ jobs:
           # F5 XC API objects also use top-level apiVersion and kind fields.
           # Super-Linter otherwise misclassifies their native YAML sources as
           # Kubernetes. Limit this option to Kubeconform so YAML and security
-          # validators still inspect every minimum configuration.
-          KUBERNETES_KUBECONFORM_OPTIONS: ${{ inputs.classify_xc_minimum_configs && '-ignore-filename-pattern=(^|/)tools/minimum-configs/' || '' }}
+          # validators still inspect every minimum configuration. Super-Linter
+          # reparses validator options through bash -c, so keep this regex free
+          # of shell metacharacters.
+          KUBERNETES_KUBECONFORM_OPTIONS: ${{ inputs.classify_xc_minimum_configs && '-ignore-filename-pattern=tools/minimum-configs/' || '' }}
           # tree-sitter-<grammar>/src/{parser,scanner}.c are either machine-
           # generated (parser.c from `tree-sitter generate`) or hand-written
           # to upstream tree-sitter conventions that do not match

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -452,11 +452,25 @@ fi
 KUBECONFORM_OPTIONS=$(grep -E \
   '^[[:space:]]*KUBERNETES_KUBECONFORM_OPTIONS:' "$SL_YML" || true)
 if printf '%s' "$KUBECONFORM_OPTIONS" |
-  grep -Fq "inputs.classify_xc_minimum_configs && '-ignore-filename-pattern=(^|/)tools/minimum-configs/' || ''"; then
+  grep -Fq "inputs.classify_xc_minimum_configs && '-ignore-filename-pattern=tools/minimum-configs/' || ''"; then
   pass "5e.6 XC classification affects only Kubeconform's filename set"
 else
   fail "5e.6 XC classification affects only Kubeconform's filename set" \
     "the fixed minimum-config path must be routed through KUBERNETES_KUBECONFORM_OPTIONS"
+fi
+
+KUBECONFORM_ARGUMENT=$(printf '%s\n' "$KUBECONFORM_OPTIONS" |
+  sed -nE "s/.*&& '([^']+)' \\|\\| ''.*/\\1/p")
+if [ -z "$KUBECONFORM_ARGUMENT" ]; then
+  fail "5e.6a Kubeconform options survive Super-Linter's shell reparse" \
+    "could not extract the enabled Kubeconform argument"
+elif bash -c \
+  'expected="$1"; shift; set -- kubeconform '"$KUBECONFORM_ARGUMENT"'; [ "$#" -eq 2 ] && [ "$2" = "$expected" ]' \
+  bash "$KUBECONFORM_ARGUMENT" 2>/dev/null; then
+  pass "5e.6a Kubeconform options survive Super-Linter's shell reparse"
+else
+  fail "5e.6a Kubeconform options survive Super-Linter's shell reparse" \
+    "the argument is not one shell-safe word after bash -c reparsing"
 fi
 
 FILTER_REGEX=$(grep -E '^[[:space:]]*FILTER_REGEX_EXCLUDE:' "$SL_YML" | head -1)


### PR DESCRIPTION
<!-- markdownlint-disable-next-line MD041 -->
## Summary

Make the provider-only Kubeconform filename exclusion safe when Super-Linter reparses validator options through `bash -c`, and cover that exact runtime boundary with a regression test.

## Related Issue

Closes #1255

## Changes

- Replace the metacharacter-bearing anchored regex with the narrow literal `tools/minimum-configs/` path pattern.
- Extract the configured Kubeconform argument in the linter-config test and execute an equivalent shell-reparsed command.
- Keep the exclusion scoped to Kubeconform; every other YAML and security validator still sees the minimum configs.

## Verification evidence

- Test-first red: `bash tests/test-linter-configs.sh` — 173 passed, 1 failed at the new shell-reparse assertion before the workflow fix.
- Green: `bash tests/test-linter-configs.sh` — 174 passed, 0 failed.
- Green: `pre-commit run shellcheck --all-files`.
- Green: `pre-commit run --all-files` — all configured gates passed.
- Green: `bash scripts/agy-pre-push-review.sh` on `ca20fae7633bfe5f332dad240f4eb9670c7eaf5c`; PII enforcement scope clean.
- CI terminal link will be supplied by the governed watcher.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] CI watched to green (governed watcher owns terminal completion)
- [x] Follows project conventions
