### PR TITLE
style: format workflow security JSON

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -44,17 +44,87 @@
         "real-api-tests": {
           "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh"],
           "environment": "acceptance-tests",
-          "permissions": {"checks": "write", "contents": "read"},
+          "permissions": { "checks": "write", "contents": "read" },
           "allowed_secrets": ["XCSH_API_TOKEN", "XCSH_API_URL"],
-          "triggers": {"pull_request":{"branches":["main"],"paths":["internal/provider/**","internal/client/**","internal/acctest/**","internal/functions/**","internal/blindfold/**"]},"schedule":[{"cron":"0 2 * * 1"}],"workflow_dispatch":{"inputs":{"mode":{"default":"full","description":"Test mode","options":["mock-only","real-only","full","pr-subset"],"required":true,"type":"choice"},"parallel":{"default":"4","description":"Parallelism for mock tests","required":false,"type":"string"},"timeout":{"default":"10","description":"Timeout per test (minutes)","required":false,"type":"string"}}}},
+          "triggers": {
+            "pull_request": {
+              "branches": ["main"],
+              "paths": [
+                "internal/provider/**",
+                "internal/client/**",
+                "internal/acctest/**",
+                "internal/functions/**",
+                "internal/blindfold/**"
+              ]
+            },
+            "schedule": [{ "cron": "0 2 * * 1" }],
+            "workflow_dispatch": {
+              "inputs": {
+                "mode": {
+                  "default": "full",
+                  "description": "Test mode",
+                  "options": ["mock-only", "real-only", "full", "pr-subset"],
+                  "required": true,
+                  "type": "choice"
+                },
+                "parallel": {
+                  "default": "4",
+                  "description": "Parallelism for mock tests",
+                  "required": false,
+                  "type": "string"
+                },
+                "timeout": {
+                  "default": "10",
+                  "description": "Timeout per test (minutes)",
+                  "required": false,
+                  "type": "string"
+                }
+              }
+            }
+          },
           "if": "always() &&\ngithub.event_name != 'pull_request' &&\n((github.event_name == 'schedule' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'full' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'real-only' &&\n  needs.mock-tests.result == 'skipped'))\n"
         },
         "cleanup": {
           "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh"],
           "environment": "acceptance-tests",
-          "permissions": {"contents": "read"},
+          "permissions": { "contents": "read" },
           "allowed_secrets": ["XCSH_API_TOKEN", "XCSH_API_URL"],
-          "triggers": {"pull_request":{"branches":["main"],"paths":["internal/provider/**","internal/client/**","internal/acctest/**","internal/functions/**","internal/blindfold/**"]},"schedule":[{"cron":"0 2 * * 1"}],"workflow_dispatch":{"inputs":{"mode":{"default":"full","description":"Test mode","options":["mock-only","real-only","full","pr-subset"],"required":true,"type":"choice"},"parallel":{"default":"4","description":"Parallelism for mock tests","required":false,"type":"string"},"timeout":{"default":"10","description":"Timeout per test (minutes)","required":false,"type":"string"}}}},
+          "triggers": {
+            "pull_request": {
+              "branches": ["main"],
+              "paths": [
+                "internal/provider/**",
+                "internal/client/**",
+                "internal/acctest/**",
+                "internal/functions/**",
+                "internal/blindfold/**"
+              ]
+            },
+            "schedule": [{ "cron": "0 2 * * 1" }],
+            "workflow_dispatch": {
+              "inputs": {
+                "mode": {
+                  "default": "full",
+                  "description": "Test mode",
+                  "options": ["mock-only", "real-only", "full", "pr-subset"],
+                  "required": true,
+                  "type": "choice"
+                },
+                "parallel": {
+                  "default": "4",
+                  "description": "Parallelism for mock tests",
+                  "required": false,
+                  "type": "string"
+                },
+                "timeout": {
+                  "default": "10",
+                  "description": "Timeout per test (minutes)",
+                  "required": false,
+                  "type": "string"
+                }
+              }
+            }
+          },
           "if": "always() &&\ngithub.event_name != 'pull_request' &&\nneeds.real-api-tests.result != 'skipped'\n"
         }
       },
@@ -64,7 +134,32 @@
           "environment": "default-discovery",
           "permissions": {},
           "allowed_secrets": ["REPO_SYNC_TOKEN", "XCSH_API_TOKEN", "XCSH_API_URL"],
-          "triggers": {"schedule":[{"cron":"0 6 1 * *"}],"workflow_dispatch":{"inputs":{"dry_run":{"default":false,"description":"Dry run (no PR creation)","required":false,"type":"boolean"},"mode":{"default":"discover","description":"Discovery mode","options":["discover","validate","single"],"required":true,"type":"choice"},"resource":{"default":"","description":"Resource name (for single mode only)","required":false,"type":"string"}}}},
+          "triggers": {
+            "schedule": [{ "cron": "0 6 1 * *" }],
+            "workflow_dispatch": {
+              "inputs": {
+                "dry_run": {
+                  "default": false,
+                  "description": "Dry run (no PR creation)",
+                  "required": false,
+                  "type": "boolean"
+                },
+                "mode": {
+                  "default": "discover",
+                  "description": "Discovery mode",
+                  "options": ["discover", "validate", "single"],
+                  "required": true,
+                  "type": "choice"
+                },
+                "resource": {
+                  "default": "",
+                  "description": "Resource name (for single mode only)",
+                  "required": false,
+                  "type": "string"
+                }
+              }
+            }
+          },
           "if": null
         }
       }

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -564,6 +564,12 @@ jobs:
         if: hashFiles('tests/test-linter-configs.sh') != ''
         run: bash tests/test-linter-configs.sh
 
+      - name: Setup uv for workflow-security integration
+        if: hashFiles('tests/test-workflow-security-validator-integration.sh') != ''
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+        with:
+          version: "0.8.24"
+
       - name: Run workflow-security validator integration test
         if: hashFiles('tests/test-workflow-security-validator-integration.sh') != ''
         run: bash tests/test-workflow-security-validator-integration.sh

--- a/tests/fixtures/workflow-security/policy.json
+++ b/tests/fixtures/workflow-security/policy.json
@@ -6,17 +6,17 @@
         "first": {
           "runs_on": ["self-hosted", "Linux", "X64", "fixture"],
           "environment": "first-environment",
-          "permissions": {"contents": "read"},
+          "permissions": { "contents": "read" },
           "allowed_secrets": ["FIXTURE_TOKEN"],
-          "triggers": {"push": {"branches": ["main"]}, "workflow_dispatch": null},
+          "triggers": { "push": { "branches": ["main"] }, "workflow_dispatch": null },
           "if": null
         },
         "second": {
           "runs_on": ["self-hosted", "Linux", "X64", "fixture"],
           "environment": "second-environment",
-          "permissions": {"checks": "write", "contents": "read"},
+          "permissions": { "checks": "write", "contents": "read" },
           "allowed_secrets": [],
-          "triggers": {"push": {"branches": ["main"]}, "workflow_dispatch": null},
+          "triggers": { "push": { "branches": ["main"] }, "workflow_dispatch": null },
           "if": null
         }
       }

--- a/tests/fixtures/workflow-security/zizmor-1.29-findings.json
+++ b/tests/fixtures/workflow-security/zizmor-1.29-findings.json
@@ -3,21 +3,21 @@
     "ident": "self-hosted-runner",
     "desc": "runs on a self-hosted runner",
     "url": "https://docs.zizmor.sh/audits/#self-hosted-runner",
-    "determinations": {"confidence": "High", "severity": "Medium", "persona": "Auditor"},
+    "determinations": { "confidence": "High", "severity": "Medium", "persona": "Auditor" },
     "locations": [
       {
         "symbolic": {
-          "key": {"Local": {"verbatim_path": ".github/workflows/audit.yml"}},
+          "key": { "Local": { "verbatim_path": ".github/workflows/audit.yml" } },
           "annotation": "self-hosted runner used here",
-          "route": {"route": [{"Key": "jobs"}, {"Key": "first"}, {"Key": "runs-on"}]},
+          "route": { "route": [{ "Key": "jobs" }, { "Key": "first" }, { "Key": "runs-on" }] },
           "feature_kind": "Normal",
           "kind": "Primary"
         },
         "concrete": {
           "location": {
-            "start_point": {"row": 12, "column": 4},
-            "end_point": {"row": 12, "column": 51},
-            "offset_span": {"start": 137, "end": 184}
+            "start_point": { "row": 12, "column": 4 },
+            "end_point": { "row": 12, "column": 51 },
+            "offset_span": { "start": 137, "end": 184 }
           },
           "feature": "    runs-on: [self-hosted, Linux, X64, fixture]",
           "comments": []
@@ -31,21 +31,21 @@
     "ident": "self-hosted-runner",
     "desc": "runs on a self-hosted runner",
     "url": "https://docs.zizmor.sh/audits/#self-hosted-runner",
-    "determinations": {"confidence": "High", "severity": "Medium", "persona": "Auditor"},
+    "determinations": { "confidence": "High", "severity": "Medium", "persona": "Auditor" },
     "locations": [
       {
         "symbolic": {
-          "key": {"Local": {"verbatim_path": ".github/workflows/audit.yml"}},
+          "key": { "Local": { "verbatim_path": ".github/workflows/audit.yml" } },
           "annotation": "self-hosted runner used here",
-          "route": {"route": [{"Key": "jobs"}, {"Key": "second"}, {"Key": "runs-on"}]},
+          "route": { "route": [{ "Key": "jobs" }, { "Key": "second" }, { "Key": "runs-on" }] },
           "feature_kind": "Normal",
           "kind": "Primary"
         },
         "concrete": {
           "location": {
-            "start_point": {"row": 25, "column": 4},
-            "end_point": {"row": 25, "column": 51},
-            "offset_span": {"start": 519, "end": 566}
+            "start_point": { "row": 25, "column": 4 },
+            "end_point": { "row": 25, "column": 51 },
+            "offset_span": { "start": 519, "end": 566 }
           },
           "feature": "    runs-on: [self-hosted, Linux, X64, fixture]",
           "comments": []

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -53,12 +53,11 @@ for f in .yamllint.yaml zizmor.yaml .checkov.yaml .textlintrc actionlint.yml; do
   fi
 done
 
-if python3 - "$REPO_ROOT/actionlint.yml" <<'PY'
+if python3 - "$REPO_ROOT/actionlint.yml" <<'PY'; then
 import sys, yaml
 config = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
 assert config.get("self-hosted-runner", {}).get("labels") == ["terraform-provider-xcsh"]
 PY
-then
   pass "2.1 actionlint recognizes the governed provider runner label"
 else
   fail "2.1 actionlint recognizes the governed provider runner label" \
@@ -1324,7 +1323,7 @@ else
     "the group needs a reusable-workflow-specific prefix"
 fi
 
-if python3 - "$SUPER_LINTER_WORKFLOW" <<'PY'
+if python3 - "$SUPER_LINTER_WORKFLOW" <<'PY'; then
 import sys, yaml
 
 workflow = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
@@ -1343,7 +1342,6 @@ assert setup["uses"] == "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8c
 assert setup["with"] == {"version": "0.8.24"}
 assert setup["if"] == "hashFiles('tests/test-workflow-security-validator-integration.sh') != ''"
 PY
-then
   pass "14.3 workflow-security integration installs an immutable uv toolchain first"
 else
   fail "14.3 workflow-security integration installs an immutable uv toolchain first" \

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -1324,15 +1324,41 @@ else
     "the group needs a reusable-workflow-specific prefix"
 fi
 
+if python3 - "$SUPER_LINTER_WORKFLOW" <<'PY'
+import sys, yaml
+
+workflow = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+steps = workflow["jobs"]["shell-unit-tests"]["steps"]
+setup_index = next(
+    i for i, step in enumerate(steps)
+    if step.get("name") == "Setup uv for workflow-security integration"
+)
+integration_index = next(
+    i for i, step in enumerate(steps)
+    if step.get("name") == "Run workflow-security validator integration test"
+)
+setup = steps[setup_index]
+assert setup_index < integration_index
+assert setup["uses"] == "astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc"
+assert setup["with"] == {"version": "0.8.24"}
+assert setup["if"] == "hashFiles('tests/test-workflow-security-validator-integration.sh') != ''"
+PY
+then
+  pass "14.3 workflow-security integration installs an immutable uv toolchain first"
+else
+  fail "14.3 workflow-security integration installs an immutable uv toolchain first" \
+    "setup-uv must be pinned, versioned, guarded, and ordered before the integration test"
+fi
+
 # One workflow_call default is resolved to an immutable digest after registry
 # authentication; there is no runtime fallback or historical digest pin.
 if [ "$(grep -cF "default: '$EXPECTED_BUILDER'" "$PAGES_WORKFLOW")" = "1" ] &&
   grep -qF '^ghcr\.io/f5-sales-demo/docs-builder@sha256:[0-9a-f]{64}$' "$PAGES_WORKFLOW" &&
   grep -qF '${{ steps.builder.outputs.builder_image }}' "$PAGES_WORKFLOW" &&
   ! grep -Eq '905d2398|inputs\.builder-image \|\|' "$PAGES_WORKFLOW"; then
-  pass "14.3 latest documentation builder resolves to an approved immutable identity"
+  pass "14.4 latest documentation builder resolves to an approved immutable identity"
 else
-  fail "14.3 latest documentation builder resolves to an approved immutable identity" \
+  fail "14.4 latest documentation builder resolves to an approved immutable identity" \
     "expected latest selection, approved digest validation, and no historical fallback"
 fi
 


### PR DESCRIPTION
## Summary

- apply the exact Biome 2.5.6 formatting required by the merged Super-Linter workflow
- install pinned uv before the real Zizmor integration test
- preserve policy and captured Zizmor fixture semantics while repairing post-merge CI

## Verification

- Biome 2.5.6 passes all tracked JS/TS/JSON/CSS inputs
- 30 Python unit tests pass
- linter governance suite passes (179 checks)
- real Zizmor 1.29 integration passes and the ungoverned mutation fails closed
- exact-head CI rerun 31500104183 passed both required jobs
- git diff --check passes

Closes #1338