### PR TITLE
fix: initialize Antigravity keyring headlessly

### DIFF
--- a/.github/workflows/antigravity-fleet-watcher.yml
+++ b/.github/workflows/antigravity-fleet-watcher.yml
@@ -295,7 +295,9 @@ jobs:
         run: |
           set -euo pipefail
           dbus-run-session -- bash -euo pipefail <<'INNER'
-          eval "$(printf '' | gnome-keyring-daemon --unlock --daemonize)"
+          keyring_password=$(openssl rand -hex 32)
+          eval "$(printf '%s\n' "$keyring_password" | gnome-keyring-daemon --unlock --daemonize --components=secrets)"
+          unset keyring_password
           export SSH_AUTH_SOCK GNOME_KEYRING_CONTROL GNOME_KEYRING_PID
           printf '%s' "${ANTIGRAVITY_TOKEN#go-keyring-base64:}" | base64 -d |
             python3 -c 'import keyring,sys; keyring.set_password("gemini", "antigravity", sys.stdin.read())'

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -134,7 +134,9 @@ jobs:
           }
           mkdir "$RUNNER_TEMP/review-artifact"
           dbus-run-session -- bash -euo pipefail <<'INNER'
-          eval "$(printf '' | gnome-keyring-daemon --unlock --daemonize)"
+          keyring_password=$(openssl rand -hex 32)
+          eval "$(printf '%s\n' "$keyring_password" | gnome-keyring-daemon --unlock --daemonize --components=secrets)"
+          unset keyring_password
           export SSH_AUTH_SOCK GNOME_KEYRING_CONTROL GNOME_KEYRING_PID
           printf '%s' "${ANTIGRAVITY_TOKEN#go-keyring-base64:}" | base64 -d |
             python3 -c 'import keyring,sys; keyring.set_password("gemini", "antigravity", sys.stdin.read())'

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -142,7 +142,9 @@ jobs:
             exit 1
           }
           dbus-run-session -- bash -euo pipefail <<'INNER'
-          eval "$(printf '' | gnome-keyring-daemon --unlock --daemonize)"
+          keyring_password=$(openssl rand -hex 32)
+          eval "$(printf '%s\n' "$keyring_password" | gnome-keyring-daemon --unlock --daemonize --components=secrets)"
+          unset keyring_password
           export SSH_AUTH_SOCK GNOME_KEYRING_CONTROL GNOME_KEYRING_PID
           printf '%s' "${ANTIGRAVITY_TOKEN#go-keyring-base64:}" | base64 -d |
             python3 -c 'import keyring,sys; keyring.set_password("gemini", "antigravity", sys.stdin.read())'

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -163,6 +163,23 @@ function testProgressRouting() {
   assert.match(watcher, /scripts\/run-with-progress[.]sh --phase fleet-triage/);
 }
 
+function testHeadlessKeyringBootstrap() {
+  for (const [workflow, stepName] of [
+    [reviewWorkflow, 'Run isolated reviewer and verifier'],
+    [translationWorkflow, 'Generate translations without write credentials'],
+    [watcherWorkflow, 'Triage redacted failure logs'],
+  ]) {
+    const script = extractStepBlock(workflow, stepName);
+    assert.match(script, /keyring_password=\$\(openssl rand -hex 32\)/);
+    assert.match(
+      script,
+      /printf '%s\\n' "\$keyring_password" \| gnome-keyring-daemon --unlock --daemonize --components=secrets/,
+    );
+    assert.match(script, /unset keyring_password/);
+    assert.doesNotMatch(script, /printf '' \| gnome-keyring-daemon/);
+  }
+}
+
 function writeExecutable(file, body) {
   fs.writeFileSync(file, body, { mode: 0o755 });
 }
@@ -538,7 +555,16 @@ function writeSandboxCommandFakes(bin) {
     path.join(bin, 'dbus-run-session'),
     '#!/usr/bin/env bash\nset -euo pipefail\ntest "$1" = --\nshift\nexec "$@"\n',
   );
-  writeExecutable(path.join(bin, 'gnome-keyring-daemon'), '#!/usr/bin/env bash\nexit 0\n');
+  writeExecutable(
+    path.join(bin, 'gnome-keyring-daemon'),
+    `#!/usr/bin/env bash
+set -euo pipefail
+test "$*" = "--unlock --daemonize --components=secrets"
+IFS= read -r password
+test "\${#password}" -eq 64
+printf 'GNOME_KEYRING_CONTROL=%q\nGNOME_KEYRING_PID=%q\n' "$RUNNER_TEMP/keyring" "12345"
+`,
+  );
   writeExecutable(path.join(bin, 'python3'), '#!/usr/bin/env bash\ncat >/dev/null\n');
 }
 
@@ -1046,6 +1072,7 @@ assert.notEqual(
 await testReviewerPreparation();
 testNoAppTokenRouting();
 testProgressRouting();
+testHeadlessKeyringBootstrap();
 await testTranslationPreparation();
 testPinnedInstallers();
 testReviewerModelAndGate();


### PR DESCRIPTION
## Summary

Initialize the ephemeral GNOME secret-service collection with a random session password so Antigravity model jobs can store their token in a real headless login collection.

## Related Issue

Closes #1246

## Changes

- initialize the review, translation, and fleet-watcher keyrings with a random 256-bit password
- restrict the daemon to the secrets component
- make the behavioral UAT reject empty input, missing component selection, or a malformed password

## Verification evidence

- `node tests/antigravity-ci-feature-uat.mjs "$PWD"` — passed
- `bash tests/test-antigravity-suspension.sh` — 34 passed
- actionlint and yamllint — passed
- `zizmor --no-config --no-ignores --persona=auditor .github/workflows/ workflows/*.yml` — no findings
- targeted pre-commit — passed
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean
- `bash scripts/agy-pre-push-review.sh` on `a8c9efe52c06ea51d83b183493b714f0d4a90cf4` — both reviewers approved with no findings

## Delivery evidence

- Live workflow execution and pilot continuation will be recorded after required CI passes.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] Feature branch passed exact-HEAD Antigravity review before every PR push
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions