### PR TITLE
chore: ignore .etag_cache in governed .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ docs/specifications/api/
 docs/api-reference/
 .version
 .etag
+.etag_cache
 .github_release
 
 # Autoresearch session artifacts


### PR DESCRIPTION
Closes #1335. Adds .etag_cache (active cache path in the downloader and workflows) to the governed .gitignore.