### PR TITLE
ci(xcsh): require the Alpine container test

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -66,7 +66,7 @@
       "additional_contexts": ["Run plugin test suites"]
     },
     "xcsh": {
-      "additional_contexts": ["check", "pii-guard", "test"]
+      "additional_contexts": ["check", "container-test", "pii-guard", "test"]
     },
     "vscode-xcsh": {
       "additional_contexts": ["Validate Generation", "Test (ubuntu-latest)", "Build VSIX"]

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -304,6 +304,13 @@ else
   fail "7c.2 xcsh requires the pii-guard check" "pii-guard is not in xcsh additional_contexts"
 fi
 
+if echo "$XCSH_CONTEXTS" | jq -e 'index("container-test") != null' >/dev/null; then
+  pass "7c.3 xcsh requires the container-test check"
+else
+  fail "7c.3 xcsh requires the container-test check" \
+    "container-test is not in xcsh additional_contexts"
+fi
+
 # ════════════════════════════════════════════════════════════════════
 # SECTION 7d: additional_contexts must name checks that ALWAYS run
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #1380

## What

- Add `container-test` to `.repo_overrides.xcsh.additional_contexts`.
- Add a regression assertion that xcsh keeps the container context in canonical repository settings.

## Why

xcsh#3100 has merged the unconditional pull-request container workflow and its final head reported `container-test` successfully. Requiring the context now makes the hardened Alpine build, runtime, Compose contract, and deterministic UAT a protected-main gate without introducing a missing-check deadlock.

## Testing

- `jq empty .github/config/repo-settings.json`
- `shellcheck tests/test-linter-configs.sh`
- `bash tests/test-linter-configs.sh` — 181 passed
- `bash tests/test-protect-managed-files.sh` — 138 passed
- `bash tests/test-dispatch-matrix.sh`
- `git diff --check`
- Verified xcsh#3100 reported successful `container-test` before merge
