### PR TITLE
fix: serialize Antigravity reusable workflows

### DIFF
--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -39,6 +39,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: antigravity-reusable-review-${{ github.repository }}-${{ inputs.pr_number }}-${{ inputs.expected_head_sha }}
+  cancel-in-progress: true
+
 jobs:
   review:
     name: PR review with Antigravity

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -41,6 +41,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: antigravity-reusable-translation-${{ github.repository }}-${{ inputs.pr_number }}-${{ inputs.expected_head_sha }}
+  cancel-in-progress: true
+
 jobs:
   translate:
     name: Generate isolated translations

--- a/tests/test-antigravity-suspension.sh
+++ b/tests/test-antigravity-suspension.sh
@@ -83,7 +83,16 @@ for workflow in \
   "$REPO_ROOT/.github/workflows/antigravity-translate.yml"; do
   assert_contains "$workflow" "workflow_dispatch:" \
     "$(basename "$workflow") supports the same-repository pilot"
+  assert_contains "$workflow" "cancel-in-progress: true" \
+    "$(basename "$workflow") cancels duplicate exact-head runs"
 done
+
+assert_contains "$REPO_ROOT/.github/workflows/antigravity-review.yml" \
+  'group: antigravity-reusable-review-${{ github.repository }}-${{ inputs.pr_number }}-${{ inputs.expected_head_sha }}' \
+  "review workflow uses a caller-distinct exact-head concurrency group"
+assert_contains "$REPO_ROOT/.github/workflows/antigravity-translate.yml" \
+  'group: antigravity-reusable-translation-${{ github.repository }}-${{ inputs.pr_number }}-${{ inputs.expected_head_sha }}' \
+  "translation workflow uses a caller-distinct exact-head concurrency group"
 
 for file in \
   "$REPO_ROOT/.github/workflows/antigravity-review.yml" \


### PR DESCRIPTION
## Summary

Repairs the post-merge Workflow Security Audit failure from #1296 by adding caller-distinct exact-head concurrency to the two newly dispatchable reusable Antigravity workflows.

## Related Issue

Closes #1246

## Changes

- serialize reviewer runs by caller repository, PR number, and exact head
- serialize translator runs with a distinct group to avoid caller/reusable workflow cancellation collisions
- assert duplicate-run cancellation and exact concurrency identities

## Verification evidence

- `bash tests/test-antigravity-suspension.sh` — 34 passed, 0 failed
- `zizmor --no-config --no-ignores --persona=auditor .github/workflows/ workflows/*.yml` — no findings
- changed-workflow `actionlint` and `yamllint` — passed
- targeted `pre-commit` — all hooks passed
- staged and HEAD PII enforcement — clean
- `bash scripts/agy-pre-push-review.sh` at `13d1c1d24b540e4fd58a4663285279e9f46bcd78` — reviewer and verifier approved with zero findings

## Delivery evidence

- Repairs failed post-merge audit run https://github.com/f5-sales-demo/docs-control/actions/runs/31092038490

## Checklist

- [x] Linked to detailed issue #1246
- [x] Reproduced the exact post-merge failure before implementation
- [x] Focused behavioral and security audit verification passes
- [x] Exact-HEAD Antigravity review passed before push
- [ ] PR checks green and merged
- [ ] Post-merge Workflow Security Audit green
- [x] Follows project conventions