### PR TITLE
fix(governance): bootstrap translation audit caller

### DIFF
--- a/scripts/bootstrap-downstream-callers.sh
+++ b/scripts/bootstrap-downstream-callers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Deliver the exact enforcement, Super-Linter, and linked-issue workflows
-# through bounded, monotonic PRs before reusable governance is invoked.
+# Deliver the exact enforcement, Super-Linter, translation-audit, and linked-issue
+# workflows through bounded, monotonic PRs before reusable governance is invoked.
 set -euo pipefail
 
 repository="${GITHUB_REPOSITORY:-}"
@@ -13,6 +13,7 @@ repo_settings_config="${REPO_SETTINGS_CONFIG:-.github/config/repo-settings.json}
 governance_config="${GOVERNANCE_CONFIG:-.claude/governance.json}"
 caller_path=".github/workflows/enforce-repo-settings.yml"
 lint_caller_path=".github/workflows/super-linter.yml"
+audit_caller_path=".github/workflows/translation-audit.yml"
 linked_caller_path=".github/workflows/require-linked-issue.yml"
 linked_context="Check linked issues"
 legacy_linked_context="check / Check linked issues"
@@ -146,8 +147,8 @@ gh() {
   return "$rc"
 }
 
-# Enforcement and linked-issue callers are universal. Super-Linter is the one
-# exact caller with intentional repository-owned variants declared in skip_files.
+# Enforcement and linked-issue callers are universal. Super-Linter and the
+# translation audit permit intentional repository-owned variants through skip_files.
 lint_caller_applies() {
   local name="$1"
   ! jq -e --arg repo "$name" --arg path "$lint_caller_path" \
@@ -155,13 +156,23 @@ lint_caller_applies() {
     "$governance_config" >/dev/null
 }
 
+audit_caller_applies() {
+  local name="$1"
+  ! jq -e --arg repo "$name" --arg path "$audit_caller_path" \
+    '(.skip_files[$repo] // []) | index($path) != null' \
+    "$governance_config" >/dev/null
+}
+
 exact_caller_branch_for_repo() {
-  local name="$1" lint_receipt=skipped
+  local name="$1" lint_receipt=skipped audit_receipt=skipped
   if lint_caller_applies "$name"; then
     lint_receipt="$expected_lint_blob"
   fi
-  printf 'sync/exact-caller-%s%s%s' \
-    "$expected_blob" "$lint_receipt" "$expected_linked_blob"
+  if audit_caller_applies "$name"; then
+    audit_receipt="$expected_audit_blob"
+  fi
+  printf 'sync/exact-caller-%s%s%s%s' \
+    "$expected_blob" "$lint_receipt" "$audit_receipt" "$expected_linked_blob"
 }
 
 api_value_or_404() {
@@ -1007,6 +1018,10 @@ recover_linked_transition_receipt() {
     actual=$(gh api "repos/${slug}/contents/${lint_caller_path}?ref=${head}" --jq '.sha')
     [ "$actual" = "$expected_lint_blob" ] || return 1
   fi
+  if audit_caller_applies "$name"; then
+    actual=$(gh api "repos/${slug}/contents/${audit_caller_path}?ref=${head}" --jq '.sha')
+    [ "$actual" = "$expected_audit_blob" ] || return 1
+  fi
   actual=$(gh api "repos/${slug}/contents/${linked_caller_path}?ref=${head}" --jq '.sha')
   [ "$actual" = "$expected_linked_blob" ] || return 1
   jq -n --argjson pr "$pr_number" --arg head "$head" \
@@ -1412,6 +1427,37 @@ if [ "$(git hash-object "$work/lint-caller.yml")" != "$expected_lint_blob" ]; th
 fi
 set +e
 gh api \
+  "repos/${repository}/contents/workflows/translation-audit.yml?ref=${source_sha}" \
+  >"$work/audit-caller.json"
+rc=$?
+set -e
+if [ "$rc" -eq 84 ]; then
+  exit 84
+fi
+if [ "$rc" -ne 0 ]; then
+  echo "[ERROR] Could not fetch the exact translation-audit caller" >&2
+  exit 1
+fi
+if ! jq -e '
+  .type == "file" and .encoding == "base64" and
+  (.sha | type == "string" and test("^[0-9a-f]{40}$")) and
+  (.content | type == "string" and length > 0)
+' "$work/audit-caller.json" >/dev/null; then
+  echo "[ERROR] Translation-audit caller response is malformed" >&2
+  exit 1
+fi
+expected_audit_blob=$(jq -r '.sha' "$work/audit-caller.json")
+jq -r '.content' "$work/audit-caller.json" | tr -d '\n' >"$work/audit-caller.b64"
+if ! base64 -d <"$work/audit-caller.b64" >"$work/audit-caller.yml"; then
+  echo "[ERROR] Translation-audit caller response contains invalid base64" >&2
+  exit 1
+fi
+if [ "$(git hash-object "$work/audit-caller.yml")" != "$expected_audit_blob" ]; then
+  echo "[ERROR] Translation-audit caller bytes do not match the GitHub blob receipt" >&2
+  exit 1
+fi
+set +e
+gh api \
   "repos/${repository}/contents/workflows/require-linked-issue.yml?ref=${source_sha}" \
   >"$work/linked-caller.json"
 rc=$?
@@ -1491,17 +1537,21 @@ echo "[OK] Downstream enforcement workflows are disabled with no active runs"
 
 bootstrap_one() {
   local name="$1" slug default_branch base_sha main_sha actual_blob actual_lint_blob
-  local actual_linked_blob protection_state rc branch_head branch_blob branch_lint_blob
-  local branch_linked_blob
+  local actual_audit_blob actual_linked_blob protection_state rc branch_head branch_blob
+  local branch_lint_blob branch_audit_blob branch_linked_blob
   local expected_change_count first_repo=false
   local branch manages_lint_caller=true lint_caller_exact=true
+  local manages_audit_caller=true audit_caller_exact=true
   local pr_number pr_url pr_body created_pr_number compare_file pr_file verified_head verified_blob
-  local verified_lint_blob verified_linked_blob transition_checks
+  local verified_lint_blob verified_audit_blob verified_linked_blob transition_checks
   local base_commit_file base_tree_sha refresh_tree_file refresh_tree_sha refresh_commit_file
   local refresh_head refresh_ref_file current_base_sha current_branch_head
   slug="${owner}/${name}"
   if ! lint_caller_applies "$name"; then
     manages_lint_caller=false
+  fi
+  if ! audit_caller_applies "$name"; then
+    manages_audit_caller=false
   fi
   branch=$(exact_caller_branch_for_repo "$name")
 
@@ -1547,6 +1597,26 @@ bootstrap_one() {
     esac
     [ "$actual_lint_blob" = "$expected_lint_blob" ] || lint_caller_exact=false
   fi
+  actual_audit_blob=""
+  if [ "$manages_audit_caller" = true ]; then
+    set +e
+    actual_audit_blob=$(api_value_or_404 \
+      "repos/${slug}/contents/${audit_caller_path}?ref=${main_sha}" '.sha')
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      if ! printf '%s' "$actual_audit_blob" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "[ERROR] Invalid live translation-audit caller blob for ${name}" >&2
+        return 1
+      fi
+      ;;
+    44) actual_audit_blob="" ;;
+    84) return 84 ;;
+    *) return 1 ;;
+    esac
+    [ "$actual_audit_blob" = "$expected_audit_blob" ] || audit_caller_exact=false
+  fi
   set +e
   actual_linked_blob=$(api_value_or_404 \
     "repos/${slug}/contents/${linked_caller_path}?ref=${main_sha}" '.sha')
@@ -1564,7 +1634,8 @@ bootstrap_one() {
   *) return 1 ;;
   esac
   if [ -z "$actual_blob" ] && [ -z "$actual_linked_blob" ] &&
-    { [ "$manages_lint_caller" = false ] || [ -z "$actual_lint_blob" ]; }; then
+    { [ "$manages_lint_caller" = false ] || [ -z "$actual_lint_blob" ]; } &&
+    { [ "$manages_audit_caller" = false ] || [ -z "$actual_audit_blob" ]; }; then
     first_repo=true
   fi
   if [ "$first_repo" = true ] && [ "$manages_lint_caller" != true ]; then
@@ -1573,6 +1644,7 @@ bootstrap_one() {
   fi
   if [ "$actual_blob" = "$expected_blob" ] &&
     [ "$lint_caller_exact" = true ] &&
+    [ "$audit_caller_exact" = true ] &&
     [ "$actual_linked_blob" = "$expected_linked_blob" ]; then
     return 0
   fi
@@ -1586,6 +1658,7 @@ bootstrap_one() {
   expected_change_count=0
   [ "$actual_blob" = "$expected_blob" ] || expected_change_count=$((expected_change_count + 1))
   [ "$lint_caller_exact" = true ] || expected_change_count=$((expected_change_count + 1))
+  [ "$audit_caller_exact" = true ] || expected_change_count=$((expected_change_count + 1))
   [ "$actual_linked_blob" = "$expected_linked_blob" ] || expected_change_count=$((expected_change_count + 1))
   default_branch=$(gh api "repos/${slug}" --jq '.default_branch')
   if [ "$default_branch" != "main" ]; then
@@ -1663,6 +1736,26 @@ bootstrap_one() {
     esac
   fi
 
+  branch_audit_blob=""
+  if [ "$manages_audit_caller" = true ]; then
+    set +e
+    branch_audit_blob=$(api_value_or_404 \
+      "repos/${slug}/contents/${audit_caller_path}?ref=${branch_head}" '.sha')
+    rc=$?
+    set -e
+    case "$rc" in
+    0)
+      if ! printf '%s' "$branch_audit_blob" | grep -qE '^[0-9a-f]{40}$'; then
+        echo "[ERROR] Invalid bootstrap translation-audit caller blob for ${name}" >&2
+        return 1
+      fi
+      ;;
+    44) branch_audit_blob="" ;;
+    84) return 84 ;;
+    *) return 1 ;;
+    esac
+  fi
+
   set +e
   branch_linked_blob=$(api_value_or_404 \
     "repos/${slug}/contents/${linked_caller_path}?ref=${branch_head}" '.sha')
@@ -1683,6 +1776,8 @@ bootstrap_one() {
   if { [ "$branch_blob" != "$expected_blob" ] ||
     { [ "$manages_lint_caller" = true ] &&
       [ "$branch_lint_blob" != "$expected_lint_blob" ]; } ||
+    { [ "$manages_audit_caller" = true ] &&
+      [ "$branch_audit_blob" != "$expected_audit_blob" ]; } ||
     [ "$branch_linked_blob" != "$expected_linked_blob" ]; } &&
     [ "$branch_head" != "$base_sha" ]; then
     echo "[ERROR] Refusing to append to a non-exact bootstrap branch for ${name}" >&2
@@ -1713,6 +1808,19 @@ bootstrap_one() {
       --method PUT --input "$work/update-lint-${name}.json" >/dev/null
     branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
   fi
+  if [ "$manages_audit_caller" = true ] &&
+    [ "$branch_audit_blob" != "$expected_audit_blob" ]; then
+    jq -n \
+      --arg message "chore(governance): bootstrap exact translation-audit caller" \
+      --arg branch "$branch" \
+      --arg sha "$branch_audit_blob" \
+      --rawfile content "$work/audit-caller.b64" \
+      '{message: $message, content: $content, branch: $branch, sha: $sha} |
+       if .sha == "" then del(.sha) else . end' >"$work/update-audit-${name}.json"
+    gh api "repos/${slug}/contents/${audit_caller_path}" \
+      --method PUT --input "$work/update-audit-${name}.json" >/dev/null
+    branch_head=$(gh api "repos/${slug}/git/ref/heads/${branch}" --jq '.object.sha')
+  fi
   if [ "$branch_linked_blob" != "$expected_linked_blob" ]; then
     jq -n \
       --arg message "chore(governance): bootstrap exact linked-issue evaluator" \
@@ -1739,14 +1847,17 @@ bootstrap_one() {
     fi
     if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" \
       --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
+      --arg audit_path "$audit_caller_path" --arg audit_blob "$expected_audit_blob" \
       --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
       --argjson manages_lint "$manages_lint_caller" \
+      --argjson manages_audit "$manages_audit_caller" \
       --argjson change_count "$expected_change_count" '
       .status == "diverged" and .ahead_by > 0 and .behind_by > 0 and
       (.files | length) == $change_count and
       all(.files[];
         ((.filename == $path and .sha == $blob) or
          ($manages_lint and .filename == $lint_path and .sha == $lint_blob) or
+         ($manages_audit and .filename == $audit_path and .sha == $audit_blob) or
          (.filename == $linked_path and .sha == $linked_blob)) and
         (.status == "added" or .status == "modified"))
     ' "$compare_file" >/dev/null; then
@@ -1767,14 +1878,19 @@ bootstrap_one() {
     jq -n --arg base_tree "$base_tree_sha" \
       --arg path "$caller_path" --arg blob "$expected_blob" \
       --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
+      --arg audit_path "$audit_caller_path" --arg audit_blob "$expected_audit_blob" \
       --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
-      --argjson manages_lint "$manages_lint_caller" '
+      --argjson manages_lint "$manages_lint_caller" \
+      --argjson manages_audit "$manages_audit_caller" '
       {
         base_tree: $base_tree,
         tree: (
           [{path: $path, mode: "100644", type: "blob", sha: $blob}] +
           (if $manages_lint then
             [{path: $lint_path, mode: "100644", type: "blob", sha: $lint_blob}]
+          else [] end) +
+          (if $manages_audit then
+            [{path: $audit_path, mode: "100644", type: "blob", sha: $audit_blob}]
           else [] end) +
           [{path: $linked_path, mode: "100644", type: "blob", sha: $linked_blob}]
         )
@@ -1842,8 +1958,10 @@ bootstrap_one() {
   fi
   if ! jq -e --arg path "$caller_path" --arg blob "$expected_blob" \
     --arg lint_path "$lint_caller_path" --arg lint_blob "$expected_lint_blob" \
+    --arg audit_path "$audit_caller_path" --arg audit_blob "$expected_audit_blob" \
     --arg linked_path "$linked_caller_path" --arg linked_blob "$expected_linked_blob" \
     --argjson manages_lint "$manages_lint_caller" \
+    --argjson manages_audit "$manages_audit_caller" \
     --argjson change_count "$expected_change_count" '
     .status == "ahead" and .behind_by == 0 and .ahead_by >= $change_count and
     .total_commits == .ahead_by and (.commits | length) == .total_commits and
@@ -1851,6 +1969,7 @@ bootstrap_one() {
     all(.files[];
       ((.filename == $path and .sha == $blob) or
        ($manages_lint and .filename == $lint_path and .sha == $lint_blob) or
+       ($manages_audit and .filename == $audit_path and .sha == $audit_blob) or
        (.filename == $linked_path and .sha == $linked_blob)) and
       (.status == "added" or .status == "modified"))
   ' "$compare_file" >/dev/null; then
@@ -1861,9 +1980,9 @@ bootstrap_one() {
   pr_number="$bootstrap_pr_number"
   created_pr_number=""
   if [ -z "$pr_number" ]; then
-    pr_body="Installs the exact enforcement, Super-Linter, and linked-issue workflows before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement."
+    pr_body="Installs the exact enforcement, Super-Linter, translation-audit, and linked-issue workflows before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement."
     if [ "$first_repo" = true ]; then
-      pr_body="Installs the exact enforcement, Super-Linter, and linked-issue workflows for a first governed repository. Classic branch protection temporarily requires only real checks available on the bootstrap PR; the canonical linked-issue context is restored only after its default-branch workflow reports a real success."
+      pr_body="Installs the exact enforcement, Super-Linter, translation-audit, and linked-issue workflows for a first governed repository. Classic branch protection temporarily requires only real checks available on the bootstrap PR; the canonical linked-issue context is restored only after its default-branch workflow reports a real success."
     fi
     pr_url=$(gh pr create \
       --repo "$slug" \
@@ -1889,14 +2008,17 @@ bootstrap_one() {
   gh pr view "$pr_number" --repo "$slug" \
     --json baseRefName,headRefName,headRefOid,files,commits >"$pr_file"
   if ! jq -e --arg path "$caller_path" --arg lint_path "$lint_caller_path" \
+    --arg audit_path "$audit_caller_path" \
     --arg linked_path "$linked_caller_path" \
     --arg base "$default_branch" --arg head "$branch" --arg oid "$branch_head" \
     --argjson manages_lint "$manages_lint_caller" \
+    --argjson manages_audit "$manages_audit_caller" \
     --argjson change_count "$expected_change_count" '
     .baseRefName == $base and .headRefName == $head and .headRefOid == $oid and
     (.commits | length) >= $change_count and (.files | length) == $change_count and
     all(.files[];
       .path == $path or ($manages_lint and .path == $lint_path) or
+      ($manages_audit and .path == $audit_path) or
       .path == $linked_path)
   ' "$pr_file" >/dev/null; then
     echo "[ERROR] Bootstrap PR for ${name} contains an unexpected diff" >&2
@@ -1926,6 +2048,14 @@ bootstrap_one() {
       "repos/${slug}/contents/${lint_caller_path}?ref=${verified_head}" --jq '.sha')
     if [ "$verified_lint_blob" != "$expected_lint_blob" ]; then
       echo "[ERROR] Super-Linter caller changed after exact PR verification for ${name}" >&2
+      return 1
+    fi
+  fi
+  if [ "$manages_audit_caller" = true ]; then
+    verified_audit_blob=$(gh api \
+      "repos/${slug}/contents/${audit_caller_path}?ref=${verified_head}" --jq '.sha')
+    if [ "$verified_audit_blob" != "$expected_audit_blob" ]; then
+      echo "[ERROR] Translation-audit caller changed after exact PR verification for ${name}" >&2
       return 1
     fi
   fi
@@ -2089,6 +2219,26 @@ while true; do
           exit 1
         fi
         [ "$live_lint_blob" = "$expected_lint_blob" ] || pending=$((pending + 1))
+        ;;
+      44) pending=$((pending + 1)) ;;
+      84) exit 84 ;;
+      *) exit 1 ;;
+      esac
+    fi
+
+    if audit_caller_applies "$name"; then
+      set +e
+      live_audit_blob=$(api_value_or_404 \
+        "repos/${slug}/contents/${audit_caller_path}?ref=${main_sha}" '.sha')
+      rc=$?
+      set -e
+      case "$rc" in
+      0)
+        if ! printf '%s' "$live_audit_blob" | grep -qE '^[0-9a-f]{40}$'; then
+          echo "[ERROR] Invalid live translation-audit caller receipt while verifying ${name}" >&2
+          exit 1
+        fi
+        [ "$live_audit_blob" = "$expected_audit_blob" ] || pending=$((pending + 1))
         ;;
       44) pending=$((pending + 1)) ;;
       84) exit 84 ;;

--- a/scripts/run-consumer-shell-tests.sh
+++ b/scripts/run-consumer-shell-tests.sh
@@ -151,7 +151,7 @@ if [ "$discovered" != "$expected" ]; then
 
   bootstrap_transition=false
   if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] &&
-    [[ "${GITHUB_HEAD_REF:-}" =~ ^sync/exact-caller-[0-9a-f]{40}(skipped|[0-9a-f]{40})[0-9a-f]{40}$ ]] &&
+    [[ "${GITHUB_HEAD_REF:-}" =~ ^sync/exact-caller-[0-9a-f]{40}(skipped|[0-9a-f]{40})(skipped|[0-9a-f]{40})[0-9a-f]{40}$ ]] &&
     [ -z "$unexpected" ] && [ -n "$missing" ]; then
     bootstrap_transition=true
     while IFS= read -r path; do

--- a/tests/test-bootstrap-downstream-callers.sh
+++ b/tests/test-bootstrap-downstream-callers.sh
@@ -24,6 +24,9 @@ CALLER_BLOB=$(printf '%s\n' "$CALLER_TEXT" | git hash-object --stdin)
 LINT_CALLER_TEXT='name: Super-Linter'
 LINT_CALLER_CONTENT=$(printf '%s\n' "$LINT_CALLER_TEXT" | base64 | tr -d '\n')
 LINT_CALLER_BLOB=$(printf '%s\n' "$LINT_CALLER_TEXT" | git hash-object --stdin)
+AUDIT_CALLER_TEXT='name: Translation Audit'
+AUDIT_CALLER_CONTENT=$(printf '%s\n' "$AUDIT_CALLER_TEXT" | base64 | tr -d '\n')
+AUDIT_CALLER_BLOB=$(printf '%s\n' "$AUDIT_CALLER_TEXT" | git hash-object --stdin)
 LINKED_CALLER_TEXT='name: Require Linked Issue'
 LINKED_CALLER_CONTENT=$(printf '%s\n' "$LINKED_CALLER_TEXT" | base64 | tr -d '\n')
 LINKED_CALLER_BLOB=$(printf '%s\n' "$LINKED_CALLER_TEXT" | git hash-object --stdin)
@@ -124,6 +127,13 @@ if ! grep -Fq 'contents/workflows/super-linter.yml?ref=${source_sha}' "$SOURCE" 
 fi
 echo "[OK] bootstrap carries the lint caller that validates its own PR"
 
+if ! grep -Fq 'contents/workflows/translation-audit.yml?ref=${source_sha}' "$SOURCE" ||
+  ! grep -Fq '.github/workflows/translation-audit.yml' "$SOURCE"; then
+  echo "[FAIL] exact-caller bootstrap does not carry the major-only translation audit caller"
+  exit 1
+fi
+echo "[OK] bootstrap carries the audit caller that prevents legacy freshness deadlocks"
+
 if grep -Fqi 'checkov' "$SOURCE" || ! grep -Fq 'first_repo' "$SOURCE"; then
   echo "[FAIL] first-repository bootstrap is not limited to exact managed callers"
   exit 1
@@ -175,6 +185,14 @@ case "$1 $endpoint" in
     else
       printf '{"type":"file","encoding":"base64","sha":"%s","content":"%s"}\n' \
         "$LINT_CALLER_BLOB" "$LINT_CALLER_CONTENT"
+    fi
+    ;;
+  'api repos/f5-sales-demo/docs-control/contents/workflows/translation-audit.yml?ref='*)
+    if [[ "$*" == *'--jq .sha'* ]]; then
+      printf '%s\n' "$AUDIT_CALLER_BLOB"
+    else
+      printf '{"type":"file","encoding":"base64","sha":"%s","content":"%s"}\n' \
+        "$AUDIT_CALLER_BLOB" "$AUDIT_CALLER_CONTENT"
     fi
     ;;
   'api repos/f5-sales-demo/docs-control/contents/workflows/require-linked-issue.yml?ref='*)
@@ -424,6 +442,9 @@ case "$1 $endpoint" in
   'api repos/f5-sales-demo/example-two/contents/.github/workflows/super-linter.yml?ref='*)
     printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
     ;;
+  'api repos/f5-sales-demo/example-two/contents/.github/workflows/translation-audit.yml?ref='*)
+    printf '%s\n' "$DOWNSTREAM_AUDIT_BLOB"
+    ;;
   'api repos/f5-sales-demo/example-two/contents/.github/workflows/require-linked-issue.yml?ref='*)
     printf '%s\n' "$DOWNSTREAM_LINKED_BLOB"
     ;;
@@ -583,6 +604,29 @@ case "$1 $endpoint" in
       printf '%s\n' "$DOWNSTREAM_LINT_BLOB"
     fi
     ;;
+  'api repos/f5-sales-demo/example/contents/.github/workflows/translation-audit.yml?ref='*)
+    if [ "${FAKE_FORBID_AUDIT_READ:-}" = 1 ]; then
+      echo 'unexpected opted-out translation-audit caller read' >&2
+      exit 65
+    fi
+    ref=${endpoint##*ref=}
+    if { [ "${FAKE_FIRST_REPO:-}" = 1 ] ||
+      [ "${FAKE_PROTECTED_EMPTY_CALLERS:-}" = 1 ]; } &&
+      [ ! -f "$FAKE_STATE/merged" ] &&
+      [ "$ref" != "$BRANCH_HEAD" ]; then
+      echo 'gh: Not Found (HTTP 404)' >&2
+      exit 1
+    elif { [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; } &&
+      [ -f "$FAKE_STATE/audit-updated" ]; then
+      printf '%s\n' "$AUDIT_CALLER_BLOB"
+    elif [ "$ref" = "$BRANCH_HEAD" ] || [ "$ref" = "$REFRESH_HEAD" ]; then
+      printf '%s\n' "$DOWNSTREAM_AUDIT_BLOB"
+    elif [ -f "$FAKE_STATE/merged" ]; then
+      printf '%s\n' "$AUDIT_CALLER_BLOB"
+    else
+      printf '%s\n' "$DOWNSTREAM_AUDIT_BLOB"
+    fi
+    ;;
   'api repos/f5-sales-demo/example/contents/.github/workflows/require-linked-issue.yml?ref='*)
     ref=${endpoint##*ref=}
     if [ "${FAKE_BAD_RECOVER_LINKED:-}" = 1 ] && [ "$ref" = "$BRANCH_HEAD" ]; then
@@ -694,7 +738,7 @@ case "$1 $endpoint" in
       elif [ -f "$FAKE_STATE/refreshed" ]; then
         printf '%s\n' "$REFRESH_HEAD"
       elif [ -f "$FAKE_STATE/updated" ] || [ -f "$FAKE_STATE/lint-updated" ] ||
-        [ -f "$FAKE_STATE/linked-updated" ]; then
+        [ -f "$FAKE_STATE/audit-updated" ] || [ -f "$FAKE_STATE/linked-updated" ]; then
         printf '%s\n' "$BRANCH_HEAD"
       else
         printf '%s\n' "$BASE_SHA"
@@ -719,15 +763,21 @@ case "$1 $endpoint" in
     done
     [ -n "$input" ] || exit 64
     skip_lint=false
+    skip_audit=false
     [ "${FAKE_SKIP_LINT_CALLER:-}" != 1 ] || skip_lint=true
+    [ "${FAKE_SKIP_AUDIT_CALLER:-}" != 1 ] || skip_audit=true
     jq -e --arg base "$BASE_TREE" --arg caller "$CALLER_BLOB" \
-      --arg lint "$LINT_CALLER_BLOB" --arg linked "$LINKED_CALLER_BLOB" \
-      --argjson skip_lint "$skip_lint" '
+      --arg lint "$LINT_CALLER_BLOB" --arg audit "$AUDIT_CALLER_BLOB" \
+      --arg linked "$LINKED_CALLER_BLOB" --argjson skip_lint "$skip_lint" \
+      --argjson skip_audit "$skip_audit" '
       .base_tree == $base and
       .tree == (
         [{path:".github/workflows/enforce-repo-settings.yml",mode:"100644",type:"blob",sha:$caller}] +
         (if $skip_lint then [] else
           [{path:".github/workflows/super-linter.yml",mode:"100644",type:"blob",sha:$lint}]
+        end) +
+        (if $skip_audit then [] else
+          [{path:".github/workflows/translation-audit.yml",mode:"100644",type:"blob",sha:$audit}]
         end) +
         [{path:".github/workflows/require-linked-issue.yml",mode:"100644",type:"blob",sha:$linked}]
       )
@@ -777,6 +827,9 @@ case "$1 $endpoint" in
   'api repos/f5-sales-demo/example/contents/.github/workflows/super-linter.yml')
     touch "$FAKE_STATE/lint-updated"
     ;;
+  'api repos/f5-sales-demo/example/contents/.github/workflows/translation-audit.yml')
+    touch "$FAKE_STATE/audit-updated"
+    ;;
   'api repos/f5-sales-demo/example/contents/.github/workflows/require-linked-issue.yml')
     touch "$FAKE_STATE/linked-updated"
     ;;
@@ -792,6 +845,12 @@ case "$1 $endpoint" in
       [ "$DOWNSTREAM_LINT_BLOB" != "$LINT_CALLER_BLOB" ]; then
       files=$(jq -cn --argjson files "$files" --arg sha "$LINT_CALLER_BLOB" \
         '$files + [{filename:".github/workflows/super-linter.yml",sha:$sha,status:"modified"}]')
+      count=$((count + 1))
+    fi
+    if [ "${FAKE_SKIP_AUDIT_CALLER:-}" != 1 ] &&
+      [ "$DOWNSTREAM_AUDIT_BLOB" != "$AUDIT_CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" --arg sha "$AUDIT_CALLER_BLOB" \
+        '$files + [{filename:".github/workflows/translation-audit.yml",sha:$sha,status:"modified"}]')
       count=$((count + 1))
     fi
     if [ "$DOWNSTREAM_LINKED_BLOB" != "$LINKED_CALLER_BLOB" ]; then
@@ -873,6 +932,12 @@ case "$1 $endpoint" in
       files=$(jq -cn --argjson files "$files" '$files + [{path:".github/workflows/super-linter.yml"}]')
       count=$((count + 1))
     fi
+    if [ "${FAKE_SKIP_AUDIT_CALLER:-}" != 1 ] &&
+      [ "$DOWNSTREAM_AUDIT_BLOB" != "$AUDIT_CALLER_BLOB" ]; then
+      files=$(jq -cn --argjson files "$files" \
+        '$files + [{path:".github/workflows/translation-audit.yml"}]')
+      count=$((count + 1))
+    fi
     if [ "$DOWNSTREAM_LINKED_BLOB" != "$LINKED_CALLER_BLOB" ]; then
       files=$(jq -cn --argjson files "$files" \
         '$files + [{path:".github/workflows/require-linked-issue.yml"}]')
@@ -906,10 +971,14 @@ chmod +x "$WORK/bin/gh"
 run_bootstrap() {
   local state="$1"
   local expected_lint_receipt="$LINT_CALLER_BLOB"
+  local expected_audit_receipt="$AUDIT_CALLER_BLOB"
   if [ "${FAKE_SKIP_LINT_CALLER:-}" = 1 ]; then
     expected_lint_receipt=skipped
   fi
-  local expected_branch="sync/exact-caller-${CALLER_BLOB}${expected_lint_receipt}${LINKED_CALLER_BLOB}"
+  if [ "${FAKE_SKIP_AUDIT_CALLER:-}" = 1 ]; then
+    expected_audit_receipt=skipped
+  fi
+  local expected_branch="sync/exact-caller-${CALLER_BLOB}${expected_lint_receipt}${expected_audit_receipt}${LINKED_CALLER_BLOB}"
   env \
     PATH="$WORK/bin:$PATH" \
     GITHUB_REPOSITORY=f5-sales-demo/docs-control \
@@ -939,13 +1008,18 @@ run_bootstrap() {
     CALLER_CONTENT="$CALLER_CONTENT" \
     LINT_CALLER_BLOB="$LINT_CALLER_BLOB" \
     LINT_CALLER_CONTENT="$LINT_CALLER_CONTENT" \
+    AUDIT_CALLER_BLOB="$AUDIT_CALLER_BLOB" \
+    AUDIT_CALLER_CONTENT="$AUDIT_CALLER_CONTENT" \
     LINKED_CALLER_BLOB="$LINKED_CALLER_BLOB" \
     LINKED_CALLER_CONTENT="$LINKED_CALLER_CONTENT" \
     DOWNSTREAM_BLOB="$DOWNSTREAM_BLOB" \
     DOWNSTREAM_LINT_BLOB="${DOWNSTREAM_LINT_BLOB:-$LINT_CALLER_BLOB}" \
+    DOWNSTREAM_AUDIT_BLOB="${DOWNSTREAM_AUDIT_BLOB:-$AUDIT_CALLER_BLOB}" \
     DOWNSTREAM_LINKED_BLOB="${DOWNSTREAM_LINKED_BLOB:-$LINKED_CALLER_BLOB}" \
     FAKE_SKIP_LINT_CALLER="${FAKE_SKIP_LINT_CALLER:-}" \
     FAKE_FORBID_LINT_READ="${FAKE_FORBID_LINT_READ:-}" \
+    FAKE_SKIP_AUDIT_CALLER="${FAKE_SKIP_AUDIT_CALLER:-}" \
+    FAKE_FORBID_AUDIT_READ="${FAKE_FORBID_AUDIT_READ:-}" \
     FAKE_READ_ERROR="${FAKE_READ_ERROR:-}" \
     FAKE_MAIN_ADVANCE_AT="${FAKE_MAIN_ADVANCE_AT:-}" \
     FAKE_DIVERGED_BASE="${FAKE_DIVERGED_BASE:-}" \
@@ -983,6 +1057,7 @@ run_bootstrap() {
 
 DOWNSTREAM_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_AUDIT_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
 for lint_mode in absent pending failed malformed spoofed wrong-pr wrong-run; do
   state="$WORK/state-first-repo-${lint_mode}-lint"
@@ -1016,7 +1091,7 @@ for lint_mode in absent pending failed malformed spoofed wrong-pr wrong-run; do
     exit 1
   fi
 done
-unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_AUDIT_BLOB DOWNSTREAM_LINKED_BLOB
 echo "[OK] absent, pending, failed, malformed, spoofed, and untrusted first-repository lint receipts fail closed"
 
 state="$WORK/state-stale"
@@ -1231,6 +1306,28 @@ if [ "$rc" != 83 ] ||
 fi
 echo "[OK] exact enforcement with stale lint updates only lint and remains quiesced"
 
+state="$WORK/state-stale-audit-only"
+mkdir -p "$state"
+touch "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$CALLER_BLOB"
+DOWNSTREAM_AUDIT_BLOB="$OLD_BLOB"
+set +e
+run_bootstrap "$state" >"$WORK/stale-audit-only.out" 2>"$WORK/stale-audit-only.err"
+rc=$?
+set -e
+unset DOWNSTREAM_AUDIT_BLOB
+if [ "$rc" != 83 ] ||
+  grep -q 'contents/.github/workflows/enforce-repo-settings.yml --method PUT' "$WORK/gh.log" ||
+  grep -q 'contents/.github/workflows/super-linter.yml --method PUT' "$WORK/gh.log" ||
+  ! grep -q 'contents/.github/workflows/translation-audit.yml --method PUT' "$WORK/gh.log" ||
+  grep -q 'actions/workflows/enforce-repo-settings.yml/enable --method PUT' "$WORK/gh.log"; then
+  echo "[FAIL] stale legacy translation audit was not replaced in the exact bootstrap PR"
+  cat "$WORK/stale-audit-only.err"
+  exit 1
+fi
+echo "[OK] stale legacy translation audit is replaced before managed-file fan-out"
+
 cat >"$WORK/governance-skip-lint.json" <<'EOF'
 {"skip_files":{"example":[".github/workflows/super-linter.yml"]}}
 EOF
@@ -1262,6 +1359,38 @@ if [ "$rc" != 83 ] ||
   exit 1
 fi
 echo "[OK] opted-out lint caller is untouched while mandatory callers stay fail-closed"
+
+cat >"$WORK/governance-skip-audit.json" <<'EOF'
+{"skip_files":{"example":[".github/workflows/translation-audit.yml"]}}
+EOF
+state="$WORK/state-skip-stale-audit"
+mkdir -p "$state"
+touch "$state/disabled"
+: >"$WORK/gh.log"
+DOWNSTREAM_BLOB="$OLD_BLOB"
+DOWNSTREAM_AUDIT_BLOB="$OLD_BLOB"
+FAKE_SKIP_AUDIT_CALLER=1
+FAKE_FORBID_AUDIT_READ=1
+set +e
+TEST_GOVERNANCE_CONFIG="$WORK/governance-skip-audit.json" run_bootstrap "$state" \
+  >"$WORK/skip-stale-audit.out" 2>"$WORK/skip-stale-audit.err"
+rc=$?
+set -e
+unset DOWNSTREAM_AUDIT_BLOB FAKE_SKIP_AUDIT_CALLER FAKE_FORBID_AUDIT_READ \
+  TEST_GOVERNANCE_CONFIG
+if [ "$rc" != 83 ] ||
+  ! grep -q 'contents/.github/workflows/enforce-repo-settings.yml --method PUT' \
+    "$WORK/gh.log" ||
+  grep -q 'example/contents/.github/workflows/translation-audit.yml' "$WORK/gh.log" ||
+  grep -q 'contents/.github/workflows/translation-audit.yml --method PUT' "$WORK/gh.log" ||
+  grep -q 'actions/workflows/enforce-repo-settings.yml/enable --method PUT' \
+    "$WORK/gh.log"; then
+  echo "[FAIL] opted-out audit caller was read, changed, or allowed to bypass exact enforcement"
+  cat "$WORK/skip-stale-audit.err"
+  sed 's/^/  log: /' "$WORK/gh.log"
+  exit 1
+fi
+echo "[OK] opted-out audit caller is untouched while mandatory callers stay fail-closed"
 
 state="$WORK/state-diverged-skip-stale-lint"
 mkdir -p "$state"
@@ -1918,6 +2047,7 @@ mkdir -p "$state"
 : >"$WORK/gh.log"
 DOWNSTREAM_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_AUDIT_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
 FAKE_FIRST_REPO=1
 FAKE_FIRST_REPO_LINT_MODE=success
@@ -1926,7 +2056,7 @@ set +e
 run_bootstrap "$state" >"$WORK/first-repo.out" 2>"$WORK/first-repo.err"
 rc=$?
 set -e
-unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO \
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_AUDIT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO \
   FAKE_FIRST_REPO_LINT_MODE FAKE_MERGE_LANDS
 protection_line=$(grep -n 'branches/main/protection --method PUT' "$WORK/gh.log" |
   head -1 | cut -d: -f1 || true)
@@ -1950,7 +2080,7 @@ if [ "$rc" != 0 ] || [ -z "$protection_line" ] || [ -z "$check_line" ] ||
     "$state/transition-protection.json" >/dev/null ||
   ! jq -e '.contexts | index("Check linked issues") != null' \
     "$state/final-required-checks.json" >/dev/null; then
-  echo "[FAIL] first governed repository did not complete the verified three-caller transition"
+  echo "[FAIL] first governed repository did not complete the verified four-caller transition"
   echo "  rc=$rc"
   sed 's/^/  /' "$WORK/first-repo.err"
   sed 's/^/  log: /' "$WORK/gh.log"
@@ -1965,6 +2095,7 @@ cp "$WORK/state-first-repo/transition-protection.json" \
   "$state/transition-protection.json"
 : >"$WORK/gh.log"
 DOWNSTREAM_LINT_BLOB="$OLD_BLOB"
+DOWNSTREAM_AUDIT_BLOB="$OLD_BLOB"
 DOWNSTREAM_LINKED_BLOB="$OLD_BLOB"
 FAKE_FIRST_REPO=1
 FAKE_MERGE_LANDS=1
@@ -1973,7 +2104,8 @@ run_bootstrap "$state" >"$WORK/resume-first-repo-protection.out" \
   2>"$WORK/resume-first-repo-protection.err"
 rc=$?
 set -e
-unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_LINKED_BLOB FAKE_FIRST_REPO FAKE_MERGE_LANDS
+unset DOWNSTREAM_LINT_BLOB DOWNSTREAM_AUDIT_BLOB DOWNSTREAM_LINKED_BLOB \
+  FAKE_FIRST_REPO FAKE_MERGE_LANDS
 if [ "$rc" != 0 ] ||
   grep -q 'branches/main/protection --method PUT' "$WORK/gh.log" ||
   ! grep -q '^pr merge ' "$WORK/gh.log" ||
@@ -2001,11 +2133,11 @@ if ! grep -q 'pulls?state=closed&sort=updated&direction=desc&per_page=100' "$WOR
   [ "$(grep -c 'required_status_checks --method PATCH' "$WORK/gh.log")" -ne 1 ] ||
   grep -qE 'git/refs --method POST|contents/.github/workflows/.* --method PUT|^pr (create|merge)' \
     "$WORK/gh.log"; then
-  echo "[FAIL] interrupted first-repository transition did not recover from three exact blobs"
+  echo "[FAIL] interrupted first-repository transition did not recover from four exact blobs"
   cat "$WORK/recover-first-repo.err"
   exit 1
 fi
-echo "[OK] interrupted first-repository transition recovers from three exact blobs"
+echo "[OK] interrupted first-repository transition recovers from four exact blobs"
 
 state="$WORK/state-hostile-first-repo-receipt"
 mkdir -p "$state"

--- a/tests/test-consumer-shell-tests.sh
+++ b/tests/test-consumer-shell-tests.sh
@@ -139,7 +139,7 @@ assert_contains "inventory does not match" "missing-test failure explains the dr
 # Exact-caller bootstrap can precede managed-file delivery. Only a missing test
 # declared by the canonical managed-file inventory may be deferred, and only on
 # the strictly formed generated receipt branch.
-bootstrap_branch="sync/exact-caller-$(printf 'a%.0s' {1..120})"
+bootstrap_branch="sync/exact-caller-$(printf 'a%.0s' {1..160})"
 config=$(write_config bootstrap-managed '{
   "managed_files": {
     "files": [


### PR DESCRIPTION
## Summary

- add the managed major-only translation-audit caller to the exact downstream bootstrap contract
- bind branch ownership, exact diffs, protected-main refreshes, verification, and fleet receipts to the audit blob while preserving `skip_files`
- extend the consumer shell-test selector to authenticate the new four-receipt bootstrap branch
- add regression coverage for the live legacy freshness-audit deadlock and audit opt-outs

## Live failure repaired

`f5-sales-demo/mcn#923` failed `audit / Translation freshness` on an ordinary `sync/exact-caller-*` PR because the legacy audit caller ran before managed-file fan-out could install the new major-only policy. The exact bootstrap previously carried enforcement, Super-Linter, and linked-issue callers but omitted translation-audit.

## Verification

- `bash tests/test-bootstrap-downstream-callers.sh`
- `bash tests/test-consumer-shell-tests.sh` (34/34)
- dispatch/preflight, governed pins/scripts, managed-file protection/sync, translation policy/suspension/validator
- linter configuration (180/180), review routing (69/69), agent guidance (116/116), API resilience, Antigravity controls
- `pre-commit run --files` on all four changed shell files
- ShellCheck, shfmt, `git diff --check`
- staged and head PII enforcement/audit clean
- Antigravity pre-push reviewer/verifier: no critical or high findings

Closes #1356