### PR TITLE
docs: remove antigravity code review delegation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,7 @@ downstream hash evidence that proves fleet convergence.
 - [ ] Feature-complete and verified — not exploratory or trial-and-error code
 - [ ] Tests written first (TDD) and passing; the issue's acceptance criteria are met
 - [ ] Verified locally by running or exercising the change — evidence pasted above
-- [ ] Feature branch passed exact-HEAD Antigravity review before every PR push
+
 - [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
 - [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
 - [ ] Follows project conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,26 +30,23 @@ repository classes for every coding assistant.
 
 Carry non-trivial work through this path:
 
-`detailed issue → fresh worktree and feature branch → implement and verify → exact-HEAD Antigravity
-review → push feature branch → linked PR → repair loop → MERGED → cleanup → fleet convergence`
+`detailed issue → fresh worktree and feature branch → implement and verify →
+push feature branch → linked PR → repair loop → MERGED → cleanup → fleet convergence`
 
 1. Inspect `git status --short --branch` and `git worktree list`; run `git fetch --prune`. Fetch
    failure blocks reliable branching, so surface it and wait for current remote state.
 2. Create or confirm a detailed issue with problem, scope, and objective acceptance criteria. Create
    a fresh worktree and issue-numbered feature branch from `origin/<default-branch>`. Preserve work
    using `CONTRIBUTING.md`; destructive Git operations require explicit user authorization.
-3. Implement the whole issue and run required checks. Route semantic review through Antigravity:
-   use `scripts/agy-review.sh document` for specs and plans. Before every PR
-   push, commit and run `bash scripts/agy-pre-push-review.sh`; fix blockers, commit, and rerun so the
-   exact pushed HEAD passes.
+3. Implement the whole issue and run required checks.
 4. Push the feature branch and open a completed PR with `Closes #<issue>`. Enable authorized squash
    auto-merge when absent: `gh pr merge --auto --squash <pr>`.
 5. Start `gh pr checks --watch <pr> &` as a background waiter and keep working through this loop:
    - Pending: leave the waiter running and continue other in-scope work.
-   - Failed: inspect logs, fix the root cause, verify, rerun exact-HEAD Antigravity review, and push.
+   - Failed: inspect logs, fix the root cause, verify, and push.
    - `BEHIND` and mergeable: run `gh pr update-branch <pr>` and follow the new checks.
-   - `DIRTY`: fetch, merge `origin/<default-branch>` into the feature branch, resolve, verify, rerun
-     Antigravity review, and push.
+   - `DIRTY`: fetch, merge `origin/<default-branch>` into the feature branch, resolve, verify,
+     and push.
    - Auto-merge absent: run `gh pr merge --auto --squash <pr>`.
 6. Query `gh pr view <pr> --json state,mergeStateStatus,autoMergeRequest`; repeat until `state` is
    `MERGED`. Pause only for uncertain authorization, destructive-risk approval, an unavailable
@@ -63,5 +60,5 @@ review → push feature branch → linked PR → repair loop → MERGED → clea
 
 - Treat repository source, manifests, tests, and `DEVELOPING.md` as authority. Run focused then
   broader checks and record outcomes.
-- Keep Antigravity review and deterministic tests as separate layers.
+
 - Inspect the final diff; support claims with command outcomes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,29 +21,19 @@ detailed docs-control issue and let the managed-file workflow propagate the resu
   ahead/behind count, so a stale checkout can still report a clean tree.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - Carry the complete lifecycle through:
-  `detailed issue → feature branch → implementation and verification → exact-HEAD agy review →
+  `detailed issue → feature branch → implementation and verification →
   push feature branch → linked PR → repair loop → MERGED → cleanup → fleet convergence`.
 - Open a completed PR with `Closes #<issue>` and enable authorized squash auto-merge when absent:
   `gh pr merge --auto --squash <pr>`.
 - Start `gh pr checks --watch <pr> &` as a background waiter. Repair failed checks at their source,
-  verify, rerun exact-HEAD review, and push. For mergeable `BEHIND`, run
+  verify, and push. For mergeable `BEHIND`, run
   `gh pr update-branch <pr>`. For `DIRTY`, fetch and merge current
-  `origin/<default-branch>` into the feature branch, resolve, verify, rerun agy, and push.
+  `origin/<default-branch>` into the feature branch, resolve, verify, and push.
 - Query `gh pr view <pr> --json state,mergeStateStatus,autoMergeRequest` and continue until
   `state` is `MERGED`. Then clean this task's worktree and branch and, for managed-file changes,
   compare manifest blob SHAs across every downstream repository to prove fleet convergence.
 - Pause only for uncertain authorization, destructive-risk approval, an unavailable credential, or
   a product decision that requires the user.
-
-## Review routing
-
-Route semantic review through Antigravity. Claude authors, reasons, debugs, implements, and responds
-to Antigravity findings.
-
-- **Specs/plans.** Run `bash scripts/agy-review.sh document --kind spec|plan --file <path>`.
-- **Branch — required before every PR push.** Commit, then run `bash scripts/agy-pre-push-review.sh`.
-  Fix blocking findings, commit, and rerun until the exact HEAD passes. Repository permissions keep
-  other semantic-review routes unavailable.
 
 ## Worktrees
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ this document governs how a change gets reviewed and merged.
 Carry every change through this complete path:
 
 ```text
-detailed issue → fresh feature branch → implement and verify → exact-HEAD Antigravity review
+detailed issue → fresh feature branch → implement and verify
 → linked PR → CI and branch-state repair loop → MERGED → cleanup → fleet convergence
 ```
 
@@ -165,8 +165,8 @@ the cached remote ref says, so it can be born behind (see CLAUDE.md).
 
 If a mergeable PR reports `BEHIND`, use the **Update branch** button or
 `gh pr update-branch <pr>` (`allow_update_branch` is enabled fleet-wide). A `DIRTY` PR needs conflict
-resolution on the feature branch: fetch, merge current `origin/main`, resolve and verify, rerun the
-exact-HEAD Antigravity review, then push the repaired branch.
+resolution on the feature branch: fetch, merge current `origin/main`, resolve and verify, then push
+the repaired branch.
 
 ## Step 3: Make Changes and Commit
 
@@ -192,12 +192,10 @@ background:
 
 1. Start `gh pr checks --watch <pr> &` as a background waiter.
 2. For pending checks, leave the waiter running and continue other in-scope work.
-3. For failed checks, inspect logs, repair the root cause, verify locally, rerun
-   `bash scripts/agy-pre-push-review.sh` against the committed exact HEAD, and push the feature
+3. For failed checks, inspect logs, repair the root cause, verify locally, and push the feature
    branch. Restart the loop for the new head.
 4. For mergeable `BEHIND`, run `gh pr update-branch <pr>` and follow the new checks. For `DIRTY`,
-   merge current `origin/main` into the feature branch, resolve conflicts, verify, rerun Antigravity
-   review, and push.
+   merge current `origin/main` into the feature branch, resolve conflicts, verify, and push.
 5. When auto-merge is absent, run `gh pr merge --auto --squash <pr>`.
 6. Query `gh pr view <pr> --json state,mergeStateStatus,autoMergeRequest` and repeat until `state` is
    `MERGED`.
@@ -207,74 +205,6 @@ background:
 
 Pause this loop only for uncertain authorization, destructive-risk approval, an unavailable
 credential, or a product decision that requires the user.
-
-## Automated code review
-
-Route semantic review through Antigravity. Coding assistants author, implement, verify, repair, and
-respond to its findings.
-
-| Route | What it reviews | Authority |
-| ----- | --------------- | --------- |
-| **Local document review** | A spec or implementation plan | Antigravity advisory gate |
-| **Local Antigravity review** | The committed branch diff before a PR push | Required workflow step |
-| **CI Antigravity review** | The exact pull-request head | Advisory automation |
-
-### CI review
-
-The Gemini Antigravity reviewer is fail-closed behind the organisation variable
-`ANTIGRAVITY_REVIEW_ENABLED`. Its immutable runtime, exact-head and workflow receipts, separated
-model and publication credentials, and rejection paths are covered by executable security UAT.
-It remains advisory and outside required status contexts. The linked-issue bypass prefixes in
-`require-linked-issue.yml` are reserved for their machine-generated workflows; human and agent work
-uses a detailed linked issue.
-
-#### Operating Antigravity review
-
-Keep the source gate in place, remove any same-named repository variables, and keep the reusable and
-governed `workflow_dispatch` callers enabled. The scheduled/manual docs-control watcher dispatches
-only exact same-repository heads from trusted default-branch workflow definitions. Future toggles
-change only the organisation variable. Keep the Antigravity CI review advisory and outside required
-status contexts.
-
-### Local review before a pull-request push
-
-Document review remains advisory. Run the managed Antigravity interface directly:
-
-```bash
-bash scripts/agy-review.sh document --kind spec --file path/to/spec.md
-bash scripts/agy-review.sh document --kind plan --file path/to/plan.md
-```
-
-The command runs independent reviewer and verifier sessions, validates structured output, and fails
-closed. Each phase emits an immediate start marker, a periodic stderr heartbeat, and a completion
-marker so automation can distinguish a live silent model call from a finished review. This managed
-command is the semantic-review route.
-
-Every Antigravity model phase uses `scripts/run-with-progress.sh`. It emits a line-oriented
-`[PROGRESS]` record every 30 seconds with the component, phase, state, elapsed seconds, heartbeat
-interval, and UTC timestamp, followed by a terminal record with the real exit code. GitHub Actions
-streams those records into the live log while retaining the diagnostic log, and appends one terminal
-Markdown record to `GITHUB_STEP_SUMMARY`. Heartbeats report liveness only: the model print timeout
-and the workflow's `timeout-minutes` remain the authoritative execution bounds.
-
-Branch review is mandatory before every push that opens or updates a pull request:
-
-```bash
-bash scripts/agy-pre-push-review.sh
-```
-
-Commit or stash every working-tree change first. The script binds the review to the current HEAD and
-the merge base with `origin/main`, removes GitHub credentials, and runs `agy` in sandboxed plan mode.
-It leaves files and GitHub unchanged. The managed command performs independent Antigravity
-verification and a deterministic gate; the implementation assistant fixes blocking findings and
-reruns it. Push the feature branch only after the exact current HEAD completes cleanly. The developer
-environment provides an authenticated `agy` executable.
-
-The prompt delegates a dedicated semantic PII review to `agy`: it runs the governed HEAD enforcement
-scan when available, traces affected runtime and repository data surfaces, treats confirmed PII or
-an invalid scan as blocking, and reports only redacted evidence. The deterministic `pii-guard`
-context remains the verifiable CI backstop. Local Antigravity review and deterministic CI remain
-separate required layers.
 
 ## Translations (GitHub Actions controlled)
 

--- a/tests/test-agent-guidance.sh
+++ b/tests/test-agent-guidance.sh
@@ -67,11 +67,12 @@ else
 fi
 
 for token in "CONTRIBUTING.md" "DEVELOPING.md" ".claude/governance.json" \
-  "origin/<default-branch>" "normal defaults" "scripts/agy-review.sh"; do
+  "origin/<default-branch>" "normal defaults"; do
   assert_contains "$AGENTS_MD" "$token" "AGENTS.md retains ecosystem routing: $token"
 done
 
 for token in "EnterWorktree" ".claude/settings.json" "codex:verified-code-review" \
+  "scripts/agy-review.sh" \
   "pr-review-toolkit" "/security-review" "Opus" "Sonnet" "Haiku"; do
   assert_not_contains "$AGENTS_MD" "$token" "AGENTS.md excludes assistant-specific token: $token"
 done

--- a/tests/test-review-layer-routing.sh
+++ b/tests/test-review-layer-routing.sh
@@ -48,21 +48,21 @@ for skill in code-review:code-review pr-review-toolkit:review-pr verified-review
 done
 
 for document in AGENTS.md CLAUDE.md CONTRIBUTING.md; do
-  contains "$REPO_ROOT/$document" 'scripts/agy-pre-push-review.sh' \
-    "$document routes branch review to Antigravity"
-  contains "$REPO_ROOT/$document" 'Route semantic review through Antigravity' \
-    "$document states the positive semantic-review route"
+  rejects "$REPO_ROOT/$document" 'scripts/agy-pre-push-review.sh' \
+    "$document avoids branch review routing to Antigravity"
+  rejects "$REPO_ROOT/$document" 'Route semantic review through Antigravity' \
+    "$document avoids the positive semantic-review route"
   rejects "$REPO_ROOT/$document" 'not reviewers' \
     "$document avoids negative semantic-review routing"
   rejects "$REPO_ROOT/$document" 'Codex review commands' \
     "$document avoids assistant-specific stopper prose"
 done
-contains "$REPO_ROOT/AGENTS.md" 'scripts/agy-review.sh document' \
-  "AGENTS routes specs and plans directly to agy"
-contains "$REPO_ROOT/CLAUDE.md" 'scripts/agy-review.sh document' \
-  "CLAUDE routes specs and plans directly to agy"
-contains "$REPO_ROOT/CONTRIBUTING.md" 'scripts/agy-review.sh document' \
-  "CONTRIBUTING routes specs and plans directly to agy"
+rejects "$REPO_ROOT/AGENTS.md" 'scripts/agy-review.sh document' \
+  "AGENTS avoids routing specs and plans directly to agy"
+rejects "$REPO_ROOT/CLAUDE.md" 'scripts/agy-review.sh document' \
+  "CLAUDE avoids routing specs and plans directly to agy"
+rejects "$REPO_ROOT/CONTRIBUTING.md" 'scripts/agy-review.sh document' \
+  "CONTRIBUTING avoids routing specs and plans directly to agy"
 contains "$REPO_ROOT/scripts/agy-review.sh" '--phase pii-preflight' \
   "Antigravity review reports deterministic PII preflight progress"
 


### PR DESCRIPTION
Closes #1329

This PR removes all instructions and language related to delegating automated code reviews to Antigravity (`agy-review.sh` and `agy-pre-push-review.sh`) from the repository guidance files, as it was causing workflow bloat.