### PR TITLE
fix: make validator Ruff suppressions portable

### DIFF
--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -481,15 +481,20 @@ def parse_args(argv=None):
 
 def main(argv=None):
     args = parse_args(argv)
+    if not args.repository or args.repository.count("/") != 1:
+        print(
+            "workflow security validation failed: "
+            "an exact --repository owner/name is required",
+            file=sys.stderr,
+        )
+        return 1
     try:
-        if not args.repository or args.repository.count("/") != 1:
-            raise PolicyError("an exact --repository owner/name is required")  # noqa: TRY301
         findings = json.loads(args.findings.read_text(encoding="utf-8"))
         validate_zizmor_result(args.zizmor_exit, findings)
         routes = validate(
             findings, Path.cwd(), args.repository, args.policy, args.governance
         )
-    except Exception as exc:  # noqa: BLE001 - final CLI boundary fails closed
+    except (OSError, ValueError) as exc:
         print(f"workflow security validation failed: {exc}", file=sys.stderr)
         return 1
     for workflow, job_id, route in routes:

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -120,6 +120,36 @@ else
   echo "  SKIP: ruff CLI not installed in this environment"
 fi
 
+# The managed validator is linted under downstream profiles that may not
+# enable BLE001. Its CLI must catch expected input/I/O errors without an
+# inline BLE suppression that becomes an RUF100 unused-noqa failure.
+if python3 - "$REPO_ROOT/scripts/workflow-security-validator.py" <<'PY'; then
+import ast
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+module = ast.parse(source)
+main = next(node for node in module.body if isinstance(node, ast.FunctionDef) and node.name == "main")
+handlers = [node for node in ast.walk(main) if isinstance(node, ast.ExceptHandler)]
+expected = {"OSError", "ValueError"}
+actual = {
+    item.id
+    for handler in handlers
+    if isinstance(handler.type, ast.Tuple)
+    for item in handler.type.elts
+    if isinstance(item, ast.Name)
+}
+has_inline_portability_suppression = any(
+    marker in source for marker in ("noqa: BLE001", "noqa: TRY301")
+)
+raise SystemExit(0 if actual == expected and not has_inline_portability_suppression else 1)
+PY
+  pass "4.4 validator CLI catches portable input/I/O failures without BLE suppression"
+else
+  fail "4.4 validator CLI catches portable input/I/O failures without BLE suppression" \
+    "expected only OSError/ValueError and no inline BLE001 suppression"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 5: .codespellrc skip patterns cover expected noise sources
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- validate the repository argument before the exception boundary without `TRY301`
- catch only expected input and I/O failures instead of broad `Exception`
- add a regression assertion that rejects inline `BLE001` and `TRY301` suppressions

## Verification

- Ruff 0.16.2 passes the validator under both docs-control and provider profiles
- 30 Python tests pass
- linter governance passes (180 checks)
- real Zizmor 1.29 integration passes and ungoverned mutation fails closed
- shfmt and git diff checks pass

Closes #1346