### PR TITLE
fix(i18n): make translation audit bootstrap-safe

### DIFF
--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -32,6 +32,10 @@ jobs:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
+          if [[ ! "$HEAD_REF" =~ ^release/v[1-9][0-9]*\.0\.0$ ]]; then
+            echo "[i18n] translation freshness is not applicable outside an exact major-release branch"
+            exit 0
+          fi
           git tag --list >"$RUNNER_TEMP/translation-tags.txt"
           decision=$(bash scripts/translation-release-policy.sh \
             --head-ref "$HEAD_REF" --tags-file "$RUNNER_TEMP/translation-tags.txt")

--- a/tests/test-translation-release-policy.sh
+++ b/tests/test-translation-release-policy.sh
@@ -62,6 +62,95 @@ CALLER="$REPO_ROOT/workflows/antigravity-translate.yml"
 TRANSLATE="$REPO_ROOT/.github/workflows/antigravity-translate.yml"
 AUDIT="$REPO_ROOT/.github/workflows/translation-audit.yml"
 
+AUDIT_BODY=$(awk '
+  /^      - name: Audit translation freshness$/ {step=1}
+  step && /^        run: \|$/ {capture=1; next}
+  capture && /^          / {sub(/^          /, ""); print; next}
+  capture {exit}
+' "$AUDIT")
+
+assert_audit_without_scripts() {
+  local expected=$1 label=$2 head_ref=$3
+  local scenario="$WORK/audit-$PASS-$FAIL"
+  mkdir -p "$scenario/temp"
+  git -C "$scenario" init -q
+
+  local output rc
+  set +e
+  output=$(cd "$scenario" &&
+    RUNNER_TEMP="$scenario/temp" HEAD_REF="$head_ref" bash -c "$AUDIT_BODY" 2>&1)
+  rc=$?
+  set -e
+
+  if [ "$expected" = success ] && [ "$rc" -eq 0 ] &&
+    grep -qF 'not applicable outside an exact major-release branch' <<<"$output"; then
+    pass "$label"
+  elif [ "$expected" = failure ] && [ "$rc" -ne 0 ] &&
+    grep -qF 'scripts/translation-release-policy.sh' <<<"$output"; then
+    pass "$label"
+  else
+    fail "$label" "exit=$rc output=$output"
+  fi
+}
+
+assert_audit_without_scripts success \
+  "exact-caller bootstrap is not applicable before policy scripts arrive" \
+  sync/exact-caller-deadbeef
+assert_audit_without_scripts success \
+  "ordinary development is not applicable before policy scripts arrive" \
+  feature/1358-bootstrap-safe-translation-audit
+assert_audit_without_scripts success \
+  "minor releases are not applicable before policy scripts arrive" \
+  release/v20.1.0
+assert_audit_without_scripts success \
+  "patch releases are not applicable before policy scripts arrive" \
+  release/v20.0.1
+assert_audit_without_scripts success \
+  "prefixed major-like branches are not applicable before policy scripts arrive" \
+  preview/release/v20.0.0
+assert_audit_without_scripts success \
+  "leading-zero major branches are not applicable before policy scripts arrive" \
+  release/v020.0.0
+assert_audit_without_scripts failure \
+  "exact major candidates fail closed when policy scripts are absent" \
+  release/v20.0.0
+
+assert_exact_audit_route() {
+  local eligible=$1 expected_calls=$2 label=$3
+  local scenario="$WORK/exact-$eligible"
+  mkdir -p "$scenario/scripts" "$scenario/temp"
+  git -C "$scenario" init -q
+  cat >"$scenario/scripts/translation-release-policy.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'policy\n' >>"$AUDIT_CALLS"
+printf 'eligible=%s\n' "$FAKE_ELIGIBLE"
+EOF
+  cat >"$scenario/scripts/validate-translations.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'validator:%s\n' "$*" >>"$AUDIT_CALLS"
+EOF
+
+  local output rc
+  set +e
+  output=$(cd "$scenario" &&
+    AUDIT_CALLS="$scenario/calls" FAKE_ELIGIBLE="$eligible" \
+      RUNNER_TEMP="$scenario/temp" HEAD_REF=release/v20.0.0 \
+      bash -c "$AUDIT_BODY" 2>&1)
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ] && [ "$(cat "$scenario/calls")" = "$expected_calls" ]; then
+    pass "$label"
+  else
+    fail "$label" "exit=$rc calls=$(cat "$scenario/calls" 2>/dev/null || true) output=$output"
+  fi
+}
+
+assert_exact_audit_route true $'policy\nvalidator:--all' \
+  "policy-approved exact major candidates run the full-corpus validator"
+assert_exact_audit_route false 'policy' \
+  "policy-rejected exact major candidates do not run the validator"
+
 if grep -qF 'scripts/translation-release-policy.sh' "$WATCHER" &&
   grep -qF -- '--argjson reconcile_all true' "$WATCHER"; then
   pass "fleet watcher routes only policy-approved full reconciliation"


### PR DESCRIPTION
## Summary

Make the major-only translation audit bootstrap-safe by rejecting every non-exact `release/vN.0.0` branch before it depends on managed policy scripts. This lets exact-caller bootstrap PRs report translation freshness as not applicable while exact major candidates remain fail-closed and fully validated.

## Related Issue

Closes #1358

## Changes

- Add a script-free exact branch-shape guard to the reusable translation audit.
- Preserve canonical policy and full-corpus validation for exact major candidates.
- Execute the workflow step hermetically across bootstrap, development, minor, patch, malformed, and exact-major cases.

## Verification evidence

- `bash tests/test-translation-release-policy.sh` — 22 passed, 0 failed.
- Translation suspension 10/10; validator 16/16; consumer selector 34/34.
- Managed protection 138/138; sync 73/73; linter configuration 180/180; agent guidance 116/116.
- Dispatch, source, review-routing, privileged-workflow, and Antigravity feature UAT suites passed.
- `actionlint .github/workflows/translation-audit.yml`, ShellCheck, shfmt, YAML/security hooks, staged PII enforcement, and `git diff --check` passed.
- Antigravity pre-push gate passed with no critical or high finding.
- Repository-wide local Actionlint also reports an unrelated pre-existing `DOCS_SITE` SC2153 warning in `.github/workflows/github-pages-deploy.yml`; that file is unchanged.

## Delivery evidence

- Feature branch pushed; squash auto-merge and the CI repair loop will remain active through `MERGED`.
- The governed workflow pin, manifest, downstream caller bootstrap, and fleet blob-SHA convergence will be verified after merge.

## Checklist

- [x] Linked to a detailed issue with `Closes #1358`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions