### PR TITLE
fix(pii): recognize xcsh service home paths (#1366)

### DIFF
--- a/scripts/check_pii.py
+++ b/scripts/check_pii.py
@@ -382,6 +382,7 @@ SURROGATE_ESCAPE_LAST = 0xDCFF
 SAFE_EMAIL_DOMAINS = {"example.com", "example.net", "example.org"}
 PROVENANCE_EMAIL_DOMAINS = {"noreply.github.com", "users.noreply.github.com"}
 SAFE_HOME_USERS = {
+    "xcsh",
     "you",
     "user",
     "users",

--- a/tests/test-check-pii.sh
+++ b/tests/test-check-pii.sh
@@ -2062,10 +2062,12 @@ git -C "$repo" commit -qm path
 assert_violation "personal home path" "$repo" --scope head --mode enforce
 
 repo=$(new_repo placeholder-paths)
-printf 'mac=/Users/you/work ci=/home/runner/work variable=/home/${USERNAME}/work route=/home/%s\n' index >"${repo}/config.ini"
+SYNTHETIC_SERVICE_USER=xcsh
+printf 'mac=/Users/you/work ci=/home/runner/work service=/home/%s/.config variable=/home/${USERNAME}/work route=/home/%s\n' \
+  "$SYNTHETIC_SERVICE_USER" index >"${repo}/config.ini"
 git -C "$repo" add config.ini
 git -C "$repo" commit -qm paths
-assert_clean "placeholder, CI, and variable home paths" "$repo" --scope head --mode enforce
+assert_clean "placeholder, CI, service, and variable home paths" "$repo" --scope head --mode enforce
 
 repo=$(new_repo embedded-home-tokens)
 printf 'keys=Shift+page/%s/%s route=service/%s/%s windows=prefixC:\\%s\\%s\n' home end Users list Users record >"${repo}/config.ini"


### PR DESCRIPTION
## Summary

- recognize the public `xcsh` application account as a safe home-directory segment
- cover `/home/xcsh` alongside existing placeholder, CI, and variable paths
- retain the existing negative personal-home-path assertion

## Verification

- `bash tests/test-check-pii.sh`
- `python3 -m compileall -q scripts/check_pii.py`
- `bash scripts/check-pii.sh --scope staged --mode enforce`
- `git diff --check`

Closes #1366
