### PR TITLE
chore(governance): regenerate managed-files-manifest.json

### DIFF
--- a/.github/config/managed-files-manifest.json
+++ b/.github/config/managed-files-manifest.json
@@ -1,5 +1,5 @@
 {
-  "source_commit": "ac0ba518c4958a7e15b5fb1773d9d0a0debe1b0d",
+  "source_commit": "cee19147283134dd777ea751757dbd6c69b14fa5",
   "files": {
     ".github/workflows/github-pages-deploy.yml": {
       "src": "workflows/github-pages-deploy.yml",
@@ -473,8 +473,8 @@
     "scripts/workflow-security-validator.py": {
       "src": "scripts/workflow-security-validator.py",
       "dest": "scripts/workflow-security-validator.py",
-      "sha": "56fe703890be77166594e72ab9a52f524c735457",
-      "size": 20706,
+      "sha": "a050fc336c82db80a169a30d541b583b389fe89b",
+      "size": 20730,
       "mode": "100755"
     },
     ".github/config/self-hosted-runner-policy.json": {


### PR DESCRIPTION
Automated managed-files manifest refresh. Auto-merges once checks pass; sync reads this to take the fast path instead of per-file API fetches.