### PR TITLE
fix(security): validate documented Zizmor exit codes

### DIFF
--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -61,10 +61,14 @@ jobs:
           targets=(.github/workflows/ workflows/*.yml)
           ZIZMOR_EXIT=0
           uvx --from 'zizmor==1.29.0' zizmor --no-config --no-ignores --persona=auditor --format=json "${targets[@]}" > zizmor-findings.json 2>zizmor-diagnostics.log || ZIZMOR_EXIT=$?
-          if [ "$ZIZMOR_EXIT" -ne 0 ] && [ "$ZIZMOR_EXIT" -ne 13 ]; then
-            echo "::error::Zizmor execution failed with exit code ${ZIZMOR_EXIT}"
-            exit 1
-          fi
+          case "$ZIZMOR_EXIT" in
+            0|11|12|13|14) ;;
+            *)
+              cat zizmor-diagnostics.log >&2
+              echo "::error::Zizmor execution failed with exit code ${ZIZMOR_EXIT}"
+              exit 1
+              ;;
+          esac
           uv run --with 'PyYAML==6.0.2' --no-project python scripts/workflow-security-validator.py \
             --repository "$AUDITED_REPOSITORY" \
             --policy .github/config/self-hosted-runner-policy.json \

--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -35,7 +35,12 @@ ALLOWED_PERMISSIONS = {
     "contents": {"read", "none"},
     "checks": {"write", "read", "none"},
 }
-ZIZMOR_FINDINGS_EXIT = 13
+ZIZMOR_EXIT_BY_SEVERITY = {
+    "Informational": 11,
+    "Low": 12,
+    "Medium": 13,
+    "High": 14,
+}
 
 
 class PolicyError(ValueError):
@@ -46,12 +51,29 @@ def validate_zizmor_result(exit_code, findings):
     """Validate Zizmor's documented findings exit contract before authorization."""
     if not isinstance(findings, list):
         raise PolicyError("Zizmor output must be a JSON array")
-    if exit_code == 0 and findings:
+    if not findings:
+        if exit_code != 0:
+            raise PolicyError("Zizmor empty output requires exit 0")
+        return
+    if exit_code == 0:
         raise PolicyError("Zizmor exit 0 requires an empty finding array")
-    if exit_code == ZIZMOR_FINDINGS_EXIT and not findings:
-        raise PolicyError("Zizmor findings exit requires a non-empty finding array")
-    if exit_code not in {0, ZIZMOR_FINDINGS_EXIT}:
-        raise PolicyError(f"unsupported Zizmor exit code: {exit_code}")
+
+    expected_exit = 0
+    for index, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            raise PolicyError(f"Zizmor finding {index} must be an object")
+        determinations = finding.get("determinations")
+        if not isinstance(determinations, dict):
+            raise PolicyError(f"Zizmor finding {index} determinations must be an object")
+        severity = determinations.get("severity")
+        if severity not in ZIZMOR_EXIT_BY_SEVERITY:
+            raise PolicyError(f"Zizmor finding {index} has invalid severity: {severity!r}")
+        expected_exit = max(expected_exit, ZIZMOR_EXIT_BY_SEVERITY[severity])
+
+    if exit_code != expected_exit:
+        raise PolicyError(
+            f"Zizmor findings require exit {expected_exit}, received {exit_code}"
+        )
 
 
 def strict_object(value, allowed, context):

--- a/tests/test_workflow_security_validator.py
+++ b/tests/test_workflow_security_validator.py
@@ -82,7 +82,9 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
     def tearDown(self):
         self.temp.cleanup()
 
-    def finding(self, ident="self-hosted-runner", route=None, locations=None):
+    def finding(
+        self, ident="self-hosted-runner", route=None, locations=None, severity="Medium"
+    ):
         if route is None:
             route = [{"Key": "jobs"}, {"Key": self.job_id}, {"Key": "runs-on"}]
         location = {
@@ -94,6 +96,8 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         return {
             "ident": ident,
             "locations": locations if locations is not None else [location],
+            "determinations": {"severity": severity},
+            "ignored": False,
         }
 
     def write_fixture(self, workflow=None, policy=None, governance=None):
@@ -348,14 +352,36 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         self.assert_rejected(workflow=workflow, policy=policy)
 
     def test_zizmor_exit_and_json_contract(self):
+        severities = {
+            "Informational": 11,
+            "Low": 12,
+            "Medium": 13,
+            "High": 14,
+        }
         validator.validate_zizmor_result(0, [])
-        validator.validate_zizmor_result(13, self.findings)
-        for code, findings in ((0, self.findings), (13, []), (1, [])):
+        for severity, code in severities.items():
+            validator.validate_zizmor_result(code, [self.finding(severity=severity)])
+
+        rejected = [
+            (0, self.findings),
+            (11, []),
+            (12, [self.finding(severity="Informational")]),
+            (13, [self.finding(severity="High")]),
+            (14, [self.finding(severity="Low")]),
+            (1, []),
+            (15, [self.finding(severity="High")]),
+        ]
+        for code, findings in rejected:
             with (
                 self.subTest(code=code, findings=findings),
                 self.assertRaises(validator.PolicyError),
             ):
                 validator.validate_zizmor_result(code, findings)
+
+        malformed = self.finding()
+        del malformed["determinations"]
+        with self.assertRaises(validator.PolicyError):
+            validator.validate_zizmor_result(13, [malformed])
         with self.assertRaises(validator.PolicyError):
             validator.validate_zizmor_result(13, {"findings": self.findings})
         with self.assertRaises(json.JSONDecodeError):

--- a/workflows/workflow-security-audit.yml
+++ b/workflows/workflow-security-audit.yml
@@ -61,10 +61,14 @@ jobs:
           targets=(.github/workflows/ workflows/*.yml)
           ZIZMOR_EXIT=0
           uvx --from 'zizmor==1.29.0' zizmor --no-config --no-ignores --persona=auditor --format=json "${targets[@]}" > zizmor-findings.json 2>zizmor-diagnostics.log || ZIZMOR_EXIT=$?
-          if [ "$ZIZMOR_EXIT" -ne 0 ] && [ "$ZIZMOR_EXIT" -ne 13 ]; then
-            echo "::error::Zizmor execution failed with exit code ${ZIZMOR_EXIT}"
-            exit 1
-          fi
+          case "$ZIZMOR_EXIT" in
+            0|11|12|13|14) ;;
+            *)
+              cat zizmor-diagnostics.log >&2
+              echo "::error::Zizmor execution failed with exit code ${ZIZMOR_EXIT}"
+              exit 1
+              ;;
+          esac
           uv run --with 'PyYAML==6.0.2' --no-project python scripts/workflow-security-validator.py \
             --repository "$AUDITED_REPOSITORY" \
             --policy .github/config/self-hosted-runner-policy.json \


### PR DESCRIPTION
Closes #1386

- accept Zizmor finding exits 11 through 14
- validate the exit against the highest reported severity
- fail closed on empty, malformed, unsupported, or inconsistent results
- keep the governed and executable workflow copies identical