### PR TITLE
fix: tolerate terminal ghost workflow parents

### DIFF
--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -270,6 +270,23 @@ active_run_ids() {
   done
 }
 
+run_jobs_are_terminal() {
+  local slug="$1" run_id="$2" jobs rc
+  set +e
+  jobs=$(GH_TOKEN="$REPO_SETTINGS_TOKEN" gh api \
+    "repos/${slug}/actions/runs/${run_id}/jobs?filter=all&per_page=100")
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || return "$rc"
+  printf '%s' "$jobs" | jq -e '
+    type == "object" and
+    (.total_count | type == "number" and . > 0) and
+    (.jobs | type == "array") and
+    (.total_count == (.jobs | length)) and
+    all(.jobs[]; .status == "completed")
+  ' >/dev/null
+}
+
 assert_source_current() {
   local current_main
   current_main=$(gh api "repos/${repository}/commits/main" --jq '.sha')
@@ -1177,6 +1194,7 @@ reconcile_bootstrap_prs() {
 
 quiesce_one() {
   local name="$1" slug state runs run_id status attempt rc workflow_present=true empty_sweeps=0
+  local actionable_runs effectively_terminal
   local required_empty_sweeps=1
   slug="${owner}/${name}"
   set +e
@@ -1213,6 +1231,7 @@ quiesce_one() {
     rc=$?
     set -e
     [ "$rc" -eq 0 ] || return "$rc"
+    actionable_runs=0
     while IFS= read -r run_id; do
       [ -n "$run_id" ] || continue
       if [[ ! "$run_id" =~ ^[1-9][0-9]*$ ]]; then
@@ -1224,6 +1243,7 @@ quiesce_one() {
         "repos/${slug}/actions/runs/${run_id}/cancel" --method POST >/dev/null
       rc=$?
       set -e
+      effectively_terminal=false
       if [ "$rc" -ne 0 ]; then
         [ "$rc" -ne 84 ] || return 84
         set +e
@@ -1232,10 +1252,25 @@ quiesce_one() {
         rc=$?
         set -e
         [ "$rc" -eq 0 ] || return "$rc"
-        [ "$status" = "completed" ] || return 1
+        if [ "$status" = "completed" ]; then
+          effectively_terminal=true
+        else
+          set +e
+          run_jobs_are_terminal "$slug" "$run_id"
+          rc=$?
+          set -e
+          [ "$rc" -ne 84 ] || return 84
+          if [ "$rc" -eq 0 ]; then
+            effectively_terminal=true
+            echo "[WARN] Ignoring ghost parent run ${run_id} for ${slug}; all jobs are terminal"
+          else
+            return 1
+          fi
+        fi
       fi
+      [ "$effectively_terminal" = true ] || actionable_runs=$((actionable_runs + 1))
     done <<<"$runs"
-    if [ -z "$runs" ]; then
+    if [ "$actionable_runs" -eq 0 ]; then
       empty_sweeps=$((empty_sweeps + 1))
       [ "$empty_sweeps" -ge "$required_empty_sweeps" ] && break
     else

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -464,6 +464,9 @@ case "$1 $endpoint" in
         printf '\n'
       fi
     elif [[ "$endpoint" == *'status=in_progress'* ]] &&
+      [ "${FAKE_GHOST_RUN:-}" = 1 ]; then
+      printf '905\n'
+    elif [[ "$endpoint" == *'status=in_progress'* ]] &&
       [ "${FAKE_LEGACY_RUN:-}" = 1 ] && [ ! -f "$FAKE_STATE/legacy-canceled" ]; then
       printf '902\n'
     elif [[ "$endpoint" == *'status=in_progress'* ]] &&
@@ -509,6 +512,27 @@ case "$1 $endpoint" in
     ;;
   'api repos/f5-sales-demo/example/actions/runs/904/cancel')
     touch "$FAKE_STATE/forward-transition-canceled"
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/905/cancel')
+    echo 'gh: Failed to cancel workflow run (HTTP 500)' >&2
+    exit 1
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/905')
+    printf 'in_progress\n'
+    ;;
+  'api repos/f5-sales-demo/example/actions/runs/905/jobs?filter=all&per_page=100')
+    case "${FAKE_GHOST_JOBS:-}" in
+      terminal)
+        printf '%s\n' '{"total_count":2,"jobs":[{"status":"completed"},{"status":"completed"}]}'
+        ;;
+      active)
+        printf '%s\n' '{"total_count":2,"jobs":[{"status":"completed"},{"status":"in_progress"}]}'
+        ;;
+      empty) printf '%s\n' '{"total_count":0,"jobs":[]}' ;;
+      incomplete) printf '%s\n' '{"total_count":2,"jobs":[{"status":"completed"}]}' ;;
+      malformed) printf '%s\n' '{"total_count":"two","jobs":{}}' ;;
+      *) exit 1 ;;
+    esac
     ;;
   'api repos/f5-sales-demo/example/contents/.github/workflows/enforce-repo-settings.yml?ref='*)
     if [ "${FAKE_READ_ERROR:-}" = 403 ]; then
@@ -937,6 +961,8 @@ run_bootstrap() {
     FAKE_LEGACY_RUN="${FAKE_LEGACY_RUN:-}" \
     FAKE_UNRELATED_RUN="${FAKE_UNRELATED_RUN:-}" \
     FAKE_MALFORMED_RUN_ID="${FAKE_MALFORMED_RUN_ID:-}" \
+    FAKE_GHOST_RUN="${FAKE_GHOST_RUN:-}" \
+    FAKE_GHOST_JOBS="${FAKE_GHOST_JOBS:-}" \
     FAKE_STALE_REQUIRED_CHECKS="${FAKE_STALE_REQUIRED_CHECKS:-}" \
     FAKE_REQUIRED_CHECKS_ERROR="${FAKE_REQUIRED_CHECKS_ERROR:-}" \
     FAKE_REQUIRED_CHECKS_VERIFY_DRIFT="${FAKE_REQUIRED_CHECKS_VERIFY_DRIFT:-}" \
@@ -1496,6 +1522,51 @@ if [ "$rc" != 83 ] ||
   exit 1
 fi
 echo "[OK] repeated empty inventories catch and cancel status transitions"
+
+state="$WORK/state-ghost-terminal-run"
+mkdir -p "$state"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+FAKE_GHOST_RUN=1
+FAKE_GHOST_JOBS=terminal
+set +e
+run_bootstrap "$state" >"$WORK/ghost-terminal.out" 2>"$WORK/ghost-terminal.err"
+rc=$?
+set -e
+unset FAKE_GHOST_RUN FAKE_GHOST_JOBS
+if [ "$rc" != 83 ] ||
+  ! grep -q 'all jobs are terminal' "$WORK/ghost-terminal.out" ||
+  ! grep -q 'actions/runs/905/cancel --method POST' "$WORK/gh.log" ||
+  ! grep -q 'actions/runs/905/jobs?filter=all&per_page=100' "$WORK/gh.log" ||
+  ! grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr create ' "$WORK/gh.log"; then
+  echo "[FAIL] all-terminal ghost parent did not count as settled quiescence"
+  echo "  rc=$rc"
+  sed 's/^/  out: /' "$WORK/ghost-terminal.out"
+  sed 's/^/  err: /' "$WORK/ghost-terminal.err"
+  sed 's/^/  log: /' "$WORK/gh.log"
+  exit 1
+fi
+echo "[OK] all-terminal ghost parent counts as settled quiescence"
+
+for ghost_jobs in active empty incomplete malformed; do
+  state="$WORK/state-ghost-${ghost_jobs}-run"
+  mkdir -p "$state"
+  : >"$WORK/gh.log"
+  DOWNSTREAM_BLOB="$OLD_BLOB"
+  FAKE_GHOST_RUN=1
+  FAKE_GHOST_JOBS="$ghost_jobs"
+  set +e
+  run_bootstrap "$state" >/dev/null 2>&1
+  rc=$?
+  set -e
+  unset FAKE_GHOST_RUN FAKE_GHOST_JOBS
+  if [ "$rc" = 0 ] ||
+    grep -qE 'git/refs --method POST|contents/.github/workflows/enforce-repo-settings.yml --method PUT|^pr (create|merge)' "$WORK/gh.log"; then
+    echo "[FAIL] ${ghost_jobs} ghost-job inventory did not fail closed"
+    exit 1
+  fi
+done
+echo "[OK] active, empty, incomplete, and malformed ghost-job inventories fail closed"
 
 state="$WORK/state-page-two-owner"
 mkdir -p "$state"


### PR DESCRIPTION
## Summary

- keep normal workflow-run cancellation as the first quiescence operation
- after a cancellation API failure, recognize a ghost parent only from a complete, non-empty job inventory in which every job is terminal
- count proven ghost parents as empty quiescence sweeps while failing closed for active, empty, incomplete, or malformed job inventories
- add hermetic coverage for the exact GitHub state observed in traffic-generator run 31503017304 and demo-resource-template run 31502795627

## Validation

- `./tests/test-bootstrap-downstream-callers.sh` (pass, including terminal-ghost and four fail-closed boundaries)
- `./tests/test-dispatch-matrix.sh` (pass)
- `./tests/test-linter-configs.sh` (180 passed)
- `shellcheck scripts/bootstrap-downstream-callers.sh tests/test-bootstrap-downstream-callers.sh` (pass)
- `git diff --check` (pass)
- Live read-only job inventories for both affected runs contain 3/3 jobs and only `completed` statuses.

Closes #1351
