### PR TITLE
fix: scope headless writes to translation locales

### DIFF
--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -157,16 +157,25 @@ jobs:
             model: "Gemini 3.6 Flash (High)",
             trustedWorkspaces: [$workspace],
             permissions: {
-              allow: [
+              allow: ([
                 "command(*)",
                 ("read_file(" + $workspace + ")"),
                 "read_file(/opt/agy-translation-contract)"
-              ],
+              ] + (
+                ["fr", "es", "de", "pt-br", "ja", "ko", "zh-cn", "zh-tw", "ar", "it", "hi", "th"] |
+                map("write_file(" + $workspace + "/docs/" + . + ")")
+              ) + (
+                ["fr", "es", "de", "pt-br", "ja", "ko", "zh-cn", "zh-tw", "ar", "it", "hi", "th"] |
+                map("write_file(" + $workspace + "/src/content/docs/" + . + ")")
+              )),
               deny: [
                 "unsandboxed(*)",
                 "read_url(*)",
                 "execute_url(*)",
-                "write_file(/opt/agy-translation-contract)"
+                "write_file(/opt/agy-translation-contract)",
+                ("write_file(" + $workspace + "/docs/en)"),
+                ("write_file(" + $workspace + "/src/content/docs/en)"),
+                ("write_file(" + $workspace + "/.git)")
               ]
             }
           }' >"$HOME/.gemini/antigravity-cli/settings.json"

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -794,8 +794,22 @@ function testTranslationModel() {
     fs.readFileSync(path.join(completed.work, 'home/.gemini/antigravity-cli/settings.json'), 'utf8'),
   );
   assert.deepEqual(settings.permissions, {
-    allow: ['command(*)', `read_file(${completed.work})`, 'read_file(/opt/agy-translation-contract)'],
-    deny: ['unsandboxed(*)', 'read_url(*)', 'execute_url(*)', 'write_file(/opt/agy-translation-contract)'],
+    allow: [
+      'command(*)',
+      `read_file(${completed.work})`,
+      'read_file(/opt/agy-translation-contract)',
+      ...locales.map((locale) => `write_file(${completed.work}/docs/${locale})`),
+      ...locales.map((locale) => `write_file(${completed.work}/src/content/docs/${locale})`),
+    ],
+    deny: [
+      'unsandboxed(*)',
+      'read_url(*)',
+      'execute_url(*)',
+      'write_file(/opt/agy-translation-contract)',
+      `write_file(${completed.work}/docs/en)`,
+      `write_file(${completed.work}/src/content/docs/en)`,
+      `write_file(${completed.work}/.git)`,
+    ],
   });
   assert.equal(
     fs.readFileSync(path.join(completed.work, 'translation-credentials'), 'utf8').trim(),


### PR DESCRIPTION
## Summary

Grant headless Antigravity write access only to the 24 approved locale roots while explicitly denying English source and Git metadata writes.

## Related Issue

Closes #1307

Related to #1246 and #1304.

## Changes

- generate exact `write_file` permissions for all 12 `docs/<locale>` roots
- generate exact `write_file` permissions for all 12 `src/content/docs/<locale>` roots
- explicitly deny writes to both English roots and `.git`
- retain root-owned contract, network, and unsandboxed denials
- verify the complete generated permission arrays in behavioral UAT

## Verification evidence

- Live run 31100144487 read the contract and checkout successfully, emitted heartbeats through 150 seconds, and identified the exact remaining `write_file` prompt at its first edit
- Official permission model: https://antigravity.google/docs/permissions
- Antigravity CI feature UAT — passed after catching and repairing an initial jq syntax defect
- Antigravity suspension/control tests — 34 passed
- actionlint and yamllint — passed
- zizmor auditor — no findings
- targeted pre-commit — passed
- staged PII enforcement — clean
- exact-head Antigravity review on `c82129a09792f26c71fd4a5fda0702ba01a9d16e` — reviewer and verifier approved with no findings

## Security boundary

There is no workspace-wide write permission. Only the 24 locale roots are writable. English sources, `.git`, and the external trusted contract are denied; the model remains sandboxed and credential-stripped, and the separate publication job accepts only validator-approved locale patches.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [x] Feature branch passed exact-HEAD Antigravity review before every PR push
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions