### PR TITLE
fix: clean stale keyrings before gnome-keyring-daemon unlock (#1327)

### DIFF
--- a/.github/workflows/antigravity-fleet-watcher.yml
+++ b/.github/workflows/antigravity-fleet-watcher.yml
@@ -296,6 +296,8 @@ jobs:
         run: |
           set -euo pipefail
           dbus-run-session -- bash -euo pipefail <<'INNER'
+          rm -rf "$HOME/.local/share/keyrings"
+          mkdir -p "$HOME/.local/share/keyrings"
           keyring_password=$(openssl rand -hex 32)
           eval "$(printf '%s\n' "$keyring_password" | gnome-keyring-daemon --unlock --daemonize --components=secrets)"
           unset keyring_password

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -135,6 +135,8 @@ jobs:
           }
           mkdir "$RUNNER_TEMP/review-artifact"
           dbus-run-session -- bash -euo pipefail <<'INNER'
+          rm -rf "$HOME/.local/share/keyrings"
+          mkdir -p "$HOME/.local/share/keyrings"
           keyring_password=$(openssl rand -hex 32)
           eval "$(printf '%s\n' "$keyring_password" | gnome-keyring-daemon --unlock --daemonize --components=secrets)"
           unset keyring_password

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -169,6 +169,8 @@ jobs:
             exit 1
           }
           dbus-run-session -- bash -euo pipefail <<'INNER'
+          rm -rf "$HOME/.local/share/keyrings"
+          mkdir -p "$HOME/.local/share/keyrings"
           keyring_password=$(openssl rand -hex 32)
           eval "$(printf '%s\n' "$keyring_password" | gnome-keyring-daemon --unlock --daemonize --components=secrets)"
           unset keyring_password


### PR DESCRIPTION
Closes #1327

## Summary
On persistent self-hosted runners, `gnome-keyring-daemon --unlock` failed with `KeyringLocked` when stale keyring databases existed in `~/.local/share/keyrings` with a password from a prior run.

This PR adds `rm -rf "$HOME/.local/share/keyrings"` and `mkdir -p "$HOME/.local/share/keyrings"` before `gnome-keyring-daemon --unlock` across reusable Antigravity workflows.