### PR TITLE
chore(governance): recognize hosted ARM runner

### DIFF
--- a/actionlint.yml
+++ b/actionlint.yml
@@ -2,5 +2,6 @@
 self-hosted-runner:
   labels:
     - terraform-provider-xcsh
+    - ubuntu-24.04-arm
 
 config-variables: null

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -56,12 +56,15 @@ done
 if python3 - "$REPO_ROOT/actionlint.yml" <<'PY'; then
 import sys, yaml
 config = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
-assert config.get("self-hosted-runner", {}).get("labels") == ["terraform-provider-xcsh"]
+assert config.get("self-hosted-runner", {}).get("labels") == [
+    "terraform-provider-xcsh",
+    "ubuntu-24.04-arm",
+]
 PY
-  pass "2.1 actionlint recognizes the governed provider runner label"
+  pass "2.1 actionlint recognizes the governed and hosted ARM runner labels"
 else
-  fail "2.1 actionlint recognizes the governed provider runner label" \
-    "self-hosted-runner.labels must contain the exact governed label"
+  fail "2.1 actionlint recognizes the governed and hosted ARM runner labels" \
+    "self-hosted-runner.labels must contain the exact governed labels"
 fi
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- add GitHub’s `ubuntu-24.04-arm` hosted runner to the fleet-managed actionlint configuration
- enforce the exact governed runner-label set in the linter configuration test
- keep downstream protected-file updates owned by docs-control automation

## Verification

- `bash tests/test-linter-configs.sh` (181 passed)
- all `tests/test-*.sh` suites
- `actionlint -config-file actionlint.yml workflows/*.yml`
- `actionlint -config-file actionlint.yml /data/robin-GIT/xcsh/.worktrees/feature/issue-3133-multi-arch-container/.github/workflows/container.yml`
- `shellcheck tests/test-linter-configs.sh`
- `shfmt -d tests/test-linter-configs.sh`
- staged PII enforcement and gitleaks

Closes #1400