### PR TITLE
fix: defer post-bootstrap rate exhaustion

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -142,6 +142,10 @@ jobs:
                       echo "[DEFER] bootstrap state changed; scheduled recovery remains active"
                       exit 0
                       ;;
+                    84)
+                      echo "[DEFER] GitHub API rate capacity was exhausted after bootstrap; scheduled recovery is active"
+                      exit 0
+                      ;;
                     *)
                       echo "::error::Post-bootstrap preflight failed"
                       exit "$postflight_rc"

--- a/tests/test-dispatch-matrix.sh
+++ b/tests/test-dispatch-matrix.sh
@@ -156,6 +156,7 @@ count=0
 count=$((count + 1))
 printf '%s\n' "$count" >"$count_file"
 [ "$count" -eq 1 ] && exit 80
+[ -z "${FAKE_POSTFLIGHT_RC:-}" ] || exit "$FAKE_POSTFLIGHT_RC"
 exit 78
 EOF
 cat >"$WORK/scripts/provision-governance-secrets.sh" <<'EOF'
@@ -190,6 +191,27 @@ recovery_rc=$?
 set -e
 check "post-bootstrap historical receipt enqueues current main and succeeds" \
   "[ '$recovery_rc' -eq 0 ] && grep -q 'workflow run dispatch-downstream.yml.*--ref main' '$WORK/gh.log'"
+
+rm -f "$WORK/.preflight-count"
+: >"$WORK/gh.log"
+set +e
+(
+  cd "$WORK"
+  env \
+    PATH="$WORK/bin:$PATH" \
+    FAKE_GH_LOG="$WORK/gh.log" \
+    FAKE_POSTFLIGHT_RC=84 \
+    GITHUB_REPOSITORY=f5-sales-demo/docs-control \
+    GITHUB_REPOSITORY_OWNER=f5-sales-demo \
+    SOURCE_SHA=1111111111111111111111111111111111111111 \
+    REPO_SETTINGS_TOKEN=settings-token \
+    REPO_SYNC_TOKEN=sync-token \
+    bash "$WORK/dispatch.sh"
+)
+recovery_rc=$?
+set -e
+check "post-bootstrap API rate exhaustion defers to scheduled recovery" \
+  "[ '$recovery_rc' -eq 0 ] && ! grep -q 'workflow run dispatch-downstream.yml' '$WORK/gh.log'"
 
 rm -f "$WORK/.preflight-count"
 : >"$WORK/gh.log"


### PR DESCRIPTION
## Summary

Preserves the durable-defer contract when GitHub primary quota is exhausted during post-bootstrap verification.

## Related Issue

Closes #1263

## Changes

- handle post-bootstrap preflight exit 84 as a successful scheduled-recovery defer
- add a hermetic regression that reproduces the exact control-flow path from run 31077544409
- retain fail-closed behavior for non-retryable post-bootstrap errors

## Verification evidence

- `bash tests/test-dispatch-matrix.sh` — regression failed before the fix and passes after it
- all 34 `tests/test-*.sh` files — passed
- `pre-commit run --all-files` — passed
- `bash scripts/agy-pre-push-review.sh` on `31dc3b4bdf9d90ff85bed4b673cd14fa819d48dc` — PII clean; reviewer and verifier passed; no critical/high finding remains

## Delivery evidence

- Reproduced failure: https://github.com/f5-sales-demo/docs-control/actions/runs/31077544409
- All 38 exact managed callers are merged and active; final enforcement fanout and blob convergence will be verified after this PR merges.

## Checklist

- [x] Linked to detailed issue #1263
- [x] Feature-complete and verified
- [x] Regression test written first and passing
- [x] Exact-HEAD Antigravity review passed
- [ ] CI green and PR merged
- [ ] Final 38-repository fanout and convergence verified