### PR TITLE
fix: retire root-owned runner backups safely

### DIFF
--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -65,7 +65,9 @@ def download_runner_tarball(version, cache_dir):
     if temporary.exists():
         temporary.unlink()
     url = f"https://github.com/actions/runner/releases/download/v{version}/{name}"
-    urllib.request.urlretrieve(url, temporary)
+    urllib.request.urlretrieve(  # noqa: S310 - immutable GitHub HTTPS origin
+        url, temporary
+    )
     if not temporary.is_file() or temporary.stat().st_size == 0:
         raise RuntimeError("downloaded runner archive is empty")
     temporary.replace(destination)
@@ -166,7 +168,7 @@ class CommandGitHubClient:
 
 
 class RunnerManager:
-    def __init__(  # noqa: PLR0917 - injected side effects make recovery tests hermetic
+    def __init__(
         self,
         base_dir=DEFAULT_BASE_DIR,
         proc_root=DEFAULT_PROC_ROOT,
@@ -209,13 +211,13 @@ class RunnerManager:
     def repo_dir(self, repo):
         return validate_repo_dir(self.base_dir, repo)
 
-    def recovery_backup(self, repo):
+    def _recovery_backup(self, repo):
         repo_dir = self.repo_dir(repo)
         return repo_dir.with_name(repo_dir.name + ".recovery-backup")
 
     def _validated_removal_target(self, repo, path):
         repo_dir = self.repo_dir(repo)
-        backup = self.recovery_backup(repo)
+        backup = self._recovery_backup(repo)
         target = Path(path)
         if target not in {repo_dir, backup}:
             raise RuntimeError(f"refusing unrecognized runner removal target: {target}")
@@ -225,7 +227,7 @@ class RunnerManager:
             raise RuntimeError("runner removal target escapes configured base")
         return target
 
-    def remove_runner_tree(self, repo, path):
+    def _remove_runner_tree(self, repo, path):
         target = self._validated_removal_target(repo, path)
         if not target.exists():
             return
@@ -595,7 +597,7 @@ class RunnerManager:
         if self.owned_processes(repo_dir):
             raise RuntimeError("runner-owned process remains after cleanup")
         if remove_directory and repo_dir.exists():
-            self.remove_runner_tree(repo, repo_dir)
+            self._remove_runner_tree(repo, repo_dir)
 
     def _secret_command(self, command, cwd):
         result = self.command(command, cwd=cwd, check=False)
@@ -646,7 +648,7 @@ class RunnerManager:
         if existing and existing[0].get("busy") is not False:
             raise RuntimeError("refusing to reconfigure a busy runner")
         repo_dir = self.repo_dir(repo)
-        backup = self.recovery_backup(repo)
+        backup = self._recovery_backup(repo)
         if backup.exists() or backup.is_symlink():
             raise RuntimeError(f"recovery backup already exists: {backup}")
         version = self.latest_version()
@@ -674,10 +676,10 @@ class RunnerManager:
                 self.rename(backup, repo_dir)
             raise
         if backup.exists():
-            self.remove_runner_tree(repo, backup)
+            self._remove_runner_tree(repo, backup)
 
     def cleanup_backup(self, org, repo):
-        backup = self.recovery_backup(repo)
+        backup = self._recovery_backup(repo)
         if not backup.exists() and not backup.is_symlink():
             return
         errors = self.audit(org, repo)
@@ -686,7 +688,7 @@ class RunnerManager:
                 "refusing recovery-backup removal while runner audit fails: "
                 + "; ".join(errors)
             )
-        self.remove_runner_tree(repo, backup)
+        self._remove_runner_tree(repo, backup)
 
     def remove(self, org, repo):
         repo_dir = self.repo_dir(repo)
@@ -697,7 +699,7 @@ class RunnerManager:
         if config.is_file():
             token = self.removal_token(org, repo)
             self._secret_command(["./config.sh", "remove", "--token", token], repo_dir)
-        self.remove_runner_tree(repo, repo_dir)
+        self._remove_runner_tree(repo, repo_dir)
 
     def stop(self, org, repo):
         repo_dir = self.repo_dir(repo)
@@ -806,7 +808,7 @@ def main(argv=None):  # noqa: PLR0911 - each CLI action has a distinct exit cont
         if args.action == "health-check":
             results = [print_audit(manager, args.org, repo) for repo in governed]
             return 0 if all(results) else 1
-    except Exception as exc:  # noqa: BLE001 - final CLI boundary sanitizes all failures
+    except Exception as exc:
         print(f"runner management failed: {exc}", file=sys.stderr)
         return 1
     return 2

--- a/scripts/manage-github-runners.py
+++ b/scripts/manage-github-runners.py
@@ -120,7 +120,10 @@ def validate_repo_dir(base_dir, repo):
     if not repo or not re.fullmatch(r"[A-Za-z0-9_.-]+", repo):
         raise ValueError(f"invalid repository name: {repo!r}")
     base = Path(base_dir).resolve()
-    result = (base / repo).resolve()
+    candidate = base / repo
+    if candidate.is_symlink():
+        raise ValueError("repository directory must not be a symlink")
+    result = candidate.resolve()
     if result.parent != base:
         raise ValueError("repository directory escapes base")
     return result
@@ -205,6 +208,42 @@ class RunnerManager:
 
     def repo_dir(self, repo):
         return validate_repo_dir(self.base_dir, repo)
+
+    def recovery_backup(self, repo):
+        repo_dir = self.repo_dir(repo)
+        return repo_dir.with_name(repo_dir.name + ".recovery-backup")
+
+    def _validated_removal_target(self, repo, path):
+        repo_dir = self.repo_dir(repo)
+        backup = self.recovery_backup(repo)
+        target = Path(path)
+        if target not in {repo_dir, backup}:
+            raise RuntimeError(f"refusing unrecognized runner removal target: {target}")
+        if target.is_symlink():
+            raise RuntimeError(f"refusing symlink runner removal target: {target}")
+        if target.parent.resolve() != self.base_dir.resolve():
+            raise RuntimeError("runner removal target escapes configured base")
+        return target
+
+    def remove_runner_tree(self, repo, path):
+        target = self._validated_removal_target(repo, path)
+        if not target.exists():
+            return
+        self.command(
+            [
+                "chown",
+                "--recursive",
+                "--no-dereference",
+                "--",
+                f"{self.user}:{self.user}",
+                str(target),
+            ],
+            sudo=True,
+            check=True,
+        )
+        self.remove_tree(target)
+        if target.exists() or target.is_symlink():
+            raise RuntimeError(f"runner directory removal incomplete: {target}")
 
     @staticmethod
     def unit_name(org, repo):
@@ -556,7 +595,7 @@ class RunnerManager:
         if self.owned_processes(repo_dir):
             raise RuntimeError("runner-owned process remains after cleanup")
         if remove_directory and repo_dir.exists():
-            self.remove_tree(repo_dir)
+            self.remove_runner_tree(repo, repo_dir)
 
     def _secret_command(self, command, cwd):
         result = self.command(command, cwd=cwd, check=False)
@@ -607,8 +646,8 @@ class RunnerManager:
         if existing and existing[0].get("busy") is not False:
             raise RuntimeError("refusing to reconfigure a busy runner")
         repo_dir = self.repo_dir(repo)
-        backup = repo_dir.with_name(repo_dir.name + ".recovery-backup")
-        if backup.exists():
+        backup = self.recovery_backup(repo)
+        if backup.exists() or backup.is_symlink():
             raise RuntimeError(f"recovery backup already exists: {backup}")
         version = self.latest_version()
         archive = self.downloader(version, self.base_dir / ".cache")
@@ -635,7 +674,19 @@ class RunnerManager:
                 self.rename(backup, repo_dir)
             raise
         if backup.exists():
-            self.remove_tree(backup)
+            self.remove_runner_tree(repo, backup)
+
+    def cleanup_backup(self, org, repo):
+        backup = self.recovery_backup(repo)
+        if not backup.exists() and not backup.is_symlink():
+            return
+        errors = self.audit(org, repo)
+        if errors:
+            raise RuntimeError(
+                "refusing recovery-backup removal while runner audit fails: "
+                + "; ".join(errors)
+            )
+        self.remove_runner_tree(repo, backup)
 
     def remove(self, org, repo):
         repo_dir = self.repo_dir(repo)
@@ -646,7 +697,7 @@ class RunnerManager:
         if config.is_file():
             token = self.removal_token(org, repo)
             self._secret_command(["./config.sh", "remove", "--token", token], repo_dir)
-        self.remove_tree(repo_dir)
+        self.remove_runner_tree(repo, repo_dir)
 
     def stop(self, org, repo):
         repo_dir = self.repo_dir(repo)
@@ -689,7 +740,14 @@ def main(argv=None):  # noqa: PLR0911 - each CLI action has a distinct exit cont
         "--governance-path", type=Path, default=DOCS_CONTROL_GOVERNANCE_PATH
     )
     subparsers = parser.add_subparsers(dest="action", required=True)
-    for action in ("setup", "audit", "restart", "stop", "remove"):
+    for action in (
+        "setup",
+        "audit",
+        "restart",
+        "stop",
+        "remove",
+        "cleanup-backup",
+    ):
         command_parser = subparsers.add_parser(action)
         command_parser.add_argument("repo")
     status_parser = subparsers.add_parser("status")
@@ -707,7 +765,15 @@ def main(argv=None):  # noqa: PLR0911 - each CLI action has a distinct exit cont
     )
     governed = load_governed_repos(args.governance_path)
     try:
-        if args.action in {"setup", "audit", "status", "restart", "stop", "remove"}:
+        if args.action in {
+            "setup",
+            "audit",
+            "status",
+            "restart",
+            "stop",
+            "remove",
+            "cleanup-backup",
+        }:
             if args.repo is None:
                 results = [print_audit(manager, args.org, repo) for repo in governed]
                 return 0 if all(results) else 1
@@ -715,7 +781,8 @@ def main(argv=None):  # noqa: PLR0911 - each CLI action has a distinct exit cont
                 raise RuntimeError(f"repository {args.repo!r} is not governed")  # noqa: TRY301
             if args.action in {"audit", "status"}:
                 return 0 if print_audit(manager, args.org, args.repo) else 1
-            getattr(manager, args.action)(args.org, args.repo)
+            action = args.action.replace("-", "_")
+            getattr(manager, action)(args.org, args.repo)
             return 0
         if args.action in {"setup-governed", "setup-all"}:
             if not args.yes:

--- a/tests/test_manage_github_runners.py
+++ b/tests/test_manage_github_runners.py
@@ -1,5 +1,5 @@
 # mypy: ignore-errors
-# pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-public-methods,consider-using-with
+# pylint: disable=too-many-arguments,too-many-instance-attributes,too-many-public-methods,consider-using-with,protected-access
 """Hermetic procfs/systemd/recovery tests for managed GitHub runners."""
 
 import contextlib
@@ -487,13 +487,13 @@ class RunnerManagerTests(unittest.TestCase):
         outside = self.root / "must-survive"
         outside.mkdir()
         with self.assertRaisesRegex(RuntimeError, "unrecognized"):
-            self.manager.remove_runner_tree(self.repo, outside)
+            self.manager._remove_runner_tree(self.repo, outside)
         self.assertTrue(outside.exists())
 
         backup = self.repo_dir.with_name(self.repo + ".recovery-backup")
         backup.symlink_to(outside, target_is_directory=True)
         with self.assertRaisesRegex(RuntimeError, "symlink"):
-            self.manager.remove_runner_tree(self.repo, backup)
+            self.manager._remove_runner_tree(self.repo, backup)
         self.assertTrue(outside.exists())
         self.assertFalse(any(call[0][:1] == ["chown"] for call in self.calls))
 

--- a/tests/test_manage_github_runners.py
+++ b/tests/test_manage_github_runners.py
@@ -469,6 +469,68 @@ class RunnerManagerTests(unittest.TestCase):
         self.assertNotIn("ubuntu-latest", labels)
         self.assertEqual(commands.count(["./svc.sh", "install", self.user]), 1)
         self.assertEqual(commands.count(["./svc.sh", "start"]), 1)
+        backup = self.repo_dir.with_name(self.repo + ".recovery-backup")
+        chown = next(command for command in commands if command[:1] == ["chown"])
+        self.assertEqual(
+            chown,
+            [
+                "chown",
+                "--recursive",
+                "--no-dereference",
+                "--",
+                f"{self.user}:{self.user}",
+                str(backup),
+            ],
+        )
+
+    def test_runner_tree_removal_rejects_arbitrary_path_and_symlink(self):
+        outside = self.root / "must-survive"
+        outside.mkdir()
+        with self.assertRaisesRegex(RuntimeError, "unrecognized"):
+            self.manager.remove_runner_tree(self.repo, outside)
+        self.assertTrue(outside.exists())
+
+        backup = self.repo_dir.with_name(self.repo + ".recovery-backup")
+        backup.symlink_to(outside, target_is_directory=True)
+        with self.assertRaisesRegex(RuntimeError, "symlink"):
+            self.manager.remove_runner_tree(self.repo, backup)
+        self.assertTrue(outside.exists())
+        self.assertFalse(any(call[0][:1] == ["chown"] for call in self.calls))
+
+        shutil.rmtree(self.repo_dir)
+        self.repo_dir.symlink_to(outside, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, "must not be a symlink"):
+            self.manager.repo_dir(self.repo)
+
+    def test_setup_rejects_dangling_recovery_backup_symlink(self):
+        backup = self.repo_dir.with_name(self.repo + ".recovery-backup")
+        backup.symlink_to(self.root / "missing", target_is_directory=True)
+        with self.assertRaisesRegex(RuntimeError, "recovery backup already exists"):
+            self.manager.setup(self.org, self.repo)
+
+    def test_cleanup_backup_requires_healthy_runner_then_removes_exact_tree(self):
+        backup = self.repo_dir.with_name(self.repo + ".recovery-backup")
+        backup.mkdir()
+        (backup / "root-owned-fixture").touch()
+        self.runner["status"] = "offline"
+        with self.assertRaisesRegex(RuntimeError, "runner audit fails"):
+            self.manager.cleanup_backup(self.org, self.repo)
+        self.assertTrue(backup.exists())
+        self.runner["status"] = "online"
+        self.manager.cleanup_backup(self.org, self.repo)
+        self.assertFalse(backup.exists())
+        chown_call = next(call for call in self.calls if call[0][:1] == ["chown"])
+        self.assertTrue(chown_call[2])
+        self.assertEqual(chown_call[0][-1], str(backup))
+
+    def test_failed_ownership_repair_preserves_recovery_backup(self):
+        backup = self.repo_dir.with_name(self.repo + ".recovery-backup")
+        backup.mkdir()
+        self.fail.add("chown")
+        with self.assertRaises(runner_module.subprocess.CalledProcessError):
+            self.manager.cleanup_backup(self.org, self.repo)
+        self.assertTrue(backup.exists())
+        self.assertNotIn(backup, self.removed)
 
     def test_post_setup_failure_restores_old_directory_stopped(self):
         marker = self.repo_dir / "preserve-me"
@@ -501,6 +563,7 @@ class RunnerManagerTests(unittest.TestCase):
             "restart",
             "stop",
             "remove",
+            "cleanup-backup",
             "setup-governed",
             "setup-all",
             "clean-ungoverned",


### PR DESCRIPTION
## Summary

- constrain runner-tree deletion to the exact repository directory or its exact recovery-backup sibling
- reject repository and backup symlinks before privileged cleanup
- reclaim root-owned workflow artifacts without following symlinks, then use the existing filesystem remover
- add an audited `cleanup-backup` command for safely retiring a backup left by an otherwise successful setup
- cover privileged-command construction, fail-closed ownership repair, symlink/path rejection, and healthy-runner preconditions

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` (33 passed before the final focused addition)
- `python3 -m unittest tests.test_manage_github_runners -v` (22 passed)
- `uvx --from ruff==0.16.2 ruff check scripts/manage-github-runners.py tests/test_manage_github_runners.py`
- `uvx --from ruff==0.16.2 ruff format --check scripts/manage-github-runners.py tests/test_manage_github_runners.py`
- `./tests/test-linter-configs.sh` (180 passed)
- `./tests/test-privileged-pr-workflows.sh`
- `./tests/test-sync-managed-files.sh`
- `git diff --check`

Closes #1349
