### PR TITLE
fix: make downstream dispatch rate-limit durable

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -41,6 +41,7 @@ jobs:
   dispatch:
     name: Dispatch downstream enforcement
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     environment: repository-settings
     # No conclusion guard needed: dispatch now fires only when the manifest has
     # already landed on main. A bad manifest fails the sync/manifest PR's checks
@@ -57,6 +58,7 @@ jobs:
           REPO_SETTINGS_TOKEN: ${{ secrets.REPO_SETTINGS_TOKEN }}
           REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
           PROVISION_REQUEST_DELAY_SECONDS: 2
+          DISPATCH_WAIT_BUDGET_SECONDS: 900
           SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -179,24 +181,26 @@ jobs:
 
           dispatch_one() {
             local repo="$1"
-            local attempt=1
-            local max=3
-            local delay=2
-            while true; do
-              if gh workflow run enforce-repo-settings.yml \
-                  --repo "$repo" \
-                  -f source_sha="$SOURCE_SHA" >/dev/null 2>&1; then
-                printf '[OK]   %s\n' "$repo"
-                return 0
-              fi
-              if [ "$attempt" -ge "$max" ]; then
-                printf '[FAIL] %s\n' "$repo"
-                return 1
-              fi
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay * 2))
-            done
+            local result_file="$2"
+            local rc
+            set +e
+            node scripts/github-api-resilience.cjs dispatch "$repo" "$SOURCE_SHA"
+            rc=$?
+            set -e
+            case "$rc" in
+              0)
+                printf 'ok\n' >"$result_file"
+                ;;
+              84)
+                printf '[DEFER] %s exhausted its bounded GitHub cooldown budget\n' "$repo"
+                printf 'defer\n' >"$result_file"
+                ;;
+              *)
+                printf '[FAIL] %s returned non-retryable dispatch error rc=%d\n' "$repo" "$rc"
+                printf 'fail\n' >"$result_file"
+                ;;
+            esac
+            return 0
           }
           export -f dispatch_one
 
@@ -209,13 +213,15 @@ jobs:
           BATCH_SIZE=5
           # Seven fan-out gaps consume 140 seconds. Combined with the 37
           # two-second repository-secret inventory gaps, deterministic waits
-          # consume 214 seconds and leave 86 seconds of the runner's
-          # five-minute budget for API work and retries.
+          # consume 214 seconds. One complete 900-second secondary cooldown
+          # still leaves more than eleven minutes inside the 30-minute bound.
           BATCH_DELAY=20
           echo "Dispatching enforce-repo-settings to ${TOTAL} repos (batches of ${BATCH_SIZE}, ${BATCH_DELAY}s delay)..."
 
-          LOG=$(mktemp)
+          RESULTS=$(mktemp -d)
+          trap 'rm -rf "$RESULTS"' EXIT
           FAIL_COUNT=0
+          DEFER_COUNT=0
           batch=0
 
           for ((i = 0; i < TOTAL; i += BATCH_SIZE)); do
@@ -224,18 +230,45 @@ jobs:
             echo ""
             echo "--- Batch ${batch} (repos $((i+1))-$((i+${#batch_repos[@]})) of ${TOTAL}) ---"
 
+            result_files=()
+            result_index=0
             for repo in "${batch_repos[@]}"; do
-              dispatch_one "$repo" >> "$LOG" 2>&1 &
+              result_file="$RESULTS/${batch}-${result_index}"
+              result_files+=("$result_file")
+              dispatch_one "$repo" "$result_file" &
+              result_index=$((result_index + 1))
             done
             wait
 
-            # Show batch results
-            cat "$LOG"
-
-            # Count failures so far
-            BATCH_FAILS=$(grep -c '^\[FAIL\]' "$LOG" || true)
+            BATCH_FAILS=0
+            BATCH_DEFERS=0
+            for result_file in "${result_files[@]}"; do
+              if [ ! -s "$result_file" ]; then
+                echo "::error::A dispatch worker did not emit a terminal result"
+                BATCH_FAILS=$((BATCH_FAILS + 1))
+                continue
+              fi
+              case "$(cat "$result_file")" in
+                ok) ;;
+                defer) BATCH_DEFERS=$((BATCH_DEFERS + 1)) ;;
+                fail) BATCH_FAILS=$((BATCH_FAILS + 1)) ;;
+                *)
+                  echo "::error::A dispatch worker emitted an invalid terminal result"
+                  BATCH_FAILS=$((BATCH_FAILS + 1))
+                  ;;
+              esac
+            done
             FAIL_COUNT=$((FAIL_COUNT + BATCH_FAILS))
-            : > "$LOG"
+            DEFER_COUNT=$((DEFER_COUNT + BATCH_DEFERS))
+
+            if [ "$FAIL_COUNT" -gt 0 ]; then
+              echo "::error::${FAIL_COUNT} non-retryable dispatch(es) failed"
+              exit 1
+            fi
+            if [ "$DEFER_COUNT" -gt 0 ]; then
+              echo "[DEFER] ${DEFER_COUNT} dispatch(es) exhausted the bounded wait budget; scheduled recovery is active"
+              exit 0
+            fi
 
             # Delay between batches (skip after last)
             remaining=$((TOTAL - i - ${#batch_repos[@]}))
@@ -244,12 +277,6 @@ jobs:
               sleep "$BATCH_DELAY"
             fi
           done
-
-          if [ "${FAIL_COUNT}" -gt 0 ]; then
-            echo ""
-            echo "::error::${FAIL_COUNT} dispatch(es) failed"
-            exit 1
-          fi
 
           echo ""
           echo "All ${TOTAL} dispatches succeeded."

--- a/scripts/github-api-resilience.cjs
+++ b/scripts/github-api-resilience.cjs
@@ -265,17 +265,26 @@ async function requestGitHubApi(endpoint, options = {}) {
   const pages = [];
   let url = startUrl;
   do {
-    const page = await retryGitHub(() => requestPage(url), {
-      operationName: options.operationName ?? `GET ${endpoint}`,
-      maxAttempts: options.maxAttempts,
-      totalWaitBudgetSeconds: options.totalWaitBudgetSeconds,
-      readPrimaryRateLimit: rateLimit,
-      onProgress: options.onProgress,
-      sleepSeconds: options.sleepSeconds,
-      nowSeconds: options.nowSeconds,
-      jitterSeconds: options.jitterSeconds,
-      random: options.random,
-    });
+    const page = await retryGitHub(
+      async ({ attempt, maxAttempts }) => {
+        if (attempt > 1 && typeof options.recover === 'function') {
+          const recovered = await options.recover({ attempt, maxAttempts, url });
+          if (recovered !== undefined) return { data: recovered, link: null };
+        }
+        return requestPage(url);
+      },
+      {
+        operationName: options.operationName ?? `GET ${endpoint}`,
+        maxAttempts: options.maxAttempts,
+        totalWaitBudgetSeconds: options.totalWaitBudgetSeconds,
+        readPrimaryRateLimit: rateLimit,
+        onProgress: options.onProgress,
+        sleepSeconds: options.sleepSeconds,
+        nowSeconds: options.nowSeconds,
+        jitterSeconds: options.jitterSeconds,
+        random: options.random,
+      },
+    );
     pages.push(page.data);
     if (!options.paginate) break;
     const next = /<([^>]+)>;\s*rel="next"/.exec(page.link ?? '');
@@ -285,19 +294,125 @@ async function requestGitHubApi(endpoint, options = {}) {
   return pages.flat();
 }
 
+const ENFORCEMENT_WORKFLOW = 'enforce-repo-settings.yml';
+const ENFORCEMENT_RUN_PREFIX = 'Enforce Repository Settings @ ';
+
+function workflowDispatchTitle(sourceSha) {
+  return `${ENFORCEMENT_RUN_PREFIX}${sourceSha}`;
+}
+
+function validateDispatchIdentity(repository, sourceSha) {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository ?? '')) {
+    throw new Error('workflow dispatch repository is invalid');
+  }
+  if (!/^[0-9a-f]{40}$/.test(sourceSha ?? '')) {
+    throw new Error('workflow dispatch source SHA is invalid');
+  }
+}
+
+function requestOptions(options, overrides = {}) {
+  return {
+    token: options.token,
+    fetch: options.fetch,
+    maxAttempts: options.maxAttempts,
+    totalWaitBudgetSeconds: options.totalWaitBudgetSeconds,
+    sleepSeconds: options.sleepSeconds,
+    nowSeconds: options.nowSeconds,
+    jitterSeconds: options.jitterSeconds,
+    random: options.random,
+    onProgress: options.onProgress,
+    ...overrides,
+  };
+}
+
+async function findWorkflowDispatchReceipt(options) {
+  const title = workflowDispatchTitle(options.sourceSha);
+  const endpoint =
+    `repos/${options.repository}/actions/workflows/${ENFORCEMENT_WORKFLOW}/runs` +
+    '?event=workflow_dispatch&branch=main&per_page=100';
+  const data = await requestGitHubApi(
+    endpoint,
+    requestOptions(options, {
+      maxAttempts: options.receiptMaxAttempts ?? 2,
+      totalWaitBudgetSeconds: options.receiptWaitBudgetSeconds ?? 60,
+      operationName: `inspect exact-source dispatch receipt for ${options.repository}`,
+    }),
+  );
+  if (!data || !Array.isArray(data.workflow_runs)) {
+    throw new Error(`GitHub returned an invalid workflow-run inventory for ${options.repository}`);
+  }
+  const usable = data.workflow_runs
+    .filter((run) => run?.event === 'workflow_dispatch' && run?.display_title === title)
+    .filter(
+      (run) =>
+        ['queued', 'in_progress', 'waiting', 'requested', 'pending'].includes(run?.status) ||
+        (run?.status === 'completed' && run?.conclusion === 'success'),
+    )
+    .sort((left, right) => Number(right.id ?? 0) - Number(left.id ?? 0));
+  return usable[0];
+}
+
+async function dispatchWorkflow(options = {}) {
+  const repository = options.repository;
+  const sourceSha = options.sourceSha;
+  validateDispatchIdentity(repository, sourceSha);
+  if (!options.token) throw new Error('GitHub API token is required');
+
+  const shared = { ...options, repository, sourceSha };
+  const existing = await findWorkflowDispatchReceipt(shared);
+  if (existing) return { state: 'existing', run: existing };
+
+  let recoveredReceipt;
+  await requestGitHubApi(
+    `repos/${repository}/actions/workflows/${ENFORCEMENT_WORKFLOW}/dispatches`,
+    requestOptions(options, {
+      method: 'POST',
+      body: { ref: 'main', inputs: { source_sha: sourceSha } },
+      operationName: `dispatch exact-source enforcement to ${repository}`,
+      recover: async () => {
+        const receipt = await findWorkflowDispatchReceipt(shared);
+        if (!receipt) return undefined;
+        recoveredReceipt = receipt;
+        return { recovered: true, run: receipt };
+      },
+    }),
+  );
+  if (recoveredReceipt) return { state: 'recovered', run: recoveredReceipt };
+  return { state: 'dispatched' };
+}
+
 module.exports = {
   GitHubRetryDeferredError,
   classifyGitHubError,
   computeWaitSeconds,
+  dispatchWorkflow,
   formatRetryProgress,
   readPrimaryRateLimit,
   requestGitHubApi,
   retryGitHub,
+  workflowDispatchTitle,
 };
 
 async function main(argv) {
+  if (argv[0] === 'dispatch' && argv[1] && argv[2]) {
+    const waitBudget = process.env.DISPATCH_WAIT_BUDGET_SECONDS ?? '900';
+    if (!/^\d+$/.test(waitBudget)) {
+      throw new Error('DISPATCH_WAIT_BUDGET_SECONDS must be a non-negative integer');
+    }
+    const result = await dispatchWorkflow({
+      repository: argv[1],
+      sourceSha: argv[2],
+      token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+      totalWaitBudgetSeconds: Number(waitBudget),
+      onProgress: (event) => console.error(formatRetryProgress(event)),
+    });
+    const marker = result.state === 'dispatched' ? 'OK' : 'SKIP';
+    const receipt = result.run?.html_url ? `; receipt ${result.run.html_url}` : '';
+    console.log(`[${marker}] ${argv[1]} exact-source dispatch ${result.state}${receipt}`);
+    return;
+  }
   if (argv[0] !== 'get' || !argv[1]) {
-    throw new Error('usage: github-api-resilience.cjs get ENDPOINT [--paginate]');
+    throw new Error('usage: github-api-resilience.cjs get ENDPOINT [--paginate] | dispatch OWNER/REPO SOURCE_SHA');
   }
   const data = await requestGitHubApi(argv[1], {
     token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN,

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Structural check on dispatch-downstream.yml: a single runner must
-# fan out to every downstream repo, cap parallelism at 5, keep
-# retry-with-backoff, and aggregate per-repo failures.
+# fan out to every downstream repo, cap parallelism at 5, keep bounded
+# receipt-aware retry-with-backoff, and aggregate per-repo terminal states.
 set -euo pipefail
 
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
@@ -29,9 +29,8 @@ check "no read-config job (consolidated)" "! grep -q '^  read-config:$' '$WF'"
 # Parallelism cap stays at 5 via batched dispatch loop.
 check "BATCH_SIZE=5 for parallelism cap" "grep -q 'BATCH_SIZE=5' '$WF'"
 
-# The repository runner cancels jobs at five minutes. Keep at least 60 seconds
-# for preflight, API calls, and retry backoff instead of spending the entire
-# budget in deterministic inter-batch sleeps.
+# Leave room for one complete secondary-limit cooldown plus preflight and the
+# deterministic fleet pacing inside the explicit GitHub Free-compatible job timeout.
 BATCH_SIZE_VALUE=$(sed -nE 's/^[[:space:]]*BATCH_SIZE=([0-9]+)$/\1/p' "$WF")
 BATCH_DELAY_VALUE=$(sed -nE 's/^[[:space:]]*BATCH_DELAY=([0-9]+)$/\1/p' "$WF")
 PROVISION_DELAY_VALUE=$(sed -nE \
@@ -42,20 +41,31 @@ BATCH_COUNT=$(((FLEET_SIZE + BATCH_SIZE_VALUE - 1) / BATCH_SIZE_VALUE))
 SCHEDULED_SLEEP_SECONDS=$(((\
   BATCH_COUNT - 1) * BATCH_DELAY_VALUE + (\
   FLEET_SIZE - 1) * PROVISION_DELAY_VALUE))
-RUNNER_BUDGET_SECONDS=300
-RUNNER_RESERVE_SECONDS=60
-check "inventory pacing and inter-batch sleeps leave 60s of the runner budget" \
-  "[ '$SCHEDULED_SLEEP_SECONDS' -le '$((RUNNER_BUDGET_SECONDS - RUNNER_RESERVE_SECONDS))' ]"
+JOB_TIMEOUT_MINUTES=$(sed -nE 's/^[[:space:]]*timeout-minutes: ([0-9]+)$/\1/p' "$WF")
+DISPATCH_WAIT_BUDGET_SECONDS=$(sed -nE \
+  's/^[[:space:]]*DISPATCH_WAIT_BUDGET_SECONDS: ([0-9]+)$/\1/p' "$WF")
+RUNNER_RESERVE_SECONDS=300
+check "job has a bounded 30-minute timeout" \
+  "[ '$JOB_TIMEOUT_MINUTES' -eq 30 ]"
+check "one full secondary cooldown and deterministic pacing fit with five minutes reserved" \
+  "[ '$((SCHEDULED_SLEEP_SECONDS + DISPATCH_WAIT_BUDGET_SECONDS))' -le '$((JOB_TIMEOUT_MINUTES * 60 - RUNNER_RESERVE_SECONDS))' ]"
 check "repository-secret inventory stays below 30 requests per minute" \
   "[ '$PROVISION_DELAY_VALUE' -eq 2 ]"
 
-# Retry-with-backoff preserved (2s → 4s → 8s).
-check "retry max=3 attempts" "grep -Eq 'max=3' '$WF'"
-check "backoff delay starts at 2s" "grep -Eq 'delay=2' '$WF'"
+# The shared helper reads response headers, honors Retry-After, and applies the
+# tested 60/120/240-second missing-header contract.
+check "dispatch uses the receipt-aware resilience helper" \
+  "grep -qF 'github-api-resilience.cjs dispatch' '$WF'"
+check "dispatch preserves GitHub response diagnostics" \
+  "! grep -qF '>/dev/null 2>&1' '$WF'"
+check "dispatch has an explicit 15-minute wait budget" \
+  "[ '$DISPATCH_WAIT_BUDGET_SECONDS' -eq 900 ]"
 
 # Failure aggregation — step fails iff at least one dispatch failed.
 check "emits [FAIL] markers" "grep -q '\[FAIL\]' '$WF'"
 check "aggregates FAIL_COUNT" "grep -q 'FAIL_COUNT' '$WF'"
+check "emits durable [DEFER] markers" "grep -q '\[DEFER\]' '$WF'"
+check "aggregates DEFER_COUNT" "grep -q 'DEFER_COUNT' '$WF'"
 
 # Config still drives the fan-out.
 check "consumes downstream-repos.json" "grep -q 'downstream-repos.json' '$WF'"
@@ -100,7 +110,7 @@ check "queues transitions instead of cancelling a mutating bootstrap" \
 check "captures the exact triggering commit" \
   "grep -Fq 'SOURCE_SHA: \${{ github.sha }}' '$WF'"
 check "forwards the exact source receipt to every downstream run" \
-  "grep -Fq -- '-f source_sha=\"\$SOURCE_SHA\"' '$WF'"
+  "grep -Fq -- 'dispatch \"\$repo\" \"\$SOURCE_SHA\"' '$WF'"
 check "runs exact-source and immutable-pin preflight before fan-out" \
   "grep -q 'scripts/preflight-downstream-dispatch.sh' '$WF'"
 PROVISION_LINE=$(grep -n '^[[:space:]]*scripts/provision-governance-secrets.sh$' "$WF" |

--- a/tests/test-github-api-resilience.sh
+++ b/tests/test-github-api-resilience.sh
@@ -13,6 +13,7 @@ const {
   GitHubRetryDeferredError,
   classifyGitHubError,
   computeWaitSeconds,
+  dispatchWorkflow,
   formatRetryProgress,
   readPrimaryRateLimit,
   requestGitHubApi,
@@ -230,6 +231,114 @@ await requestGitHubApi('repos/f5-sales-demo/example', {
 assert.deepEqual(primaryRequestSleeps, [125]);
 assert.equal(primaryUrls.filter((url) => url.endsWith('/rate_limit')).length, 1);
 
+const exactSource = '1'.repeat(40);
+const exactTitle = `Enforce Repository Settings @ ${exactSource}`;
+const dispatchResponses = [
+  response(200, {workflow_runs: [{
+    id: 101,
+    event: 'workflow_dispatch',
+    display_title: exactTitle,
+    status: 'completed',
+    conclusion: 'failure',
+    html_url: 'https://github.example/runs/101',
+  }]}),
+  response(503, {message: 'Service unavailable'}),
+  response(200, {workflow_runs: [{
+    id: 102,
+    event: 'workflow_dispatch',
+    display_title: exactTitle,
+    status: 'in_progress',
+    conclusion: null,
+    html_url: 'https://github.example/runs/102',
+  }]}),
+];
+const dispatchRequests = [];
+const dispatchSleeps = [];
+const recoveredDispatch = await dispatchWorkflow({
+  repository: 'f5-sales-demo/example',
+  sourceSha: exactSource,
+  token: 'synthetic-token',
+  jitterSeconds: 0,
+  sleepSeconds: async (seconds) => dispatchSleeps.push(seconds),
+  onProgress: () => {},
+  fetch: async (url, options) => {
+    dispatchRequests.push({url, options});
+    return dispatchResponses.shift();
+  },
+});
+assert.equal(recoveredDispatch.state, 'recovered');
+assert.equal(recoveredDispatch.run.id, 102);
+assert.deepEqual(dispatchSleeps, [5]);
+assert.deepEqual(dispatchRequests.map(({options}) => options.method), ['GET', 'POST', 'GET']);
+assert.equal(
+  dispatchRequests.filter(({options}) => options.method === 'POST').length,
+  1,
+  'an ambiguous mutation must recover its exact receipt instead of posting twice',
+);
+assert.deepEqual(JSON.parse(dispatchRequests[1].options.body), {
+  ref: 'main',
+  inputs: {source_sha: exactSource},
+});
+
+const existingRequests = [];
+const existingDispatch = await dispatchWorkflow({
+  repository: 'f5-sales-demo/example',
+  sourceSha: exactSource,
+  token: 'synthetic-token',
+  fetch: async (url, options) => {
+    existingRequests.push({url, options});
+    return response(200, {workflow_runs: [{
+      id: 103,
+      event: 'workflow_dispatch',
+      display_title: exactTitle,
+      status: 'completed',
+      conclusion: 'success',
+      html_url: 'https://github.example/runs/103',
+    }]});
+  },
+});
+assert.equal(existingDispatch.state, 'existing');
+assert.equal(existingRequests.length, 1);
+assert.equal(existingRequests[0].options.method, 'GET');
+
+const limitedResponses = [
+  response(200, {workflow_runs: []}),
+  response(403, {message: 'secondary rate limit'}, {'Retry-After': '7'}),
+  response(200, {workflow_runs: []}),
+  response(204, null),
+];
+const limitedRequests = [];
+const limitedSleeps = [];
+const limitedDispatch = await dispatchWorkflow({
+  repository: 'f5-sales-demo/example',
+  sourceSha: exactSource,
+  token: 'synthetic-token',
+  jitterSeconds: 0,
+  sleepSeconds: async (seconds) => limitedSleeps.push(seconds),
+  onProgress: () => {},
+  fetch: async (url, options) => {
+    limitedRequests.push({url, options});
+    return limitedResponses.shift();
+  },
+});
+assert.equal(limitedDispatch.state, 'dispatched');
+assert.deepEqual(limitedSleeps, [7]);
+assert.deepEqual(limitedRequests.map(({options}) => options.method), ['GET', 'POST', 'GET', 'POST']);
+assert.equal(
+  limitedRequests.some(({url}) => url.endsWith('/rate_limit')),
+  false,
+  'secondary dispatch cooldown must not poll GitHub',
+);
+
+await assert.rejects(
+  dispatchWorkflow({
+    repository: 'f5-sales-demo/example',
+    sourceSha: 'not-a-sha',
+    token: 'synthetic-token',
+  }),
+  /source SHA/,
+);
+
 console.log('[OK] GitHub API retry classifications and wait contract');
 })().catch((error) => {
   console.error(error);
@@ -351,6 +460,8 @@ review="$repo_root/.github/workflows/antigravity-review.yml"
 translation="$repo_root/.github/workflows/antigravity-translate.yml"
 translation_caller="$repo_root/workflows/antigravity-translate.yml"
 sync_workflow="$repo_root/.github/workflows/sync-managed-files.yml"
+dispatcher="$repo_root/.github/workflows/dispatch-downstream.yml"
+enforcement_caller="$repo_root/workflows/enforce-repo-settings.yml"
 repo_settings="$repo_root/.github/config/repo-settings.json"
 
 credential_files=("$review" "$translation")
@@ -399,6 +510,13 @@ if [ -f "$watcher" ]; then
     grep -qE '\[PROGRESS\].*repository' "$watcher"
   check 'Free-tier contract remains explicit' \
     grep -qF 'GitHub Free-compatible' "$watcher"
+  check 'downstream dispatcher uses receipt-aware bounded API retries' \
+    grep -qF 'github-api-resilience.cjs dispatch' "$dispatcher"
+  check 'downstream dispatcher does not suppress GitHub response diagnostics' \
+    bash -c "! grep -qF '>/dev/null 2>&1' '$dispatcher'"
+  check 'enforcement caller exposes an exact-source dispatch receipt' \
+    grep -qF 'run-name: Enforce Repository Settings @ ${{ inputs.source_sha' \
+    "$enforcement_caller"
 else
   skip_source_contract 'fleet watcher wiring contract'
 fi

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -1,5 +1,6 @@
 ---
 name: Enforce Repository Settings
+run-name: Enforce Repository Settings @ ${{ inputs.source_sha || 'scheduled' }}
 
 #checkov:skip=CKV_GHA_7:Exact source receipts are validated before any governed read or mutation.
 on:


### PR DESCRIPTION
## Summary

Makes the 38-repository governance fanout durable under GitHub secondary content-creation limits while remaining GitHub Free-compatible.

## Related Issue

Closes #1263

## Changes

- replace the suppressed 2/4-second `gh workflow run` loop with the shared GitHub API resilience helper
- identify exact-source enforcement runs by stable `run-name` receipts, skip existing active/successful receipts, and recover ambiguous responses without duplicate POSTs
- honor `Retry-After` or bounded exponential backoff, stream wait diagnostics, and distinguish non-retryable failure from durable defer
- bound the dispatcher at 30 minutes with a 900-second mutation wait budget
- add hermetic UAT for receipt reuse, ambiguous-response recovery, secondary cooldown without polling, invalid input, and workflow terminal-state aggregation

## Verification evidence

- `bash tests/test-github-api-resilience.sh` — passed
- `bash tests/test-dispatch-matrix.sh` — passed
- all 34 `tests/test-*.sh` files — passed
- `pre-commit run --all-files` — passed
- `bash scripts/agy-pre-push-review.sh` on `3520a945ca6e93288b8b17f4e0eb2a90c90536a4` — PII preflight clean; reviewer and verifier passed; no critical/high finding remains

## Delivery evidence

- Triggering failure: https://github.com/f5-sales-demo/docs-control/actions/runs/31073339549
- CI, merge, generated manifest, downstream fanout, and 38-repository blob convergence will be followed to terminal receipts before closure.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first and passing; the issue acceptance criteria are covered
- [x] Verified locally by exercising the changed dispatch and receipt paths
- [x] Feature branch passed exact-HEAD Antigravity review before this push
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed
- [x] Follows project conventions