### PR TITLE
fix: trust translation audit tooling receipt

### DIFF
--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -21,23 +21,58 @@ jobs:
     name: Translation freshness
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Resolve governed audit tooling receipt
+        id: governance
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: |
+          set -euo pipefail
+          repository=$(jq -r '.workflow_repository // ""' <<<"$JOB_CONTEXT")
+          sha=$(jq -r '.workflow_sha // ""' <<<"$JOB_CONTEXT")
+          test "$repository" = "f5-sales-demo/docs-control"
+          grep -qE '^[0-9a-f]{40}$' <<<"$sha"
+          printf 'repository=%s\nsha=%s\n' "$repository" "$sha" >>"$GITHUB_OUTPUT"
+
+      - name: Checkout consumer pull request
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          path: consumer
           persist-credentials: false
 
+      # A pull request can replace its own scripts. Load the audit contract from
+      # the exact reusable-workflow receipt instead, in a sibling checkout that
+      # downstream content cannot pre-populate or redirect.
+      - name: Checkout governed audit tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ steps.governance.outputs.repository }}
+          ref: ${{ steps.governance.outputs.sha }}
+          path: governance
+          persist-credentials: false
+
+      - name: Verify governed audit tooling receipt
+        env:
+          GOVERNANCE_REPOSITORY: ${{ steps.governance.outputs.repository }}
+          GOVERNANCE_SHA: ${{ steps.governance.outputs.sha }}
+        run: |
+          set -euo pipefail
+          test "$GOVERNANCE_REPOSITORY" = "f5-sales-demo/docs-control"
+          grep -qE '^[0-9a-f]{40}$' <<<"$GOVERNANCE_SHA"
+          test "$(git -C governance rev-parse HEAD)" = "$GOVERNANCE_SHA"
+
       - name: Audit translation freshness
+        working-directory: consumer
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
           git tag --list >"$RUNNER_TEMP/translation-tags.txt"
-          decision=$(bash scripts/translation-release-policy.sh \
+          decision=$(bash ../governance/scripts/translation-release-policy.sh \
             --head-ref "$HEAD_REF" --tags-file "$RUNNER_TEMP/translation-tags.txt")
           printf '%s\n' "$decision"
           if ! grep -qxF 'eligible=true' <<<"$decision"; then
             echo "[i18n] translation freshness is not applicable outside the next major release"
             exit 0
           fi
-          bash scripts/validate-translations.sh --all
+          bash ../governance/scripts/validate-translations.sh --all

--- a/tests/test-translation-release-policy.sh
+++ b/tests/test-translation-release-policy.sh
@@ -72,12 +72,12 @@ AUDIT_BODY=$(awk '
 assert_audit_without_scripts() {
   local expected=$1 label=$2 head_ref=$3
   local scenario="$WORK/audit-$PASS-$FAIL"
-  mkdir -p "$scenario/temp"
-  git -C "$scenario" init -q
+  mkdir -p "$scenario/consumer" "$scenario/temp"
+  git -C "$scenario/consumer" init -q
 
   local output rc
   set +e
-  output=$(cd "$scenario" &&
+  output=$(cd "$scenario/consumer" &&
     RUNNER_TEMP="$scenario/temp" HEAD_REF="$head_ref" bash -c "$AUDIT_BODY" 2>&1)
   rc=$?
   set -e
@@ -118,21 +118,21 @@ assert_audit_without_scripts failure \
 assert_exact_audit_route() {
   local eligible=$1 expected_calls=$2 label=$3
   local scenario="$WORK/exact-$eligible"
-  mkdir -p "$scenario/scripts" "$scenario/temp"
-  git -C "$scenario" init -q
-  cat >"$scenario/scripts/translation-release-policy.sh" <<'EOF'
+  mkdir -p "$scenario/consumer" "$scenario/governance/scripts" "$scenario/temp"
+  git -C "$scenario/consumer" init -q
+  cat >"$scenario/governance/scripts/translation-release-policy.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'policy\n' >>"$AUDIT_CALLS"
 printf 'eligible=%s\n' "$FAKE_ELIGIBLE"
 EOF
-  cat >"$scenario/scripts/validate-translations.sh" <<'EOF'
+  cat >"$scenario/governance/scripts/validate-translations.sh" <<'EOF'
 #!/usr/bin/env bash
 printf 'validator:%s\n' "$*" >>"$AUDIT_CALLS"
 EOF
 
   local output rc
   set +e
-  output=$(cd "$scenario" &&
+  output=$(cd "$scenario/consumer" &&
     AUDIT_CALLS="$scenario/calls" FAKE_ELIGIBLE="$eligible" \
       RUNNER_TEMP="$scenario/temp" HEAD_REF=release/v20.0.0 \
       bash -c "$AUDIT_BODY" 2>&1)

--- a/tests/test-translation-release-policy.sh
+++ b/tests/test-translation-release-policy.sh
@@ -78,12 +78,41 @@ else
     "reconcile_all is not bound end to end"
 fi
 
-if grep -qF 'scripts/translation-release-policy.sh' "$AUDIT" &&
-  grep -qF 'scripts/validate-translations.sh --all' "$AUDIT"; then
-  pass "freshness audit is major-release-only and validates the full corpus"
+if grep -qF 'working-directory: consumer' "$AUDIT" &&
+  grep -qF 'bash ../governance/scripts/translation-release-policy.sh' "$AUDIT" &&
+  grep -qF 'bash ../governance/scripts/validate-translations.sh --all' "$AUDIT"; then
+  pass "freshness audit is major-release-only and validates the full consumer corpus"
 else
-  fail "freshness audit is major-release-only and validates the full corpus" \
-    "audit policy or full validation route is absent"
+  fail "freshness audit is major-release-only and validates the full consumer corpus" \
+    "trusted audit policy or full validation route is absent"
+fi
+
+if grep -qF 'JOB_CONTEXT: ${{ toJSON(job) }}' "$AUDIT" &&
+  grep -qF "repository=\$(jq -r '.workflow_repository // \"\"'" "$AUDIT" &&
+  grep -qF "sha=\$(jq -r '.workflow_sha // \"\"'" "$AUDIT" &&
+  grep -qF 'repository: ${{ steps.governance.outputs.repository }}' "$AUDIT" &&
+  grep -qF 'ref: ${{ steps.governance.outputs.sha }}' "$AUDIT" &&
+  grep -qF 'test "$GOVERNANCE_REPOSITORY" = "f5-sales-demo/docs-control"' "$AUDIT" &&
+  grep -qF 'test "$(git -C governance rev-parse HEAD)" = "$GOVERNANCE_SHA"' "$AUDIT"; then
+  pass "freshness audit binds tooling to its exact reusable-workflow receipt"
+else
+  fail "freshness audit binds tooling to its exact reusable-workflow receipt" \
+    "trusted workflow repository or immutable receipt verification is absent"
+fi
+
+if [ "$(grep -cF 'persist-credentials: false' "$AUDIT")" -eq 2 ] &&
+  grep -qF 'path: consumer' "$AUDIT" && grep -qF 'path: governance' "$AUDIT"; then
+  pass "consumer and governance checkouts are isolated and credential-free"
+else
+  fail "consumer and governance checkouts are isolated and credential-free" \
+    "checkout isolation or credential suppression is incomplete"
+fi
+
+if grep -Eq '(^|[[:space:]])bash scripts/(translation-release-policy|validate-translations)\.sh' "$AUDIT"; then
+  fail "freshness audit never executes pull-request-controlled policy scripts" \
+    "audit invokes a translation policy script from the consumer checkout"
+else
+  pass "freshness audit never executes pull-request-controlled policy scripts"
 fi
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #1359

## Summary

- isolate downstream pull-request content under `consumer/`
- resolve and validate the reusable workflow identity from the GitHub `job.workflow_*` context
- check out docs-control at the exact reusable-workflow SHA under `governance/`
- execute release policy and translation validation only from the trusted checkout
- add regression assertions for immutable identity, isolated credential-free checkouts, and rejection of downstream-script execution

## Verification

- `bash tests/test-translation-release-policy.sh` (16 passed)
- `bash tests/test-bootstrap-downstream-callers.sh` (pass)
- focused consumer/sync/linter/translation suites (all pass)
- `python3 -m unittest discover -s tests -p "test_*.py"` (34 passed)
- complete docs-control shell inventory via `scripts/run-consumer-shell-tests.sh` (pass)
- `actionlint .github/workflows/translation-audit.yml`
- `git diff --check`
