### PR TITLE
fix(governance): unblock managed test rollout

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -70,6 +70,7 @@
     "scripts/agy-pre-push-review.sh",
     "scripts/agy-review.sh",
     "scripts/agy-review-output.schema.json",
+    "scripts/run-with-progress.sh",
     "scripts/github-api-resilience.cjs",
     "scripts/agy-triage-output.schema.json",
     "scripts/redact_automation_log.py",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -350,6 +350,10 @@
         "dest": "scripts/agy-review-output.schema.json"
       },
       {
+        "src": "scripts/run-with-progress.sh",
+        "dest": "scripts/run-with-progress.sh"
+      },
+      {
         "src": "scripts/github-api-resilience.cjs",
         "dest": "scripts/github-api-resilience.cjs"
       },

--- a/.github/workflows/antigravity-fleet-watcher.yml
+++ b/.github/workflows/antigravity-fleet-watcher.yml
@@ -312,13 +312,14 @@ jobs:
             'Do not review code, edit files, contact GitHub, or infer missing secrets.' \
             'Classify likely cause, cite only redacted evidence, and give the smallest next action.' \
             'Return one schema-valid entry for every JSON header in the failure logs.')
-          env -u GH_TOKEN -u GITHUB_TOKEN -u GATEWAY_TOKEN -u GATEWAY_URL \
-            agy --new-project --sandbox --mode plan --disable-slash-commands \
-            --add-dir "$RUNNER_TEMP/fleet-watch" \
-            --model "Gemini 3.6 Flash (High)" \
-            --output-format stream-json \
-            --json-schema "$GITHUB_WORKSPACE/scripts/agy-triage-output.schema.json" \
-            --print-timeout 25m --print "$prompt" >"$RUNNER_TEMP/triage.stream"
+          scripts/run-with-progress.sh --phase fleet-triage -- \
+            env -u GH_TOKEN -u GITHUB_TOKEN -u GATEWAY_TOKEN -u GATEWAY_URL \
+              agy --new-project --sandbox --mode plan --disable-slash-commands \
+              --add-dir "$RUNNER_TEMP/fleet-watch" \
+              --model "Gemini 3.6 Flash (High)" \
+              --output-format stream-json \
+              --json-schema "$GITHUB_WORKSPACE/scripts/agy-triage-output.schema.json" \
+              --print-timeout 25m --print "$prompt" >"$RUNNER_TEMP/triage.stream"
           jq -s -e '
             [.[] | select(.event == "result")] as $results |
             if ($results | length) != 1 then error("expected one result event")

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -80,8 +80,9 @@ jobs:
           test "$(git rev-parse refs/agy/pr-head)" = "$HEAD_SHA"
           tool_dir="$RUNNER_TEMP/agy-review-tool"
           mkdir -p "$tool_dir"
-          cp scripts/agy-review.sh scripts/agy-review-output.schema.json "$tool_dir/"
-          chmod 0555 "$tool_dir/agy-review.sh"
+          cp scripts/agy-review.sh scripts/run-with-progress.sh \
+            scripts/agy-review-output.schema.json "$tool_dir/"
+          chmod 0555 "$tool_dir/agy-review.sh" "$tool_dir/run-with-progress.sh"
           git checkout --detach "$HEAD_SHA"
           test "$(git rev-parse HEAD)" = "$HEAD_SHA"
 
@@ -130,8 +131,8 @@ jobs:
           AGY_REVIEW_SKIP_LOCAL_PII=1 \
             AGY_REVIEW_REPORT_FILE="$RUNNER_TEMP/review-artifact/report.json" \
             bash "$RUNNER_TEMP/agy-review-tool/agy-review.sh" code --base "$BASE_SHA" \
-            >"$RUNNER_TEMP/review.log" 2>&1
-          review_rc=$?
+            2>&1 | tee "$RUNNER_TEMP/review.log"
+          review_rc=${PIPESTATUS[0]}
           set -e
           printf '%s\n' "$review_rc" >"$RUNNER_TEMP/review-artifact/tool-status"
           if [ ! -s "$RUNNER_TEMP/review-artifact/report.json" ]; then

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -86,6 +86,8 @@ jobs:
             .agents/skills/i18n-translate/SKILL.md /opt/agy-translation-contract/SKILL.md
           sudo install -o root -g root -m 0555 \
             scripts/validate-translations.sh /opt/agy-translation-contract/validate-translations.sh
+          sudo install -o root -g root -m 0555 \
+            scripts/run-with-progress.sh /opt/agy-translation-contract/run-with-progress.sh
           git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:refs/agy/pr-head"
           test "$(git rev-parse refs/agy/pr-head)" = "$HEAD_SHA"
           git checkout --detach "$HEAD_SHA"
@@ -140,11 +142,12 @@ jobs:
             "Edit only corresponding Markdown or MDX files under the 12 locale directories." \
             "Do not run repository code, commit, push, contact GitHub, or read credentials." \
             "Preserve code, MDX structure, documentation-safe examples, and exact source hashes.")
-          env -u GH_TOKEN -u GITHUB_TOKEN -u GATEWAY_TOKEN -u GATEWAY_URL \
-            agy --new-project --sandbox --mode accept-edits --disable-slash-commands \
-            --add-dir /opt/agy-translation-contract \
-            --model "Gemini 3.6 Flash (High)" \
-            --print-timeout 25m --print "$prompt"
+          /opt/agy-translation-contract/run-with-progress.sh --phase translation-generation -- \
+            env -u GH_TOKEN -u GITHUB_TOKEN -u GATEWAY_TOKEN -u GATEWAY_URL \
+              agy --new-project --sandbox --mode accept-edits --disable-slash-commands \
+              --add-dir /opt/agy-translation-contract \
+              --model "Gemini 3.6 Flash (High)" \
+              --print-timeout 25m --print "$prompt"
           test "$(agy --version)" = "$AGY_VERSION"
           INNER
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,13 @@ closed. Each phase emits an immediate start marker, a periodic stderr heartbeat,
 marker so automation can distinguish a live silent model call from a finished review. This managed
 command is the semantic-review route.
 
+Every Antigravity model phase uses `scripts/run-with-progress.sh`. It emits a line-oriented
+`[PROGRESS]` record every 30 seconds with the component, phase, state, elapsed seconds, heartbeat
+interval, and UTC timestamp, followed by a terminal record with the real exit code. GitHub Actions
+streams those records into the live log while retaining the diagnostic log, and appends one terminal
+Markdown record to `GITHUB_STEP_SUMMARY`. Heartbeats report liveness only: the model print timeout
+and the workflow's `timeout-minutes` remain the authoritative execution bounds.
+
 Branch review is mandatory before every push that opens or updates a pull request:
 
 ```bash

--- a/scripts/agy-review.sh
+++ b/scripts/agy-review.sh
@@ -87,6 +87,7 @@ repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
 cd "$repo_root"
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 schema="$script_dir/agy-review-output.schema.json"
+progress_runner="$script_dir/run-with-progress.sh"
 
 for command in agy jq; do
   command -v "$command" >/dev/null 2>&1 || {
@@ -98,13 +99,10 @@ done
   echo "[review] output schema is unavailable: $schema" >&2
   exit 1
 }
-heartbeat_seconds=${AGY_REVIEW_HEARTBEAT_SECONDS:-30}
-case "$heartbeat_seconds" in
-'' | 0 | *[!0-9]*)
-  echo "[review] AGY_REVIEW_HEARTBEAT_SECONDS must be a positive integer" >&2
-  exit 2
-  ;;
-esac
+[ -x "$progress_runner" ] || {
+  echo "[review] progress runner is unavailable: $progress_runner" >&2
+  exit 1
+}
 
 target_description=""
 target_instructions=""
@@ -124,7 +122,8 @@ if [ "$mode" = code ]; then
     exit 0
   fi
   if [ "${AGY_REVIEW_SKIP_LOCAL_PII:-0}" != "1" ] && [ -x scripts/check-pii.sh ]; then
-    bash scripts/check-pii.sh --scope head --mode enforce
+    "$progress_runner" --phase pii-preflight -- \
+      bash scripts/check-pii.sh --scope head --mode enforce
   fi
   target_description="branch range ${base_sha}...${head_sha}"
 else
@@ -149,18 +148,8 @@ else
 fi
 
 work=$(mktemp -d "$repo_root/.agy-review.XXXXXX")
-agy_pid=""
-heartbeat_pid=""
 # shellcheck disable=SC2329 # invoked through the EXIT trap below
 cleanup() {
-  if [ -n "$heartbeat_pid" ]; then
-    kill "$heartbeat_pid" 2>/dev/null || true
-    wait "$heartbeat_pid" 2>/dev/null || true
-  fi
-  if [ -n "$agy_pid" ]; then
-    kill "$agy_pid" 2>/dev/null || true
-    wait "$agy_pid" 2>/dev/null || true
-  fi
   rm -rf -- "$work"
 }
 trap cleanup EXIT
@@ -180,30 +169,13 @@ fi
 
 invoke_agy() {
   local phase=$1 prompt_file=$2 stream_file=$3 result_file=$4
-  local agy_status=0 started_at=$SECONDS
-  printf '[review] %s started; waiting for Antigravity (heartbeat every %ss)\n' \
-    "$phase" "$heartbeat_seconds" >&2
-  env -u GH_TOKEN -u GITHUB_TOKEN -u REPO_SETTINGS_TOKEN -u REPO_SYNC_TOKEN \
+  if ! "$progress_runner" --phase "$phase" -- \
+    env -u GH_TOKEN -u GITHUB_TOKEN -u REPO_SETTINGS_TOKEN -u REPO_SYNC_TOKEN \
     -u GATEWAY_TOKEN -u GATEWAY_URL AGY_REVIEW_ACTIVE=1 \
     agy --new-project --sandbox --mode plan --disable-slash-commands \
     --model "Gemini 3.6 Flash (High)" \
     --output-format stream-json --json-schema "$schema" \
-    --print-timeout 25m --print "$(<"$prompt_file")" >"$stream_file" &
-  agy_pid=$!
-  (
-    while sleep "$heartbeat_seconds"; do
-      kill -0 "$agy_pid" 2>/dev/null || exit 0
-      printf '[review] %s still running (%ss elapsed)\n' \
-        "$phase" "$((SECONDS - started_at))" >&2
-    done
-  ) &
-  heartbeat_pid=$!
-  wait "$agy_pid" || agy_status=$?
-  agy_pid=""
-  kill "$heartbeat_pid" 2>/dev/null || true
-  wait "$heartbeat_pid" 2>/dev/null || true
-  heartbeat_pid=""
-  if [ "$agy_status" -ne 0 ]; then
+    --print-timeout 25m --print "$(<"$prompt_file")" >"$stream_file"; then
     echo "[review] Antigravity execution failed" >&2
     return 1
   fi

--- a/scripts/run-consumer-shell-tests.sh
+++ b/scripts/run-consumer-shell-tests.sh
@@ -140,15 +140,51 @@ duplicates=$(jq -r '[.unit[].path, .environment[].path][]' <<<"$profile" |
 [ -z "$duplicates" ] || die "duplicate test path in ${repo_name} profile: $duplicates"
 
 expected=$(jq -r '[.unit[].path, .environment[].path][]' <<<"$profile" | LC_ALL=C sort)
+deferred_managed_tests=""
 if [ "$discovered" != "$expected" ]; then
-  {
-    echo "::error::${repo_name} test inventory does not match its canonical profile"
-    echo "--- discovered tests"
-    printf '%s\n' "$discovered"
-    echo "--- configured tests"
-    printf '%s\n' "$expected"
-  } >&2
-  exit 1
+  unexpected=$(comm -23 \
+    <(printf '%s\n' "$discovered" | sed '/^$/d') \
+    <(printf '%s\n' "$expected" | sed '/^$/d'))
+  missing=$(comm -13 \
+    <(printf '%s\n' "$discovered" | sed '/^$/d') \
+    <(printf '%s\n' "$expected" | sed '/^$/d'))
+
+  bootstrap_transition=false
+  if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] &&
+    [[ "${GITHUB_HEAD_REF:-}" =~ ^sync/exact-caller-[0-9a-f]{40}(skipped|[0-9a-f]{40})[0-9a-f]{40}$ ]] &&
+    [ -z "$unexpected" ] && [ -n "$missing" ]; then
+    bootstrap_transition=true
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      if ! jq -e --arg path "$path" --arg repo "$repo_name" '
+        (.managed_files | type == "object") and
+        (.managed_files.files | type == "array") and
+        any(.managed_files.files[];
+          type == "object" and .dest == $path) and
+        (((.managed_files.skip_files // {})[$repo] // []) | index($path) == null)
+      ' "$CONFIG" >/dev/null 2>&1; then
+        bootstrap_transition=false
+        break
+      fi
+      deferred_managed_tests="${deferred_managed_tests}${path}"$'\n'
+    done <<<"$missing"
+  fi
+
+  if [ "$bootstrap_transition" = true ]; then
+    while IFS= read -r path; do
+      [ -n "$path" ] || continue
+      echo "::notice::Deferring managed test until synchronization: ${path}"
+    done <<<"$deferred_managed_tests"
+  else
+    {
+      echo "::error::${repo_name} test inventory does not match its canonical profile"
+      echo "--- discovered tests"
+      printf '%s\n' "$discovered"
+      echo "--- configured tests"
+      printf '%s\n' "$expected"
+    } >&2
+    exit 1
+  fi
 fi
 
 rc=0
@@ -157,6 +193,10 @@ index=0
 while [ "$index" -lt "$unit_count" ]; do
   path=$(jq -r --argjson index "$index" '.unit[$index].path' <<<"$profile")
   args_json=$(jq -c --argjson index "$index" '.unit[$index].args' <<<"$profile")
+  if grep -Fqx -- "$path" <<<"$deferred_managed_tests"; then
+    index=$((index + 1))
+    continue
+  fi
   if [ "$args_json" = "[]" ]; then
     run_one "$path" || rc=1
   else

--- a/scripts/run-with-progress.sh
+++ b/scripts/run-with-progress.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Run a long Antigravity phase with live, machine-readable progress heartbeats.
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --phase LABEL -- COMMAND [ARG ...]" >&2
+}
+
+phase=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --phase)
+    [ "$#" -ge 2 ] || {
+      usage
+      exit 2
+    }
+    phase=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+  esac
+done
+
+case "$phase" in
+'' | *[!A-Za-z0-9._-]*)
+  echo "[progress] phase must use only letters, digits, dot, underscore, or hyphen" >&2
+  exit 2
+  ;;
+esac
+[ "$#" -gt 0 ] || {
+  usage
+  exit 2
+}
+
+heartbeat_seconds=${AGY_PROGRESS_INTERVAL_SECONDS:-30}
+case "$heartbeat_seconds" in
+'' | 0 | *[!0-9]*)
+  echo "[progress] AGY_PROGRESS_INTERVAL_SECONDS must be a positive integer" >&2
+  exit 2
+  ;;
+esac
+
+started_epoch=$(date +%s)
+command_pid=""
+heartbeat_pid=""
+
+timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+elapsed_seconds() {
+  local now
+  now=$(date +%s)
+  printf '%s' "$((now - started_epoch))"
+}
+
+emit_progress() {
+  local state=$1 elapsed=$2 exit_code=${3:-}
+  if [ -n "$exit_code" ]; then
+    printf '[PROGRESS] component=antigravity phase=%s state=%s elapsed_seconds=%s heartbeat_seconds=%s timestamp=%s exit_code=%s\n' \
+      "$phase" "$state" "$elapsed" "$heartbeat_seconds" "$(timestamp)" "$exit_code" >&2
+  else
+    printf '[PROGRESS] component=antigravity phase=%s state=%s elapsed_seconds=%s heartbeat_seconds=%s timestamp=%s\n' \
+      "$phase" "$state" "$elapsed" "$heartbeat_seconds" "$(timestamp)" >&2
+  fi
+}
+
+append_summary() {
+  local state=$1 elapsed=$2 exit_code=$3 completed_at
+  [ -n "${GITHUB_STEP_SUMMARY:-}" ] || return 0
+  completed_at=$(timestamp)
+  if ! printf -- '- Antigravity `%s`: **%s** after `%ss` (exit code `%s`, completed `%s`).\n' \
+    "$phase" "$state" "$elapsed" "$exit_code" "$completed_at" >>"$GITHUB_STEP_SUMMARY"; then
+    printf '[PROGRESS] component=antigravity phase=%s state=summary-write-failed elapsed_seconds=%s heartbeat_seconds=%s timestamp=%s\n' \
+      "$phase" "$elapsed" "$heartbeat_seconds" "$completed_at" >&2
+  fi
+}
+
+# shellcheck disable=SC2329 # invoked through the EXIT trap below
+cleanup() {
+  if [ -n "$heartbeat_pid" ]; then
+    kill "$heartbeat_pid" 2>/dev/null || true
+    wait "$heartbeat_pid" 2>/dev/null || true
+  fi
+  if [ -n "$command_pid" ]; then
+    kill "$command_pid" 2>/dev/null || true
+    wait "$command_pid" 2>/dev/null || true
+  fi
+}
+
+# shellcheck disable=SC2329 # invoked through the signal traps below
+handle_signal() {
+  local status=$1 elapsed
+  trap - INT TERM HUP
+  elapsed=$(elapsed_seconds)
+  emit_progress interrupted "$elapsed" "$status"
+  append_summary interrupted "$elapsed" "$status"
+  exit "$status"
+}
+
+trap cleanup EXIT
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
+trap 'handle_signal 129' HUP
+
+emit_progress started 0
+"$@" &
+command_pid=$!
+(
+  while sleep "$heartbeat_seconds"; do
+    kill -0 "$command_pid" 2>/dev/null || exit 0
+    emit_progress running "$(elapsed_seconds)"
+  done
+) &
+heartbeat_pid=$!
+
+command_status=0
+wait "$command_pid" || command_status=$?
+command_pid=""
+kill "$heartbeat_pid" 2>/dev/null || true
+wait "$heartbeat_pid" 2>/dev/null || true
+heartbeat_pid=""
+
+elapsed=$(elapsed_seconds)
+if [ "$command_status" -eq 0 ]; then
+  emit_progress completed "$elapsed" 0
+  append_summary completed "$elapsed" 0
+else
+  emit_progress failed "$elapsed" "$command_status"
+  append_summary failed "$elapsed" "$command_status"
+fi
+exit "$command_status"

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -153,6 +153,16 @@ function testNoAppTokenRouting() {
   );
 }
 
+function testProgressRouting() {
+  const review = fs.readFileSync(reviewWorkflow, 'utf8');
+  const translation = fs.readFileSync(translationWorkflow, 'utf8');
+  const watcher = fs.readFileSync(watcherWorkflow, 'utf8');
+  assert.match(review, /cp scripts\/agy-review[.]sh scripts\/run-with-progress[.]sh/);
+  assert.match(review, /2>&1 \| tee "\$RUNNER_TEMP\/review[.]log"/);
+  assert.match(translation, /\/opt\/agy-translation-contract\/run-with-progress[.]sh --phase translation-generation/);
+  assert.match(watcher, /scripts\/run-with-progress[.]sh --phase fleet-triage/);
+}
+
 function writeExecutable(file, body) {
   fs.writeFileSync(file, body, { mode: 0o755 });
 }
@@ -266,6 +276,10 @@ function initializeExactHeadFixture() {
   fs.mkdirSync(path.join(repository, '.agents/skills/i18n-translate'), { recursive: true });
   fs.mkdirSync(path.join(repository, 'docs/en'), { recursive: true });
   writeExecutable(path.join(repository, 'scripts/agy-review.sh'), '#!/usr/bin/env bash\necho trusted-review-tool\n');
+  writeExecutable(
+    path.join(repository, 'scripts/run-with-progress.sh'),
+    '#!/usr/bin/env bash\necho trusted-progress-tool\n',
+  );
   fs.writeFileSync(path.join(repository, 'scripts/agy-review-output.schema.json'), '{}\n');
   writeExecutable(
     path.join(repository, 'scripts/validate-translations.sh'),
@@ -280,6 +294,10 @@ function initializeExactHeadFixture() {
   git(repository, 'push', '-q', 'origin', 'HEAD:refs/heads/main');
 
   fs.writeFileSync(path.join(repository, 'scripts/agy-review.sh'), '#!/usr/bin/env bash\necho untrusted-head-tool\n');
+  fs.writeFileSync(
+    path.join(repository, 'scripts/run-with-progress.sh'),
+    '#!/usr/bin/env bash\necho untrusted-head-progress-tool\n',
+  );
   fs.writeFileSync(
     path.join(repository, 'scripts/validate-translations.sh'),
     '#!/usr/bin/env bash\necho untrusted-head-validator\n',
@@ -332,9 +350,17 @@ async function testReviewerPreparation() {
   assert.equal(result.status, 0, result.stderr);
   assert.equal(git(fixture.repository, 'rev-parse', 'HEAD'), fixture.head);
   assert.match(fs.readFileSync(path.join(runner, 'agy-review-tool/agy-review.sh'), 'utf8'), /trusted-review-tool/);
+  assert.match(
+    fs.readFileSync(path.join(runner, 'agy-review-tool/run-with-progress.sh'), 'utf8'),
+    /trusted-progress-tool/,
+  );
   assert.doesNotMatch(
     fs.readFileSync(path.join(runner, 'agy-review-tool/agy-review.sh'), 'utf8'),
     /untrusted-head-tool/,
+  );
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(runner, 'agy-review-tool/run-with-progress.sh'), 'utf8'),
+    /untrusted-head-progress-tool/,
   );
 
   const forkFixture = initializeExactHeadFixture();
@@ -410,6 +436,11 @@ async function testTranslationPreparation() {
   assert.doesNotMatch(
     fs.readFileSync(path.join(prepared.installed, 'validate-translations.sh'), 'utf8'),
     /untrusted-head/,
+  );
+  assert.match(fs.readFileSync(path.join(prepared.installed, 'run-with-progress.sh'), 'utf8'), /trusted-progress-tool/);
+  assert.doesNotMatch(
+    fs.readFileSync(path.join(prepared.installed, 'run-with-progress.sh'), 'utf8'),
+    /untrusted-head-progress-tool/,
   );
 
   const forkFixture = initializeExactHeadFixture();
@@ -525,6 +556,7 @@ function runReviewerModel({ fail = false, missingSecret = false } = {}) {
     `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >"$RUNNER_TEMP/review-invocation"
+printf '%s\n' '[PROGRESS] component=antigravity phase=fixture state=running elapsed_seconds=1' >&2
 if [ "\${STUB_REVIEW_FAIL:-false}" = true ]; then
   exit 19
 fi
@@ -565,6 +597,7 @@ function runReviewGate(report) {
 function testReviewerModelAndGate() {
   const completed = runReviewerModel();
   assert.equal(completed.result.status, 0, completed.result.stderr);
+  assert.match(completed.result.stdout, /component=antigravity phase=fixture state=running/);
   assert.equal(
     fs.readFileSync(path.join(completed.work, 'review-invocation'), 'utf8').trim(),
     `code --base ${'b'.repeat(40)}`,
@@ -694,7 +727,11 @@ printf '%s|%s|%s|%s\n' "\${GH_TOKEN:-}" "\${GITHUB_TOKEN:-}" "\${GATEWAY_TOKEN:-
   );
   const changedEnglish = path.join(work, 'changed-english.txt');
   fs.writeFileSync(changedEnglish, 'docs/en/page.mdx\n');
-  const result = runShell(extractStepBlock(translationWorkflow, 'Generate translations without write credentials'), {
+  const script = extractStepBlock(translationWorkflow, 'Generate translations without write credentials').replace(
+    '/opt/agy-translation-contract/run-with-progress.sh',
+    path.join(root, 'scripts/run-with-progress.sh'),
+  );
+  const result = runShell(script, {
     cwd: work,
     env: {
       AGY_VERSION: '1.1.10',
@@ -1008,6 +1045,7 @@ assert.notEqual(
 
 await testReviewerPreparation();
 testNoAppTokenRouting();
+testProgressRouting();
 await testTranslationPreparation();
 testPinnedInstallers();
 testReviewerModelAndGate();

--- a/tests/test-agy-pre-push-review.sh
+++ b/tests/test-agy-pre-push-review.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 PRE_PUSH="$REPO_ROOT/scripts/agy-pre-push-review.sh"
 REVIEW="$REPO_ROOT/scripts/agy-review.sh"
+PROGRESS="$REPO_ROOT/scripts/run-with-progress.sh"
 SCHEMA="$REPO_ROOT/scripts/agy-review-output.schema.json"
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -26,7 +27,7 @@ setup_repo() {
   git -C "$WORK/repo" init -q
   git -C "$WORK/repo" config user.email test@example.com
   git -C "$WORK/repo" config user.name Test
-  cp "$REVIEW" "$SCHEMA" "$PRE_PUSH" "$WORK/repo/scripts/"
+  cp "$REVIEW" "$PROGRESS" "$SCHEMA" "$PRE_PUSH" "$WORK/repo/scripts/"
   printf 'base\n' >"$WORK/repo/file.txt"
   git -C "$WORK/repo" add .
   git -C "$WORK/repo" commit -qm base
@@ -81,6 +82,49 @@ run_review() {
 }
 
 echo "Antigravity local review tests"
+
+progress_rc=0
+AGY_PROGRESS_INTERVAL_SECONDS=1 GITHUB_STEP_SUMMARY="$WORK/progress-summary" \
+  bash "$PROGRESS" --phase fixture-review -- bash -c 'sleep 2' \
+  >"$WORK/progress-output" 2>&1 || progress_rc=$?
+if [ "$progress_rc" -eq 0 ] &&
+  grep -Eq '^\[PROGRESS\] component=antigravity phase=fixture-review state=started elapsed_seconds=0 heartbeat_seconds=1 timestamp=[-0-9TZ:]+$' "$WORK/progress-output" &&
+  grep -Eq '^\[PROGRESS\] component=antigravity phase=fixture-review state=running elapsed_seconds=[1-9][0-9]* heartbeat_seconds=1 timestamp=[-0-9TZ:]+$' "$WORK/progress-output" &&
+  grep -Eq '^\[PROGRESS\] component=antigravity phase=fixture-review state=completed elapsed_seconds=[1-9][0-9]* heartbeat_seconds=1 timestamp=[-0-9TZ:]+ exit_code=0$' "$WORK/progress-output" &&
+  grep -q 'fixture-review.*completed.*exit code.*0' "$WORK/progress-summary"; then
+  pass "progress runner emits structured live heartbeats and a durable terminal summary"
+else
+  fail "progress runner emits structured live heartbeats and a durable terminal summary" \
+    "rc=$progress_rc; $(cat "$WORK/progress-output" 2>/dev/null || true)"
+fi
+
+progress_rc=0
+AGY_PROGRESS_INTERVAL_SECONDS=1 bash "$PROGRESS" --phase fixture-failure -- \
+  bash -c 'exit 19' >"$WORK/progress-output" 2>&1 || progress_rc=$?
+if [ "$progress_rc" -eq 19 ] &&
+  grep -Eq 'phase=fixture-failure state=failed .* exit_code=19$' "$WORK/progress-output"; then
+  pass "progress runner preserves failures and reports their terminal state"
+else
+  fail "progress runner preserves failures and reports their terminal state" \
+    "rc=$progress_rc; $(cat "$WORK/progress-output" 2>/dev/null || true)"
+fi
+
+progress_rc=0
+AGY_PROGRESS_INTERVAL_SECONDS=1 bash "$PROGRESS" --phase fixture-interrupt -- \
+  bash -c 'sleep 30' >"$WORK/progress-output" 2>&1 &
+progress_pid=$!
+sleep 1
+kill -TERM "$progress_pid"
+wait "$progress_pid" || progress_rc=$?
+if [ "$progress_rc" -eq 143 ] &&
+  grep -Eq 'phase=fixture-interrupt state=interrupted .* exit_code=143$' \
+    "$WORK/progress-output"; then
+  pass "progress runner reports interruption and preserves the signal exit code"
+else
+  fail "progress runner reports interruption and preserves the signal exit code" \
+    "rc=$progress_rc; $(cat "$WORK/progress-output" 2>/dev/null || true)"
+fi
+
 setup_repo
 if run_review "$WORK/bin:$PATH" env GATEWAY_TOKEN=private GITHUB_TOKEN=private \
   FAKE_AGY_BUNDLE_CAPTURE="$WORK/review-bundle" &&
@@ -108,11 +152,13 @@ fi
 
 setup_repo
 if run_review "$WORK/bin:$PATH" env FAKE_AGY_DELAY_CALL=1 FAKE_AGY_DELAY_SECONDS=2 \
-  AGY_REVIEW_HEARTBEAT_SECONDS=1 &&
-  grep -q '\[review\] reviewer started; waiting for Antigravity' "$WORK/output" &&
-  grep -q '\[review\] reviewer still running (' "$WORK/output" &&
+  AGY_PROGRESS_INTERVAL_SECONDS=1 &&
+  grep -q 'component=antigravity phase=reviewer state=started' "$WORK/output" &&
+  grep -q 'component=antigravity phase=reviewer state=running' "$WORK/output" &&
+  grep -q 'component=antigravity phase=reviewer state=completed' "$WORK/output" &&
   grep -q '\[review\] reviewer completed; validating structured output' "$WORK/output" &&
-  grep -q '\[review\] verifier started; waiting for Antigravity' "$WORK/output" &&
+  grep -q 'component=antigravity phase=verifier state=started' "$WORK/output" &&
+  grep -q 'component=antigravity phase=verifier state=completed' "$WORK/output" &&
   grep -q '\[review\] verifier completed; validating structured output' "$WORK/output"; then
   pass "review wrapper emits phase start, heartbeat, and completion progress"
 else

--- a/tests/test-consumer-shell-tests.sh
+++ b/tests/test-consumer-shell-tests.sh
@@ -44,7 +44,9 @@ assert_contains() {
 run_selector() {
   local root="$1" config="$2" repository="$3"
   LAST_RC=0
-  LAST_OUTPUT=$(TEST_LOG="${root}/executed.log" bash "$RUNNER" \
+  LAST_OUTPUT=$(GITHUB_EVENT_NAME="${SELECTOR_EVENT_NAME:-}" \
+    GITHUB_HEAD_REF="${SELECTOR_HEAD_REF:-}" \
+    TEST_LOG="${root}/executed.log" bash "$RUNNER" \
     --root "$root" --config "$config" --repository "$repository" 2>&1) || LAST_RC=$?
 }
 
@@ -133,6 +135,79 @@ write_probe "$root" test-unit.sh
 run_selector "$root" "$config" f5-sales-demo/profiled
 assert_rc 1 "missing classified test fails the profile"
 assert_contains "inventory does not match" "missing-test failure explains the drift"
+
+# Exact-caller bootstrap can precede managed-file delivery. Only a missing test
+# declared by the canonical managed-file inventory may be deferred, and only on
+# the strictly formed generated receipt branch.
+bootstrap_branch="sync/exact-caller-$(printf 'a%.0s' {1..120})"
+config=$(write_config bootstrap-managed '{
+  "managed_files": {
+    "files": [
+      {"src":"tests/test-managed.sh","dest":"tests/test-managed.sh"}
+    ],
+    "skip_files": {}
+  },
+  "consumer_shell_tests": {
+    "profiles": {
+      "bootstrap-managed": {
+        "unit": [
+          {"path":"tests/test-present.sh","args":[]},
+          {"path":"tests/test-managed.sh","args":[]}
+        ],
+        "environment": []
+      }
+    }
+  }
+}')
+
+root=$(new_root bootstrap-managed)
+write_probe "$root" test-present.sh
+SELECTOR_EVENT_NAME=pull_request SELECTOR_HEAD_REF="$bootstrap_branch" \
+  run_selector "$root" "$config" f5-sales-demo/bootstrap-managed
+assert_rc 0 "exact-caller bootstrap defers a missing canonically managed test"
+assert_contains "Deferring managed test until synchronization: tests/test-managed.sh" \
+  "managed-test deferral is visible"
+actual=$(cat "${root}/executed.log" 2>/dev/null || true)
+if [ "$actual" = "test-present.sh:" ]; then
+  pass "bootstrap transition still runs every present unit test"
+else
+  fail "bootstrap transition still runs every present unit test" "got: $actual"
+fi
+
+SELECTOR_EVENT_NAME=pull_request SELECTOR_HEAD_REF=feature/not-generated \
+  run_selector "$root" "$config" f5-sales-demo/bootstrap-managed
+assert_rc 1 "ordinary pull requests cannot defer a managed test"
+assert_contains "inventory does not match" "ordinary pull request stays fail-closed"
+
+config=$(write_config bootstrap-unmanaged '{
+  "managed_files": {"files": [], "skip_files": {}},
+  "consumer_shell_tests": {
+    "profiles": {
+      "bootstrap-unmanaged": {
+        "unit": [
+          {"path":"tests/test-present.sh","args":[]},
+          {"path":"tests/test-unmanaged.sh","args":[]}
+        ],
+        "environment": []
+      }
+    }
+  }
+}')
+root=$(new_root bootstrap-unmanaged)
+write_probe "$root" test-present.sh
+SELECTOR_EVENT_NAME=pull_request SELECTOR_HEAD_REF="$bootstrap_branch" \
+  run_selector "$root" "$config" f5-sales-demo/bootstrap-unmanaged
+assert_rc 1 "exact-caller bootstrap cannot defer an unmanaged test"
+assert_contains "inventory does not match" "unmanaged missing test stays fail-closed"
+
+root=$(new_root bootstrap-extra)
+write_probe "$root" test-present.sh
+write_probe "$root" test-unclassified.sh
+SELECTOR_EVENT_NAME=pull_request SELECTOR_HEAD_REF="$bootstrap_branch" \
+  run_selector "$root" "$config" f5-sales-demo/bootstrap-unmanaged
+assert_rc 1 "exact-caller bootstrap cannot hide an unclassified test"
+assert_contains "inventory does not match" "extra test stays fail-closed during bootstrap"
+unset SELECTOR_EVENT_NAME SELECTOR_HEAD_REF
 
 # Duplicate and unsafe paths are rejected even if the inventory could otherwise match.
 root=$(new_root duplicate)

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -63,6 +63,8 @@ contains "$REPO_ROOT/CLAUDE.md" 'scripts/agy-review.sh document' \
   "CLAUDE routes specs and plans directly to agy"
 contains "$REPO_ROOT/CONTRIBUTING.md" 'scripts/agy-review.sh document' \
   "CONTRIBUTING routes specs and plans directly to agy"
+contains "$REPO_ROOT/scripts/agy-review.sh" '--phase pii-preflight' \
+  "Antigravity review reports deterministic PII preflight progress"
 
 for mapping in \
   'workflows/code-review.yml|.github/workflows/code-review.yml' \
@@ -86,6 +88,7 @@ MANAGED_REVIEW_FILES=(
   scripts/agy-pre-push-review.sh
   scripts/agy-review.sh
   scripts/agy-review-output.schema.json
+  scripts/run-with-progress.sh
   scripts/validate-translations.sh
   tests/test-agy-pre-push-review.sh
   tests/test-validate-translations.sh
@@ -120,6 +123,18 @@ rejects "$REVIEW_WORKFLOW" 'context.issue.number' \
   "Antigravity reusable workflow does not depend on event issue context"
 contains "$REVIEW_WORKFLOW" 'const findings = [...new Map(' \
   "Antigravity review comments deduplicate independently verified findings"
+contains "$REVIEW_WORKFLOW" 'cp scripts/agy-review.sh scripts/run-with-progress.sh' \
+  "Antigravity review captures the trusted progress runner before head checkout"
+contains "$REVIEW_WORKFLOW" '2>&1 | tee "$RUNNER_TEMP/review.log"' \
+  "Antigravity review streams live progress while retaining its diagnostic log"
+
+TRANSLATION_WORKFLOW="$REPO_ROOT/.github/workflows/antigravity-translate.yml"
+contains "$TRANSLATION_WORKFLOW" \
+  'scripts/run-with-progress.sh /opt/agy-translation-contract/run-with-progress.sh' \
+  "Antigravity translation installs the trusted progress runner before head checkout"
+contains "$TRANSLATION_WORKFLOW" \
+  '/opt/agy-translation-contract/run-with-progress.sh --phase translation-generation' \
+  "Antigravity translation emits structured generation heartbeats"
 
 contains "$REPO_ROOT/.gitignore" '.agy-review.*' \
   "Antigravity temporary review directories are ignored"
@@ -136,6 +151,8 @@ done
 contains "$WATCHER" 'GitHub Free-compatible' "watcher declares its GitHub Free contract"
 contains "$WATCHER" 'python3 scripts/redact_automation_log.py' \
   "watcher redacts logs with the tested trusted helper"
+contains "$WATCHER" 'scripts/run-with-progress.sh --phase fleet-triage' \
+  "watcher triage emits structured model heartbeats"
 
 REDACTOR="$REPO_ROOT/scripts/redact_automation_log.py"
 redacted=$(printf '%s\n' \


### PR DESCRIPTION
## Summary

- defer only newly managed consumer tests during strictly formed exact-caller bootstrap PRs
- add a shared 30-second structured Antigravity progress protocol with terminal step summaries
- stream review progress while retaining diagnostics and cover review, translation, and fleet triage
- add focused fail-closed selector tests and exact-head CI UAT

## Verification

- `bash scripts/run-consumer-shell-tests.sh --root . --config .github/config/repo-settings.json --repository f5-sales-demo/docs-control` — all 34 shell test files passed
- `node tests/antigravity-ci-feature-uat.mjs .` — passed
- `pre-commit run --all-files` — passed all hooks
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean
- `bash scripts/agy-pre-push-review.sh` on `6973c99` — reviewer/verifier passed; no critical or high finding remains

Closes #1271