### PR TITLE
fix: grant headless access to translation workspace

### DIFF
--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -157,7 +157,11 @@ jobs:
             model: "Gemini 3.6 Flash (High)",
             trustedWorkspaces: [$workspace],
             permissions: {
-              allow: ["command(*)", "read_file(/opt/agy-translation-contract)"],
+              allow: [
+                "command(*)",
+                ("read_file(" + $workspace + ")"),
+                "read_file(/opt/agy-translation-contract)"
+              ],
               deny: [
                 "unsandboxed(*)",
                 "read_url(*)",

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -794,7 +794,7 @@ function testTranslationModel() {
     fs.readFileSync(path.join(completed.work, 'home/.gemini/antigravity-cli/settings.json'), 'utf8'),
   );
   assert.deepEqual(settings.permissions, {
-    allow: ['command(*)', 'read_file(/opt/agy-translation-contract)'],
+    allow: ['command(*)', `read_file(${completed.work})`, 'read_file(/opt/agy-translation-contract)'],
     deny: ['unsandboxed(*)', 'read_url(*)', 'execute_url(*)', 'write_file(/opt/agy-translation-contract)'],
   });
   assert.equal(


### PR DESCRIPTION
## Summary

Explicitly grant the headless Antigravity model recursive read access to the exact GitHub Actions workspace path while preserving the narrow external-contract and sandbox boundaries.

## Related Issue

Closes #1307

Related to #1246 and #1304.

## Changes

- construct `read_file(<exact GITHUB_WORKSPACE>)` in ephemeral Antigravity settings
- retain read-only access to `/opt/agy-translation-contract`
- retain contract write, unsandboxed, and URL denials
- verify the exact dynamic workspace permission in behavioral UAT

## Verification evidence

- Live run 31098713451 passed command authorization and external-contract routing, then emitted the exact remaining headless `read_file` denial for checkout data
- Official permission model: https://antigravity.google/docs/permissions
- Antigravity CI feature UAT — passed
- Antigravity suspension/control tests — 34 passed
- actionlint and yamllint — passed
- zizmor auditor — no findings
- targeted pre-commit after Biome formatting — passed
- staged PII enforcement — clean
- exact-head Antigravity review on `5a305e24a8d3e9ca391f519e46a769d872abb43b` — reviewer and verifier approved with no findings

## Security boundary

Read scope is the exact ephemeral checkout plus the root-owned contract directory, not `read_file(*)`. The model remains sandboxed and credential-stripped; network and unsandboxed actions are denied, contract writes are denied, and only validator-approved locale patches can reach the separate publication job.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] Feature branch passed exact-HEAD Antigravity review before every PR push
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions