### PR TITLE
fix: grant headless access to translation contract

### DIFF
--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -157,8 +157,13 @@ jobs:
             model: "Gemini 3.6 Flash (High)",
             trustedWorkspaces: [$workspace],
             permissions: {
-              allow: ["command(*)"],
-              deny: ["unsandboxed(*)", "read_url(*)", "execute_url(*)"]
+              allow: ["command(*)", "read_file(/opt/agy-translation-contract)"],
+              deny: [
+                "unsandboxed(*)",
+                "read_url(*)",
+                "execute_url(*)",
+                "write_file(/opt/agy-translation-contract)"
+              ]
             }
           }' >"$HOME/.gemini/antigravity-cli/settings.json"
           prompt=$(printf '%s\n' \

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -794,8 +794,8 @@ function testTranslationModel() {
     fs.readFileSync(path.join(completed.work, 'home/.gemini/antigravity-cli/settings.json'), 'utf8'),
   );
   assert.deepEqual(settings.permissions, {
-    allow: ['command(*)'],
-    deny: ['unsandboxed(*)', 'read_url(*)', 'execute_url(*)'],
+    allow: ['command(*)', 'read_file(/opt/agy-translation-contract)'],
+    deny: ['unsandboxed(*)', 'read_url(*)', 'execute_url(*)', 'write_file(/opt/agy-translation-contract)'],
   });
   assert.equal(
     fs.readFileSync(path.join(completed.work, 'translation-credentials'), 'utf8').trim(),


### PR DESCRIPTION
## Summary

Grant the sandboxed headless translator recursive read access to its root-owned external contract directory while explicitly denying writes to that directory.

## Related Issue

Closes #1307

Related to #1246 and #1304.

## Changes

- add `read_file(/opt/agy-translation-contract)` to the ephemeral Antigravity allow list
- add `write_file(/opt/agy-translation-contract)` to the deny list
- retain sandbox-only commands and explicit unsandboxed/URL denials
- verify the complete permission contract in behavioral UAT

## Verification evidence

- Live run 31097426688 emitted a 30-second heartbeat and then identified the exact missing `read_file` grant
- Official permission model: https://antigravity.google/docs/permissions
- Antigravity CI feature UAT — passed
- Antigravity suspension/control tests — 34 passed
- actionlint and yamllint — passed
- zizmor auditor — no findings
- targeted pre-commit after Biome formatting — passed
- staged PII enforcement — clean
- exact-head Antigravity review on `7ae4f8977a69104ac933bc0062a2ee6d011d6a0f` — reviewer and verifier approved with no findings

## Security boundary

The model remains under terminal sandboxing with no GitHub write token or gateway variables. The external contract is root-owned/read-only both physically and in the Antigravity permission policy. Network and unsandboxed actions remain denied; guarded publication stays in a separate exact-head job.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] Feature branch passed exact-HEAD Antigravity review before every PR push
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions