### PR TITLE
fix(i18n): make policy tests portable downstream

### DIFF
--- a/tests/test-translation-release-policy.sh
+++ b/tests/test-translation-release-policy.sh
@@ -62,6 +62,27 @@ CALLER="$REPO_ROOT/workflows/antigravity-translate.yml"
 TRANSLATE="$REPO_ROOT/.github/workflows/antigravity-translate.yml"
 AUDIT="$REPO_ROOT/.github/workflows/translation-audit.yml"
 
+# The policy script and the decisions above are fleet-managed. The remaining
+# assertions cover docs-control's canonical implementation, whose fleet watcher
+# and reusable workflow are deliberately absent from downstream repositories.
+if [ ! -f "$WATCHER" ] && [ ! -f "$CALLER" ]; then
+  printf '  SKIP: docs-control-only translation workflow assertions are not applicable\n'
+  printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+  [ "$FAIL" -eq 0 ]
+  exit
+fi
+
+for subject in "$WATCHER" "$CALLER" "$TRANSLATE" "$AUDIT"; do
+  if [ ! -f "$subject" ]; then
+    fail "docs-control translation workflow subjects are complete" \
+      "missing ${subject#"$REPO_ROOT"/}"
+  fi
+done
+if [ "$FAIL" -ne 0 ]; then
+  printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
 AUDIT_BODY=$(awk '
   /^      - name: Audit translation freshness$/ {step=1}
   step && /^        run: \|$/ {capture=1; next}


### PR DESCRIPTION
## What

- keep fleet-managed major-release policy decisions under test everywhere
- skip docs-control-only workflow implementation assertions when both canonical-only subjects are absent downstream
- fail closed if a docs-control implementation subject set is only partially present

## Why

Managed sync PR f5-sales-demo/xcsh#3120 currently fails because the canonical test expects docs-control-only watcher and reusable-workflow files in a downstream repository. The correction must originate here and propagate through managed-file sync.

## Testing

- `shellcheck tests/test-translation-release-policy.sh`
- `bash tests/test-translation-release-policy.sh` (25 passed)
- isolated downstream-shaped fixture (10 passed, explicit skip)
- `bash tests/test-linter-configs.sh` (180 passed)

Closes #1369