### PR TITLE
fix(governance): make validator Ruff-name portable

### DIFF
--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, N999, TRY003
+# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, N999, RUF100, TRY003
 # pylint: disable=invalid-name,too-many-branches,broad-exception-caught,import-error
 # fmt: off
 """Fail-closed authorization for Zizmor self-hosted-runner findings."""

--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, TRY003
+# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, N999, TRY003
 # pylint: disable=invalid-name,too-many-branches,broad-exception-caught,import-error
 # fmt: off
 """Fail-closed authorization for Zizmor self-hosted-runner findings."""

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -145,6 +145,7 @@ has_inline_portability_suppression = any(
 has_downstream_lint_contract = all(
     marker in source
     for marker in (
+        "# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, N999, TRY003",
         "# pylint: disable=invalid-name,too-many-branches,broad-exception-caught,import-error",
         "# fmt: off",
     )
@@ -160,7 +161,7 @@ PY
   pass "4.4 validator carries portable downstream lint and exception contracts"
 else
   fail "4.4 validator carries portable downstream lint and exception contracts" \
-    "expected exact exceptions, no inline BLE001 suppression, and downstream lint guards"
+    "expected exact exceptions, no inline BLE001 suppression, and Ruff/Pylint/format guards"
 fi
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -145,7 +145,7 @@ has_inline_portability_suppression = any(
 has_downstream_lint_contract = all(
     marker in source
     for marker in (
-        "# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, N999, TRY003",
+        "# ruff: noqa: ANN001, ANN201, D101, D103, EM101, EM102, N999, RUF100, TRY003",
         "# pylint: disable=invalid-name,too-many-branches,broad-exception-caught,import-error",
         "# fmt: off",
     )


### PR DESCRIPTION
## Summary

- make the managed validator portable across divergent downstream Ruff profiles
- suppress `N999` for the governed hyphenated script filename and `RUF100` for profile-dependent file-level codes
- lock the exact Ruff/Pylint/format compatibility markers into the managed linter regression test
- preserve validator behavior and all security authorization semantics

## Exact-head verification

Reviewed head: `6c6353a19806ca1f01aaf18542f35eecf40a8a7f`

- Ruff 0.14.14 and 0.16.2 check and format pass under docs-control, api-specs, api-specs-enriched, terraform-provider-xcsh, and xcsh configs
- `bash tests/test-linter-configs.sh` — 180 passed
- `python3 -m unittest tests/test_workflow_security_validator.py` — 12 passed
- `bash tests/test-workflow-security-validator-integration.sh /home/robin/GIT/developer/terraform-provider-xcsh-scratch` — captured/live Zizmor pass; ungoverned mutation fails closed
- `bash tests/test-sync-managed-files.sh` — 73 passed
- `git diff --check` — PASS

No translation model or locale generation was run.

Closes #1378