### PR TITLE
fix: authorize sandboxed translation commands

### DIFF
--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -155,7 +155,11 @@ jobs:
           jq -n --arg project "$GCP_PROJECT_ID" --arg workspace "$GITHUB_WORKSPACE" '{
             gcp: {project: $project, location: "global"},
             model: "Gemini 3.6 Flash (High)",
-            trustedWorkspaces: [$workspace]
+            trustedWorkspaces: [$workspace],
+            permissions: {
+              allow: ["command(*)"],
+              deny: ["unsandboxed(*)", "read_url(*)", "execute_url(*)"]
+            }
           }' >"$HOME/.gemini/antigravity-cli/settings.json"
           prompt=$(printf '%s\n' \
             "Translate the exact English documentation changes listed in /opt/agy-translation-contract/changed-english.txt into every required locale." \

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -789,6 +789,14 @@ function testTranslationModel() {
     /\/opt\/agy-translation-contract\/changed-english[.]txt/,
     'the translator prompt must use the exact-head manifest copied into its sandbox-readable contract directory',
   );
+  assert.doesNotMatch(argumentsUsed, /--dangerously-skip-permissions/);
+  const settings = JSON.parse(
+    fs.readFileSync(path.join(completed.work, 'home/.gemini/antigravity-cli/settings.json'), 'utf8'),
+  );
+  assert.deepEqual(settings.permissions, {
+    allow: ['command(*)'],
+    deny: ['unsandboxed(*)', 'read_url(*)', 'execute_url(*)'],
+  });
   assert.equal(
     fs.readFileSync(path.join(completed.work, 'translation-credentials'), 'utf8').trim(),
     '|||',


### PR DESCRIPTION
## Summary

Authorize Antigravity command tools in the existing terminal sandbox so headless translation can operate without interactive prompts, while explicitly denying unsandboxed and URL actions.

## Related Issue

Closes #1307

Related to #1246 and #1304.

## Changes

- allow `command(*)` only within the existing Antigravity terminal sandbox
- explicitly deny `unsandboxed(*)`, `read_url(*)`, and `execute_url(*)`
- retain the absence of `--dangerously-skip-permissions`
- parse and verify the generated permission settings in behavioral UAT

## Verification evidence

- Official permission model: https://antigravity.google/docs/permissions
- `node tests/antigravity-ci-feature-uat.mjs "$PWD"` — passed
- `bash tests/test-antigravity-suspension.sh` — 34 passed
- actionlint and yamllint — passed
- zizmor auditor — no findings
- targeted pre-commit — passed
- staged PII enforcement — clean
- exact-head Antigravity review on `56c34ed12b082dce30838993afdad36ba57c9dd4` — reviewer and verifier approved with no findings

## Security boundary

The model job remains credential-stripped and receives no GitHub write token. The trusted validator is installed root-read-only, the model remains under `--sandbox`, English edits and non-locale paths fail closed, and publication occurs in a separate exact-head job after patch validation.

## Delivery evidence

Live run 31095952425 reproduced the headless command denial and skipped publication. A successful two-job pilot retry remains required after merge and exact post-merge workflow audit.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] Feature branch passed exact-HEAD Antigravity review before every PR push
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions