### PR TITLE
fix(governance): make managed validator lint-portable

### DIFF
--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, TRY003
-# pylint: disable=invalid-name,too-many-branches,broad-exception-caught
+# pylint: disable=invalid-name,too-many-branches,broad-exception-caught,import-error
+# fmt: off
 """Fail-closed authorization for Zizmor self-hosted-runner findings."""
 
 import argparse

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -142,12 +142,25 @@ actual = {
 has_inline_portability_suppression = any(
     marker in source for marker in ("noqa: BLE001", "noqa: TRY301")
 )
-raise SystemExit(0 if actual == expected and not has_inline_portability_suppression else 1)
+has_downstream_lint_contract = all(
+    marker in source
+    for marker in (
+        "# pylint: disable=invalid-name,too-many-branches,broad-exception-caught,import-error",
+        "# fmt: off",
+    )
+)
+raise SystemExit(
+    0
+    if actual == expected
+    and not has_inline_portability_suppression
+    and has_downstream_lint_contract
+    else 1
+)
 PY
-  pass "4.4 validator CLI catches portable input/I/O failures without BLE suppression"
+  pass "4.4 validator carries portable downstream lint and exception contracts"
 else
-  fail "4.4 validator CLI catches portable input/I/O failures without BLE suppression" \
-    "expected only OSError/ValueError and no inline BLE001 suppression"
+  fail "4.4 validator carries portable downstream lint and exception contracts" \
+    "expected exact exceptions, no inline BLE001 suppression, and downstream lint guards"
 fi
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

- preserve the canonical validator formatting across downstream Ruff profiles with a formatter guard
- suppress only Pylint import resolution for the runtime-provided PyYAML dependency
- extend the managed linter regression test to require both downstream portability contracts

## Why

The exact managed rollout exposed that xcsh uses a 120-column Ruff profile and does not install PyYAML in its lint container. The canonical validator must remain byte-identical and lint-clean under both docs-control and downstream profiles.

## Testing

- `bash tests/test-linter-configs.sh` (180 passed)
- validator unit suite (12 passed)
- `bash tests/test-workflow-security-validator-integration.sh`
- Super-Linter v8.7.0 Ruff/Pylint under docs-control and xcsh profiles
- `git diff --check`

Closes #1375