### PR TITLE
fix: restore managed sync pagination

### DIFF
--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -615,11 +615,12 @@ jobs:
           select_owned_stale_issues() {
             jq -r '
               if type != "array" or
-                any(.[]; (.number | type != "number" or floor != . or . < 1) or
+                any(.[]; type != "array") or
+                any(.[][]; (.number | type != "number" or floor != . or . < 1) or
                   (.title | type != "string") or (.body | type != "string"))
               then error("invalid issue inventory")
               else
-                .[] |
+                .[][] |
                 select(.title == "chore: sync managed files from governance template") |
                 select(.body | contains("This issue was created automatically by the governance enforcement workflow.")) |
                 .number
@@ -1359,7 +1360,7 @@ jobs:
                 STALE_ISSUE_INVENTORY=$(mktemp)
                 if ! retry 3 gh api --paginate --slurp \
                   "repos/${OWNER}/${REPO}/issues?state=open&per_page=100" \
-                  --jq 'add' >"$STALE_ISSUE_INVENTORY"; then
+                  >"$STALE_ISSUE_INVENTORY"; then
                   echo "[ERROR] Could not inventory stale sync issues" >&2
                   rm -f "$STALE_ISSUE_INVENTORY"
                   exit 1

--- a/tests/test-sync-managed-files.sh
+++ b/tests/test-sync-managed-files.sh
@@ -972,6 +972,23 @@ else
     "free-text search results can still close unrelated issues"
 fi
 
+awk '
+  /select_owned_stale_issues\(\)/ { found=1 }
+  found { print }
+  found && /^          }$/ { exit }
+' "$SYNC" >"$WORK/stale-issue-selector.sh"
+if grep -qE 'gh api --paginate --slurp .*issues\?state=open&per_page=100.*--jq' \
+  "$WORK/sync-joined.txt"; then
+  fail "8.11 stale issue pagination is compatible with GitHub CLI" \
+    "gh api combines --slurp with --jq, which current GitHub CLI rejects"
+elif grep -q 'any(.\[\]; type != "array")' "$WORK/stale-issue-selector.sh" &&
+  grep -q 'any(.\[\]\[\];' "$WORK/stale-issue-selector.sh"; then
+  pass "8.11 stale issue pagination is compatible with GitHub CLI"
+else
+  fail "8.11 stale issue pagination is compatible with GitHub CLI" \
+    "the local selector does not validate and iterate every paginated response page"
+fi
+
 echo ""
 echo "=== Section 9: generated Dependabot updates enforce cooldown ==="
 


### PR DESCRIPTION
## Summary

Restore fleet managed-file propagation on the current GitHub CLI by keeping paginated issue responses as a validated array of pages and flattening them only inside the trusted local selector.

Closes #1277

## Changes

- Remove the incompatible `--jq 'add'` option from the `gh api --paginate --slurp` stale-issue inventory call.
- Validate that every slurped response page is an array and every issue row has the required shape before selecting exact automation-owned issues.
- Add a regression that rejects the unsupported `--slurp` plus `--jq` command and requires nested-page validation and iteration.

## Verification evidence

- Red phase: `bash tests/test-sync-managed-files.sh` — 72 passed, 1 expected failure at the new GitHub CLI compatibility guard.
- Green phase: `bash tests/test-sync-managed-files.sh` — 73 passed, 0 failed.
- `for test_path in tests/test-*.sh; do bash "$test_path" || exit; done` — all 34 shell test scripts passed.
- `pre-commit run --files .github/workflows/sync-managed-files.yml tests/test-sync-managed-files.sh` — all applicable hooks passed.
- `gh api --paginate --slurp 'repos/f5-sales-demo/docs-control/issues?state=open&per_page=100' | jq ...` — current CLI returned a validated array of issue pages without `--jq`.
- `bash scripts/agy-pre-push-review.sh` — PII enforce clean; Antigravity gate passed with no critical or high finding on exact head `b0de79af4b0fafd612ce177222edee085d75df60`.

## Delivery evidence

- Original failing downstream runs: docs-builder `31054533606`, docs-theme `31054533605`.
- Dispatcher that exposed the shared failure: `31052054755`.
- Governed workflow pin and manifest roll-forward will follow this merge before enforcement is re-dispatched.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified
- [x] Tests written first and passing
- [x] Exact-HEAD Antigravity review passed before push
- [ ] Required CI reaches green and PR reaches `MERGED`
- [ ] Governed pin, manifest, downstream propagation, and fleet convergence complete
