### PR TITLE
fix: make runtime installer extract directory creation idempotent (#1324)

### DIFF
--- a/.github/workflows/antigravity-fleet-watcher.yml
+++ b/.github/workflows/antigravity-fleet-watcher.yml
@@ -283,7 +283,8 @@ jobs:
           archive="$RUNNER_TEMP/agy-${AGY_VERSION}.tar.gz"
           curl --fail --silent --show-error --location "$AGY_URL" --output "$archive"
           printf '%s  %s\n' "$AGY_SHA512" "$archive" | sha512sum --check --strict
-          mkdir "$RUNNER_TEMP/agy-extract"
+          rm -rf "$RUNNER_TEMP/agy-extract"
+          mkdir -p "$RUNNER_TEMP/agy-extract"
           tar -xzf "$archive" -C "$RUNNER_TEMP/agy-extract" antigravity
           sudo install -o root -g root -m 0555 "$RUNNER_TEMP/agy-extract/antigravity" /usr/local/bin/agy
           test "$(agy --version)" = "$AGY_VERSION"

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -112,7 +112,8 @@ jobs:
           archive="$RUNNER_TEMP/agy-${AGY_VERSION}.tar.gz"
           curl --fail --silent --show-error --location "$AGY_URL" --output "$archive"
           printf '%s  %s\n' "$AGY_SHA512" "$archive" | sha512sum --check --strict
-          mkdir "$RUNNER_TEMP/agy-extract"
+          rm -rf "$RUNNER_TEMP/agy-extract"
+          mkdir -p "$RUNNER_TEMP/agy-extract"
           tar -xzf "$archive" -C "$RUNNER_TEMP/agy-extract" antigravity
           sudo install -o root -g root -m 0555 "$RUNNER_TEMP/agy-extract/antigravity" /usr/local/bin/agy
           test "$(agy --version)" = "$AGY_VERSION"

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -148,7 +148,8 @@ jobs:
           archive="$RUNNER_TEMP/agy-${AGY_VERSION}.tar.gz"
           curl --fail --silent --show-error --location "$AGY_URL" --output "$archive"
           printf '%s  %s\n' "$AGY_SHA512" "$archive" | sha512sum --check --strict
-          mkdir "$RUNNER_TEMP/agy-extract"
+          rm -rf "$RUNNER_TEMP/agy-extract"
+          mkdir -p "$RUNNER_TEMP/agy-extract"
           tar -xzf "$archive" -C "$RUNNER_TEMP/agy-extract" antigravity
           sudo install -o root -g root -m 0555 "$RUNNER_TEMP/agy-extract/antigravity" /usr/local/bin/agy
           test "$(agy --version)" = "$AGY_VERSION"

--- a/tests/antigravity-ci-feature-uat.mjs
+++ b/tests/antigravity-ci-feature-uat.mjs
@@ -522,6 +522,7 @@ for argument in "$@"; do
   source_path=$previous
   previous=$argument
 done
+rm -f "$FAKE_AGY_PATH"
 cp "$source_path" "$FAKE_AGY_PATH"
 chmod 0555 "$FAKE_AGY_PATH"
 `,
@@ -537,7 +538,7 @@ actual=$(/usr/bin/shasum -a 512 "$file" | awk '{print $1}')
 test "$actual" = "$expected"
 `,
   );
-  return runShell(extractStepBlock(workflowPath, 'Install pinned Antigravity runtime'), {
+  const options = {
     cwd: work,
     env: {
       AGY_SHA512: digestOverride ?? digest,
@@ -548,7 +549,11 @@ test "$actual" = "$expected"
       PATH: `${bin}:${process.env.PATH}`,
       RUNNER_TEMP: work,
     },
-  });
+  };
+  const block = extractStepBlock(workflowPath, 'Install pinned Antigravity runtime');
+  const firstRun = runShell(block, options);
+  if (firstRun.status !== 0) return firstRun;
+  return runShell(block, options);
 }
 
 function testPinnedInstallers() {


### PR DESCRIPTION
Closes #1324

## Summary
In `Install pinned Antigravity runtime`, `mkdir "$RUNNER_TEMP/agy-extract"` failed with `File exists` on self-hosted runners when `$RUNNER_TEMP/agy-extract` already existed from a prior step or run.

This PR updates `mkdir "$RUNNER_TEMP/agy-extract"` to `rm -rf "$RUNNER_TEMP/agy-extract" && mkdir -p "$RUNNER_TEMP/agy-extract"` across reusable workflows.