### PR TITLE
fix(governance): require xcsh Super-Linter checks

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -66,8 +66,7 @@
       "additional_contexts": ["Run plugin test suites"]
     },
     "xcsh": {
-      "additional_contexts": ["check", "pii-guard", "test"],
-      "excluded_required_contexts": ["lint / Lint Code Base", "lint / Shell Unit Tests"]
+      "additional_contexts": ["check", "pii-guard", "test"]
     },
     "vscode-xcsh": {
       "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -373,11 +373,12 @@ fi
 XCSH_EXCLUDED=$(jq -c '.repo_overrides.xcsh.excluded_required_contexts // []' \
   "$REPO_SETTINGS")
 if echo "$XCSH_EXCLUDED" | jq -e \
-  'index("lint / Shell Unit Tests") != null' >/dev/null; then
-  pass "7e.6 xcsh opts out of the Super-Linter shell context it does not emit"
+  'index("lint / Lint Code Base") == null and
+   index("lint / Shell Unit Tests") == null' >/dev/null; then
+  pass "7e.6 xcsh requires both Super-Linter contexts"
 else
-  fail "7e.6 xcsh opts out of the Super-Linter shell context it does not emit" \
-    "fleet verification proves xcsh never reports lint / Shell Unit Tests"
+  fail "7e.6 xcsh requires both Super-Linter contexts" \
+    "remove the stale xcsh exclusions for Lint Code Base and Shell Unit Tests"
 fi
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #1254

## Summary

- remove stale xcsh exclusions for lint / Lint Code Base and lint / Shell Unit Tests
- replace the stale opt-out assertion with a regression test requiring both contexts
- restore the documented effective protection set after xcsh#2998 demonstrated that red lint could merge

## Verification evidence

- red step: bash tests/test-linter-configs.sh failed only at 7e.6 with 172 passed, 1 failed
- green step: bash tests/test-linter-configs.sh passed 173/173
- bash tests/test-bootstrap-downstream-callers.sh: passed the complete reconciliation, receipt, rate-limit, transition, and recovery matrix
- bash tests/test-governed-workflow-pins.sh: passed
- all 33 tests/test-*.sh suites: passed
- pre-commit run --all-files: passed every applicable hook
- effective xcsh context calculation: Check linked issues, check, lint / Lint Code Base, lint / Shell Unit Tests, pii-guard, test
- bash scripts/agy-pre-push-review.sh: PII clean and no critical/high finding

## Checklist

- [x] Linked to a detailed issue
- [x] Test-driven red/green regression coverage
- [x] Full local shell matrix and pre-commit clean
- [x] Exact committed HEAD reviewed by Antigravity
- [ ] CI and governed auto-merge watcher complete after publication