### PR TITLE
fix: stop downstream fixture recursion

### DIFF
--- a/tests/test-github-api-resilience.sh
+++ b/tests/test-github-api-resilience.sh
@@ -434,7 +434,7 @@ check 'retry helper is governance-protected' jq -e \
   '.protected_files | index("scripts/github-api-resilience.cjs") != null' \
   "$repo_root/.claude/governance.json"
 
-if [ "${GITHUB_API_RESILIENCE_FIXTURE_MODE:-0}" != "1" ]; then
+if [ -f "$repo_settings" ]; then
   downstream_fixture=$(mktemp -d)
   trap 'rm -rf "$downstream_fixture"' EXIT
   mkdir -p \
@@ -461,8 +461,7 @@ if [ "${GITHUB_API_RESILIENCE_FIXTURE_MODE:-0}" != "1" ]; then
     "$downstream_fixture/.github/workflows/antigravity-translate.yml"
 
   if downstream_output=$(cd "$downstream_fixture" &&
-    GITHUB_API_RESILIENCE_FIXTURE_MODE=1 \
-      bash tests/test-github-api-resilience.sh 2>&1); then
+    bash tests/test-github-api-resilience.sh 2>&1); then
     printf '[OK] downstream-shaped managed checkout passes\n'
   else
     printf '%s\n' "$downstream_output" >&2
@@ -508,8 +507,7 @@ path.write_text(mutated, encoding="utf-8")
 PY
     if (
       cd "$downstream_fixture"
-      GITHUB_API_RESILIENCE_FIXTURE_MODE=1 \
-        bash tests/test-github-api-resilience.sh >/dev/null 2>&1
+      bash tests/test-github-api-resilience.sh >/dev/null 2>&1
     ); then
       printf '[FAIL] %s\n' "$label" >&2
       fail=1


### PR DESCRIPTION
## Summary

- construct the downstream-shaped API-resilience fixture only in docs-control
- remove the synthetic GITHUB_API_RESILIENCE_FIXTURE_MODE recursion switch as a clean break
- execute the nested fixture exactly like real downstream CI, where source-only workflows/ files are absent

## Fleet UAT evidence

The prior rollout reached docs-builder PR #984. Its caller contracts passed, then Shell Unit Tests failed because the downstream checkout attempted to copy absent workflows/ source files. This patch reproduces that path locally without a mode variable and makes it pass by using the authoritative docs-control repo-settings source predicate.

## Verification

- red reproduction: bash tests/test-github-api-resilience.sh failed with cannot stat workflows/antigravity-review.yml after both downstream caller contracts passed
- bash tests/test-github-api-resilience.sh — passed after the fix, including downstream positive and negative UAT
- all 34 tests/test-*.sh files — passed
- pre-commit run --all-files — passed
- bash scripts/agy-pre-push-review.sh — passed for c46cd24424367916e974c242880a8e664a546361; no critical or high finding remains

Closes #1288