### PR TITLE
fix: isolate runner profiles and harden pilot provisioning

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -158,7 +158,7 @@
     "f5-sales-demo/terraform-provider-xcsh": {
       ".github/workflows/acc-tests.yml": {
         "real-api-tests": {
-          "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh"],
+          "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh", "ubuntu-24.04"],
           "environment": "acceptance-tests",
           "permissions": {
             "checks": "write",
@@ -208,7 +208,7 @@
           "if": "always() &&\ngithub.event_name != 'pull_request' &&\n((github.event_name == 'schedule' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'full' &&\n  needs.mock-tests.result == 'success') ||\n (github.event_name == 'workflow_dispatch' &&\n  github.event.inputs.mode == 'real-only' &&\n  needs.mock-tests.result == 'skipped'))\n"
         },
         "cleanup": {
-          "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh"],
+          "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh", "ubuntu-24.04"],
           "environment": "acceptance-tests",
           "permissions": {
             "contents": "read"
@@ -259,7 +259,7 @@
       },
       ".github/workflows/discover-defaults.yml": {
         "discover": {
-          "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh"],
+          "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh", "ubuntu-24.04"],
           "environment": "default-discovery",
           "permissions": {},
           "allowed_secrets": ["REPO_SYNC_TOKEN", "XCSH_API_TOKEN", "XCSH_API_URL"],

--- a/.github/workflows/antigravity-fleet-watcher.yml
+++ b/.github/workflows/antigravity-fleet-watcher.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   collect:
     name: Collect exact-head workflow state
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 25
     environment: antigravity-automation
     permissions:
@@ -264,7 +264,7 @@ jobs:
     name: Triage failed workflows with Antigravity
     if: needs.collect.outputs.has_failures == 'true'
     needs: collect
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 35
     environment: antigravity-automation
     permissions:
@@ -355,7 +355,7 @@ jobs:
     name: Publish receipts and dispatch exact heads
     if: always() && needs.collect.result == 'success'
     needs: [collect, triage]
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 45
     environment: antigravity-automation
     permissions:

--- a/.github/workflows/antigravity-review.yml
+++ b/.github/workflows/antigravity-review.yml
@@ -47,7 +47,7 @@ jobs:
   review:
     name: PR review with Antigravity
     if: vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 35
     permissions:
       contents: read
@@ -194,7 +194,7 @@ jobs:
     name: Publish exact-head review
     if: always() && vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
     needs: review
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/antigravity-translate.yml
+++ b/.github/workflows/antigravity-translate.yml
@@ -61,7 +61,7 @@ jobs:
     if: >-
       vars.TRANSLATIONS_ENABLED == 'true' &&
       inputs.expected_head_sha != ''
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 35
     permissions:
       contents: read
@@ -362,7 +362,7 @@ jobs:
   publish:
     name: Publish exact-head translations
     needs: translate
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Enable trusted-author auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: write # merge trusted same-repository pull requests
       pull-requests: write # enable squash auto-merge

--- a/.github/workflows/build-managed-files-manifest.yml
+++ b/.github/workflows/build-managed-files-manifest.yml
@@ -59,7 +59,7 @@ concurrency:
 jobs:
   build:
     name: Build managed-files manifest
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     environment: repository-settings
     permissions:
       contents: read # check out the protected governance source

--- a/.github/workflows/configure-antigravity-controls.yml
+++ b/.github/workflows/configure-antigravity-controls.yml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   configure:
     name: Apply fail-closed organization controls
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 30
     environment: antigravity-automation
     permissions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Approve and enable auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: write # merge validated Dependabot updates
       pull-requests: write # approve pull requests and enable auto-merge

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   dispatch:
     name: Dispatch downstream enforcement
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     timeout-minutes: 30
     environment: repository-settings
     # No conclusion guard needed: dispatch now fires only when the manifest has

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   enforce:
     name: Enforce repository settings
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     steps:
       - name: Checkout calling repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   build:
     name: Build Documentation
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # checkout the documentation source
       packages: read # authenticate and resolve the latest builder image from GHCR
@@ -248,7 +248,7 @@ jobs:
   deploy:
     name: Deploy Documentation
     needs: build
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     if: success()
     permissions:
       pages: write # publish the verified Pages artifact

--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -3,9 +3,7 @@ name: Publish runner images
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 concurrency:
   group: publish-runner-images
@@ -15,6 +13,9 @@ jobs:
   publish:
     name: Publish ${{ matrix.profile }}
     runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    permissions:
+      contents: read # check out the runner image source
+      packages: write # publish runner images to GHCR
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   publish:
     name: Publish ${{ matrix.profile }}
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", container-build]
     permissions:
       contents: read # check out the runner image source
       packages: write # publish runner images to GHCR

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   check:
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       issues: write # read linked issues and publish one deduplicated guidance comment
       pull-requests: read # enumerate open pull requests and linked-issue references

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   lint:
     name: Lint Code Base
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     # Scoped to what the linter needs: read code/packages, write commit statuses
     # and PR annotations. The shell-unit-tests job below gets contents:read only.
     permissions:
@@ -473,7 +473,7 @@ jobs:
 
   shell-unit-tests:
     name: Shell Unit Tests
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/sync-managed-files.yml
+++ b/.github/workflows/sync-managed-files.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   sync:
     name: Sync managed files
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # check out the exact downstream protected-main receipt
     steps:

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   audit:
     name: Translation freshness
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     steps:
       - name: Resolve governed audit tooling receipt
         id: governance

--- a/.github/workflows/update-governed-workflow-pins.yml
+++ b/.github/workflows/update-governed-workflow-pins.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   update:
     name: Update governed workflow pins
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     environment: repository-settings
     permissions:
       contents: read # check out the protected governance source

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   audit:
     name: Audit workflows (zizmor)
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -23,6 +23,7 @@ self-hosted-runner:
     - docs-control
     - docs-icons
     - docs-theme
+    - fixture
     - i18n-core
     - marketplace
     - marketplace-claude-code

--- a/docs/self-hosted-runners.md
+++ b/docs/self-hosted-runners.md
@@ -7,10 +7,10 @@ organization repositories are inventory-only and are not changed by this system.
 
 ## Security model
 
-Every Linux job routes to labels that identify one repository:
+Every Linux job routes to labels that identify one repository and one isolation profile:
 
 ```yaml
-runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
 ```
 
 A controller registers a new runner with `--ephemeral --disableupdate`, launches it in a
@@ -24,10 +24,11 @@ The default profile has:
 
 - A read-only container root, all capabilities dropped, and `no-new-privileges`.
 - A private network namespace with workstation loopback access disabled.
-- CPU, memory, and process limits.
+- CPU, memory, and process limits enforced by the per-instance systemd cgroup.
 - A dedicated Unix account and rootless Podman storage for each repository.
 - No host container socket.
 
+The explicit profile label prevents a default job from matching a more privileged builder.
 The `container-build` profile uses a second account with a repository-specific rootless Podman
 API socket. It cannot reach another repository's images or containers. A build job can control
 its own builder account, so only workflows that require container builds receive this profile.

--- a/scripts/audit-runner-workflows.py
+++ b/scripts/audit-runner-workflows.py
@@ -72,7 +72,7 @@ def exception_for(exceptions, relative, job_id):
     return workflow.get(job_id)
 
 
-def audit_job(repository, relative, job_id, job, profiles, exceptions):
+def audit_job(repository, relative, job_id, job, profiles, exceptions, default_profile):
     errors = []
     if not isinstance(job, dict):
         return [f"{relative}/{job_id}: job must be an object"]
@@ -103,7 +103,7 @@ def audit_job(repository, relative, job_id, job, profiles, exceptions):
         if not isinstance(reason, str) or len(reason.strip()) < 12:
             errors.append(f"{relative}/{job_id}: hosted exception reason is incomplete")
     else:
-        profile = None
+        profile = default_profile
         if isinstance(runs_on, list) and len(runs_on) == 5:
             candidates = [
                 name
@@ -158,7 +158,15 @@ def audit_repository(root, repository, policy_path):
             if exception_for(exceptions, relative, job_id) is not None:
                 actual_exceptions.add((relative, job_id))
             errors.extend(
-                audit_job(repository, relative, job_id, job, profiles, exceptions)
+                audit_job(
+                    repository,
+                    relative,
+                    job_id,
+                    job,
+                    profiles,
+                    exceptions,
+                    policy["defaults"]["profile"],
+                )
             )
     declared_exceptions = {
         (workflow, job_id) for workflow, jobs in exceptions.items() for job_id in jobs

--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -27,6 +27,8 @@ DEFAULT_POLICY = (
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+")
 PROFILE_RE = re.compile(r"[a-z0-9][a-z0-9.-]*")
 IMAGE_RE = re.compile(r"ghcr\.io/f5-sales-demo/[a-z0-9._-]+@sha256:[0-9a-f]{64}")
+MEMORY_RE = re.compile(r"[1-9][0-9]*[KMGTPEkmgtpe]")
+CPU_RE = re.compile(r"[1-9][0-9]*(?:\.[0-9]+)?")
 
 
 class FleetError(RuntimeError):
@@ -161,10 +163,12 @@ class FleetPolicy:
                 raise FleetError(
                     f"profile {name!r} image must be an approved GHCR digest"
                 )
-            if not isinstance(spec["memory"], str) or not spec["memory"]:
-                raise FleetError(f"profile {name!r} memory is required")
-            if not isinstance(spec["cpus"], str) or not spec["cpus"]:
-                raise FleetError(f"profile {name!r} cpus is required")
+            if not isinstance(spec["memory"], str) or not MEMORY_RE.fullmatch(
+                spec["memory"]
+            ):
+                raise FleetError(f"profile {name!r} memory limit is invalid")
+            if not isinstance(spec["cpus"], str) or not CPU_RE.fullmatch(spec["cpus"]):
+                raise FleetError(f"profile {name!r} CPU limit is invalid")
             if not isinstance(spec["pids_limit"], int) or spec["pids_limit"] < 64:
                 raise FleetError(f"profile {name!r} pids_limit must be at least 64")
             if not isinstance(spec["container_socket"], bool):
@@ -370,12 +374,7 @@ class EphemeralController:
             "--read-only",
             "--cap-drop=all",
             "--security-opt=no-new-privileges",
-            "--pids-limit",
-            str(profile.pids_limit),
-            "--memory",
-            profile.memory,
-            "--cpus",
-            profile.cpus,
+            "--cgroups=disabled",
             "--network",
             "slirp4netns:allow_host_loopback=false",
             "--tmpfs",

--- a/scripts/provision-ephemeral-runners.py
+++ b/scripts/provision-ephemeral-runners.py
@@ -24,6 +24,7 @@ SYSTEMD_ROOT = Path("/etc/systemd/system")
 DATA_ROOT = Path("/data/actions-runners")
 USER_ROOT = DATA_ROOT / "users"
 STATE_ROOT = DATA_ROOT / "f5-sales-demo-ephemeral"
+PODMAN_RUNTIME_ROOT = Path("/run/f5-actions-podman")
 TOKEN_PATH = CONFIG_ROOT / "github.token"
 RUNNER_UNIT = "f5-actions-runner@.service"
 ACCOUNT_RE = re.compile(r"gh[ab]-[A-Za-z0-9_.-]+")
@@ -63,6 +64,9 @@ class Instance:
     slot: int
     account: str
     container_socket: bool
+    memory: str
+    cpus: str
+    pids_limit: int
 
     @property
     def identifier(self):
@@ -87,6 +91,9 @@ def instances(policy):
                         slot,
                         spec.account_for(profile),
                         profile.container_socket,
+                        profile.memory,
+                        profile.cpus,
+                        profile.pids_limit,
                     )
                 )
     return tuple(result)
@@ -206,6 +213,15 @@ WantedBy=multi-user.target
 """
 
 
+def resource_dropin_text(item):
+    cpu_quota = int(float(item.cpus) * 100)
+    return f"""[Service]
+MemoryMax={item.memory}
+CPUQuota={cpu_quota}%
+TasksMax={item.pids_limit}
+"""
+
+
 def podman_unit_text(item):
     home = USER_ROOT / item.account
     socket_dir = f"/run/f5-actions-podman/{item.repository_name}"
@@ -245,6 +261,7 @@ def install_definition():
         CONFIG_ROOT,
         INSTANCE_ROOT,
         INSTALL_ROOT,
+        PODMAN_RUNTIME_ROOT,
     ):
         path.mkdir(parents=True, exist_ok=True)
     for account in sorted(all_accounts()):
@@ -282,6 +299,10 @@ def install_definition():
             INSTANCE_ROOT / f"{item.identifier}.env",
             f"RUNNER_REPOSITORY={item.repository}\nRUNNER_PROFILE={item.profile}\nRUNNER_SLOT={item.slot}\n",
             0o600,
+        )
+        safe_write(
+            SYSTEMD_ROOT / f"{item.unit}.d" / "resources.conf",
+            resource_dropin_text(item),
         )
         if item.container_socket and item.repository_name not in socket_repositories:
             safe_write(

--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -244,8 +244,9 @@ def normalize_location(location):
         raise PolicyError(
             f"finding path is not a safe repository-relative path: {path!r}"
         )
-    if not normalized.startswith(".github/workflows/"):
-        raise PolicyError(f"finding path is outside .github/workflows: {normalized!r}")
+    workflow_roots = (".github/workflows/", "workflows/")
+    if not normalized.startswith(workflow_roots):
+        raise PolicyError(f"finding path is outside governed workflow roots: {normalized!r}")
     return normalized, parts[index + 1], parts
 
 
@@ -437,7 +438,11 @@ def validate_job(repository, workflow, job, spec):
 
 def inventory(root, repository, policy):
     actual = {}
-    for path in sorted((root / ".github/workflows").glob("*.y*ml")):
+    paths = (
+        *(root / ".github/workflows").glob("*.y*ml"),
+        *(root / "workflows").glob("*.y*ml"),
+    )
+    for path in sorted(paths):
         relative = path.relative_to(root).as_posix()
         try:
             workflow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}

--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -149,10 +149,36 @@ def load_policy(path, governance_path, repository):
         )
     if repository not in repositories:
         raise PolicyError(f"repository {repository!r} is not present in policy")
+    profiles = raw.get("profiles")
+    default_profile = raw.get("defaults", {}).get("profile")
+    if (
+        not isinstance(profiles, dict)
+        or not isinstance(default_profile, str)
+        or default_profile not in profiles
+    ):
+        raise PolicyError("policy default profile must name an existing profile")
     result = {}
     workflows = repositories[repository]
     if not isinstance(workflows, dict):
         raise PolicyError("repository policy must be a workflow object")
+    runner = workflows.get("runner", {})
+    if not isinstance(runner, dict) or set(runner) - {"profiles"}:
+        raise PolicyError("repository runner policy must contain only profiles")
+    allowed_profiles = runner.get("profiles", [default_profile])
+    if (
+        not isinstance(allowed_profiles, list)
+        or not allowed_profiles
+        or not all(
+            isinstance(profile, str) and profile in profiles
+            for profile in allowed_profiles
+        )
+        or len(set(allowed_profiles)) != len(allowed_profiles)
+        or default_profile not in allowed_profiles
+    ):
+        raise PolicyError(
+            "repository runner profiles must be a unique array of existing profiles "
+            "that includes the default"
+        )
     for workflow, jobs in workflows.items():
         if workflow == "runner":
             continue
@@ -202,7 +228,7 @@ def load_policy(path, governance_path, repository):
                     f"{workflow}/{job_id} has untrusted trigger(s): {sorted(unknown_triggers)}"
                 )
             result[(workflow, job_id)] = spec
-    return result
+    return result, default_profile, allowed_profiles
 
 
 def route_component(item):
@@ -370,11 +396,17 @@ def secret_references(text):
     return names
 
 
-def validate_job(repository, workflow, job, spec):
+def validate_job(repository, workflow, job, spec, default_profile):
     errors = []
     basename = repository.split("/", 1)[1]
     runs_on = job.get("runs-on")
-    expected_labels = ["self-hosted", "Linux", "X64", basename]
+    expected_labels = [
+        "self-hosted",
+        "Linux",
+        "X64",
+        basename,
+        default_profile,
+    ]
     if runs_on != spec["runs_on"] or runs_on != expected_labels:
         errors.append(f"runs-on must equal {expected_labels!r}, got {runs_on!r}")
     if job.get("environment") != spec["environment"]:
@@ -436,7 +468,7 @@ def validate_job(repository, workflow, job, spec):
     return errors
 
 
-def inventory(root, repository, policy):
+def inventory(root, repository, policy, default_profile, allowed_profiles):
     actual = {}
     paths = (
         *(root / ".github/workflows").glob("*.y*ml"),
@@ -466,20 +498,21 @@ def inventory(root, repository, policy):
             if self_hosted:
                 key = (relative, job_id)
                 if key in policy:
-                    errors = validate_job(repository, workflow, job, policy[key])
+                    errors = validate_job(
+                        repository, workflow, job, policy[key], default_profile
+                    )
                     if errors:
                         raise PolicyError(
                             f"{relative}/{job_id}: " + "; ".join(errors)
                         )
                 else:
-                    allowed = (
-                        ["self-hosted", "Linux", "X64", basename],
-                        [
-                            "self-hosted",
-                            "Linux",
-                            "X64",
+                    allowed = tuple(
+                        ["self-hosted", "Linux", "X64", repository_label, profile]
+                        for profile in allowed_profiles
+                        for repository_label in (
+                            basename,
                             "${{ github.event.repository.name }}",
-                        ],
+                        )
                     )
                     if runs_on not in allowed:
                         raise PolicyError(
@@ -495,8 +528,12 @@ def inventory(root, repository, policy):
 def validate(findings, root, repository, policy_path, governance_path):
     if not isinstance(findings, list):
         raise PolicyError("Zizmor output must be a JSON array")
-    policy = load_policy(policy_path, governance_path, repository)
-    actual = inventory(root, repository, policy)
+    policy, default_profile, allowed_profiles = load_policy(
+        policy_path, governance_path, repository
+    )
+    actual = inventory(
+        root, repository, policy, default_profile, allowed_profiles
+    )
     found = []
     routes = []
     for finding in findings:

--- a/scripts/workflow-security-validator.py
+++ b/scripts/workflow-security-validator.py
@@ -113,6 +113,35 @@ def governed_repositories(path):
     return {f"f5-sales-demo/{name}" for name in repos}
 
 
+def repository_runner_profiles(workflows, profiles, default_profile):
+    runner = workflows.get("runner", {})
+    if not isinstance(runner, dict) or set(runner) - {"profiles"}:
+        raise PolicyError("repository runner policy must contain only profiles")
+    allowed = runner.get("profiles", [default_profile])
+    if (
+        not isinstance(allowed, list)
+        or not allowed
+        or not all(
+            isinstance(profile, str) and profile in profiles for profile in allowed
+        )
+        or len(set(allowed)) != len(allowed)
+        or default_profile not in allowed
+    ):
+        raise PolicyError(
+            "repository runner profiles must be a unique array of existing profiles "
+            "that includes the default"
+        )
+    return allowed
+
+
+def canonical_routes(basename, allowed_profiles):
+    return tuple(
+        ["self-hosted", "Linux", "X64", repository_label, profile]
+        for profile in allowed_profiles
+        for repository_label in (basename, "${{ github.event.repository.name }}")
+    )
+
+
 def permissions_within_ceiling(permissions, context):
     if not isinstance(permissions, dict):
         raise PolicyError(f"{context} must be an object")
@@ -161,24 +190,9 @@ def load_policy(path, governance_path, repository):
     workflows = repositories[repository]
     if not isinstance(workflows, dict):
         raise PolicyError("repository policy must be a workflow object")
-    runner = workflows.get("runner", {})
-    if not isinstance(runner, dict) or set(runner) - {"profiles"}:
-        raise PolicyError("repository runner policy must contain only profiles")
-    allowed_profiles = runner.get("profiles", [default_profile])
-    if (
-        not isinstance(allowed_profiles, list)
-        or not allowed_profiles
-        or not all(
-            isinstance(profile, str) and profile in profiles
-            for profile in allowed_profiles
-        )
-        or len(set(allowed_profiles)) != len(allowed_profiles)
-        or default_profile not in allowed_profiles
-    ):
-        raise PolicyError(
-            "repository runner profiles must be a unique array of existing profiles "
-            "that includes the default"
-        )
+    allowed_profiles = repository_runner_profiles(
+        workflows, profiles, default_profile
+    )
     for workflow, jobs in workflows.items():
         if workflow == "runner":
             continue
@@ -505,19 +519,10 @@ def inventory(root, repository, policy, default_profile, allowed_profiles):
                         raise PolicyError(
                             f"{relative}/{job_id}: " + "; ".join(errors)
                         )
-                else:
-                    allowed = tuple(
-                        ["self-hosted", "Linux", "X64", repository_label, profile]
-                        for profile in allowed_profiles
-                        for repository_label in (
-                            basename,
-                            "${{ github.event.repository.name }}",
-                        )
+                elif runs_on not in canonical_routes(basename, allowed_profiles):
+                    raise PolicyError(
+                        f"{relative}/{job_id}: runs-on must use the canonical repository route"
                     )
-                    if runs_on not in allowed:
-                        raise PolicyError(
-                            f"{relative}/{job_id}: runs-on must use the canonical repository route"
-                        )
                 actual[key] = workflow
     unused = sorted(set(policy) - set(actual))
     if unused:

--- a/tests/fixtures/workflow-security/.github/workflows/audit.yml
+++ b/tests/fixtures/workflow-security/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   first:
     name: First governed job
-    runs-on: [self-hosted, Linux, X64, fixture]
+    runs-on: [self-hosted, Linux, X64, fixture, ubuntu-24.04]
     environment: first-environment
     permissions:
       contents: read
@@ -28,7 +28,7 @@ jobs:
 
   second:
     name: Second governed job
-    runs-on: [self-hosted, Linux, X64, fixture]
+    runs-on: [self-hosted, Linux, X64, fixture, ubuntu-24.04]
     environment: second-environment
     permissions:
       checks: write # publish the fixture check result

--- a/tests/fixtures/workflow-security/policy.json
+++ b/tests/fixtures/workflow-security/policy.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
-  "defaults": {"profile": "ubuntu-24.04"},
-  "profiles": {"ubuntu-24.04": {}},
+  "defaults": { "profile": "ubuntu-24.04" },
+  "profiles": { "ubuntu-24.04": {} },
   "hosted_exceptions": {},
   "repositories": {
     "f5-sales-demo/fixture": {

--- a/tests/fixtures/workflow-security/policy.json
+++ b/tests/fixtures/workflow-security/policy.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 2,
-  "defaults": {},
-  "profiles": {},
+  "defaults": {"profile": "ubuntu-24.04"},
+  "profiles": {"ubuntu-24.04": {}},
   "hosted_exceptions": {},
   "repositories": {
     "f5-sales-demo/fixture": {
       ".github/workflows/audit.yml": {
         "first": {
-          "runs_on": ["self-hosted", "Linux", "X64", "fixture"],
+          "runs_on": ["self-hosted", "Linux", "X64", "fixture", "ubuntu-24.04"],
           "environment": "first-environment",
           "permissions": {
             "contents": "read"
@@ -22,7 +22,7 @@
           "if": null
         },
         "second": {
-          "runs_on": ["self-hosted", "Linux", "X64", "fixture"],
+          "runs_on": ["self-hosted", "Linux", "X64", "fixture", "ubuntu-24.04"],
           "environment": "second-environment",
           "permissions": {
             "checks": "write",

--- a/tests/fixtures/workflow-security/zizmor-1.29-findings.json
+++ b/tests/fixtures/workflow-security/zizmor-1.29-findings.json
@@ -19,7 +19,7 @@
             "end_point": { "row": 12, "column": 51 },
             "offset_span": { "start": 137, "end": 184 }
           },
-          "feature": "    runs-on: [self-hosted, Linux, X64, fixture]",
+          "feature": "    runs-on: [self-hosted, Linux, X64, fixture, ubuntu-24.04]",
           "comments": []
         }
       }
@@ -47,7 +47,7 @@
             "end_point": { "row": 25, "column": 51 },
             "offset_span": { "start": 519, "end": 566 }
           },
-          "feature": "    runs-on: [self-hosted, Linux, X64, fixture]",
+          "feature": "    runs-on: [self-hosted, Linux, X64, fixture, ubuntu-24.04]",
           "comments": []
         }
       }

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -60,6 +60,7 @@ governance = json.load(open(sys.argv[2], encoding="utf-8"))
 expected = sorted([
     *governance["repo_classes"]["repos"],
     "container-build",
+    "fixture",
     "ubuntu-24.04-arm",
 ])
 assert config.get("self-hosted-runner", {}).get("labels") == expected

--- a/tests/test-linter-configs.sh
+++ b/tests/test-linter-configs.sh
@@ -53,17 +53,20 @@ for f in .yamllint.yaml zizmor.yaml .checkov.yaml .textlintrc actionlint.yml; do
   fi
 done
 
-if python3 - "$REPO_ROOT/actionlint.yml" <<'PY'; then
-import sys, yaml
+if python3 - "$REPO_ROOT/actionlint.yml" "$REPO_ROOT/.claude/governance.json" <<'PY'; then
+import json, sys, yaml
 config = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
-assert config.get("self-hosted-runner", {}).get("labels") == [
-    "terraform-provider-xcsh",
+governance = json.load(open(sys.argv[2], encoding="utf-8"))
+expected = sorted([
+    *governance["repo_classes"]["repos"],
+    "container-build",
     "ubuntu-24.04-arm",
-]
+])
+assert config.get("self-hosted-runner", {}).get("labels") == expected
 PY
-  pass "2.1 actionlint recognizes the governed and hosted ARM runner labels"
+  pass "2.1 actionlint recognizes governed repository, builder, and ARM labels"
 else
-  fail "2.1 actionlint recognizes the governed and hosted ARM runner labels" \
+  fail "2.1 actionlint recognizes governed repository, builder, and ARM labels" \
     "self-hosted-runner.labels must contain the exact governed labels"
 fi
 

--- a/tests/test-workflow-security-validator-integration.sh
+++ b/tests/test-workflow-security-validator-integration.sh
@@ -56,7 +56,7 @@ mkdir -p "$TMP/mutated/.github"
 cp -R "$FIXTURE/.github/workflows" "$TMP/mutated/.github/workflows"
 cat >>"$TMP/mutated/.github/workflows/audit.yml" <<'YAML'
   unapproved-self-hosted:
-    runs-on: [self-hosted, Linux, X64, fixture]
+    runs-on: [self-hosted, Linux, X64, fixture, ubuntu-24.04]
     permissions: {}
     steps:
       - run: echo mutation

--- a/tests/test_audit_runner_workflows.py
+++ b/tests/test_audit_runner_workflows.py
@@ -62,7 +62,7 @@ class WorkflowAuditTests(unittest.TestCase):
 on: [push]
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64, \"${{ github.event.repository.name }}\"]
+    runs-on: [self-hosted, Linux, X64, \"${{ github.event.repository.name }}\", ubuntu-24.04]
     steps:
       - uses: actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       - uses: ./local-action
@@ -127,13 +127,27 @@ jobs:
 on: [push]
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64, fixture]
+    runs-on: [self-hosted, Linux, X64, fixture, ubuntu-24.04]
     steps:
       - run: true
 """
         )
         errors = self.audit()
         self.assertTrue(any("unused hosted exception" in item for item in errors))
+
+    def test_missing_profile_label_fails(self):
+        self.write_workflow(
+            """name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: [self-hosted, Linux, X64, fixture]
+    steps:
+      - run: true
+"""
+        )
+        errors = self.audit()
+        self.assertTrue(any("canonical repository route" in item for item in errors))
 
     def test_profile_label_is_validated(self):
         self.write_workflow(

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -107,6 +107,17 @@ class EphemeralRunnerTests(unittest.TestCase):
         with self.assertRaises(MODULE.FleetError):
             self.policy()
 
+    def test_policy_rejects_unsafe_resource_limits(self):
+        profile = self.policy_data["profiles"]["ubuntu-24.04"]
+        for field, value in (("memory", "4g\nDelegate=yes"), ("cpus", "nan")):
+            with self.subTest(field=field):
+                original = profile[field]
+                profile[field] = value
+                self.write_policy()
+                with self.assertRaises(MODULE.FleetError):
+                    self.policy()
+                profile[field] = original
+
     def test_policy_rejects_unknown_fields_and_ungoverned_repository(self):
         self.policy_data["unexpected"] = True
         self.write_policy()
@@ -136,6 +147,10 @@ class EphemeralRunnerTests(unittest.TestCase):
         self.assertIn("slirp4netns:allow_host_loopback=false", command)
         self.assertNotIn("/var/run/docker.sock", " ".join(command))
         self.assertIn("--userns=keep-id:uid=1001,gid=1001", command)
+        self.assertIn("--cgroups=disabled", command)
+        self.assertNotIn("--memory", command)
+        self.assertNotIn("--cpus", command)
+        self.assertNotIn("--pids-limit", command)
         install_calls = [call for call in recorder.calls if call[0][0] == "install"]
         self.assertGreaterEqual(len(install_calls), 2)
 

--- a/tests/test_provision_ephemeral_runners.py
+++ b/tests/test_provision_ephemeral_runners.py
@@ -43,6 +43,18 @@ class ProvisionRunnerTests(unittest.TestCase):
         self.assertIn("ProtectSystem=strict", unit)
         self.assertNotIn("github.token serve", unit)
 
+    def test_systemd_dropin_enforces_profile_resource_limits(self):
+        item = next(
+            item
+            for item in MODULE.all_instances()
+            if item.repository == "f5-sales-demo/docs-control"
+            and item.profile == "ubuntu-24.04"
+        )
+        dropin = MODULE.resource_dropin_text(item)
+        self.assertIn("MemoryMax=8g", dropin)
+        self.assertIn("CPUQuota=400%", dropin)
+        self.assertIn("TasksMax=4096", dropin)
+
     def test_container_socket_unit_uses_builder_account(self):
         item = next(
             item

--- a/tests/test_workflow_security_validator.py
+++ b/tests/test_workflow_security_validator.py
@@ -86,13 +86,13 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         self.temp.cleanup()
 
     def finding(
-        self, ident="self-hosted-runner", route=None, locations=None, severity="Medium"
+        self, ident="self-hosted-runner", route=None, locations=None, severity="Medium", path=None
     ):
         if route is None:
             route = [{"Key": "jobs"}, {"Key": self.job_id}, {"Key": "runs-on"}]
         location = {
             "symbolic": {
-                "key": {"Local": {"verbatim_path": self.workflow_path}},
+                "key": {"Local": {"verbatim_path": path or self.workflow_path}},
                 "route": {"route": route},
             }
         }
@@ -142,6 +142,28 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         self.assertEqual(
             routes,
             [(self.workflow_path, self.job_id, ["jobs", self.job_id, "runs-on"])],
+        )
+
+    def test_managed_template_self_hosted_route_is_accounted_for(self):
+        template_path = "workflows/acc-tests.yml"
+        self.write_fixture()
+        path = self.root / template_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(self.workflow, sort_keys=False), encoding="utf-8")
+        findings = [self.finding(), self.finding(path=template_path)]
+        routes = validator.validate(
+            findings,
+            self.root,
+            self.repository,
+            self.policy_path,
+            self.governance_path,
+        )
+        self.assertEqual(
+            routes,
+            [
+                (self.workflow_path, self.job_id, ["jobs", self.job_id, "runs-on"]),
+                (template_path, self.job_id, ["jobs", self.job_id, "runs-on"]),
+            ],
         )
 
     def test_malformed_missing_duplicate_and_ambiguous_routes_fail(self):

--- a/tests/test_workflow_security_validator.py
+++ b/tests/test_workflow_security_validator.py
@@ -43,6 +43,7 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
                         "Linux",
                         "X64",
                         "terraform-provider-xcsh",
+                        "ubuntu-24.04",
                     ],
                     "environment": "acceptance-tests",
                     "if": "github.event_name != 'pull_request'",
@@ -61,7 +62,13 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
             },
         }
         self.spec = {
-            "runs_on": ["self-hosted", "Linux", "X64", "terraform-provider-xcsh"],
+            "runs_on": [
+                "self-hosted",
+                "Linux",
+                "X64",
+                "terraform-provider-xcsh",
+                "ubuntu-24.04",
+            ],
             "environment": "acceptance-tests",
             "permissions": {"contents": "read"},
             "allowed_secrets": ["XCSH_API_TOKEN"],
@@ -70,8 +77,8 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         }
         self.policy = {
             "schema_version": 2,
-            "defaults": {},
-            "profiles": {},
+            "defaults": {"profile": "ubuntu-24.04"},
+            "profiles": {"ubuntu-24.04": {}},
             "hosted_exceptions": {},
             "repositories": {
                 self.repository: {self.workflow_path: {self.job_id: self.spec}}
@@ -86,7 +93,12 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         self.temp.cleanup()
 
     def finding(
-        self, ident="self-hosted-runner", route=None, locations=None, severity="Medium", path=None
+        self,
+        ident="self-hosted-runner",
+        route=None,
+        locations=None,
+        severity="Medium",
+        path=None,
     ):
         if route is None:
             route = [{"Key": "jobs"}, {"Key": self.job_id}, {"Key": "runs-on"}]
@@ -149,7 +161,9 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
         self.write_fixture()
         path = self.root / template_path
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(yaml.safe_dump(self.workflow, sort_keys=False), encoding="utf-8")
+        path.write_text(
+            yaml.safe_dump(self.workflow, sort_keys=False), encoding="utf-8"
+        )
         findings = [self.finding(), self.finding(path=template_path)]
         routes = validator.validate(
             findings,
@@ -209,6 +223,25 @@ class WorkflowSecurityValidatorTests(unittest.TestCase):
             workflow["jobs"][self.job_id]["runs-on"] = labels
             with self.subTest(labels=labels):
                 self.assert_rejected(workflow=workflow)
+
+    def test_declared_nondefault_runner_profile_is_canonical(self):
+        workflow = copy.deepcopy(self.workflow)
+        workflow["jobs"][self.job_id]["runs-on"][-1] = "container-build"
+        policy = copy.deepcopy(self.policy)
+        policy["profiles"]["container-build"] = {}
+        policy["repositories"][self.repository] = {
+            "runner": {"profiles": ["ubuntu-24.04", "container-build"]}
+        }
+        self.write_fixture(workflow=workflow, policy=policy)
+        validator.validate(
+            self.findings,
+            self.root,
+            self.repository,
+            self.policy_path,
+            self.governance_path,
+        )
+        policy["repositories"][self.repository]["runner"]["profiles"] = ["ubuntu-24.04"]
+        self.assert_rejected(workflow=workflow, policy=policy)
 
     def test_known_repository_with_no_exceptions_accepts_empty_inventory(self):
         clean_repository = "f5-sales-demo/api-specs"

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     steps:
       - name: Require downstream-triggering token
         env:

--- a/workflows/dependabot-auto-merge.yml
+++ b/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Approve and enable auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: write # merge validated Dependabot updates
       pull-requests: write # approve pull requests and enable auto-merge

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   resolve-source:
     name: Resolve protected governance source
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     environment: repository-settings
     outputs:
       source_sha: ${{ steps.resolve.outputs.source_sha }}

--- a/workflows/require-linked-issue.yml
+++ b/workflows/require-linked-issue.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   check:
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       issues: write # read linked issues and publish one deduplicated guidance comment
       pull-requests: read # enumerate open pull requests and linked-issue references

--- a/workflows/semgrep.yml
+++ b/workflows/semgrep.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   semgrep:
     name: Semgrep SAST
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     permissions:
       contents: read # checkout the source to scan
       security-events: write # upload SARIF to Code Scanning

--- a/workflows/workflow-security-audit.yml
+++ b/workflows/workflow-security-audit.yml
@@ -40,7 +40,7 @@ concurrency:
 jobs:
   audit:
     name: Audit workflows (zizmor)
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}"]
+    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Closes #1411
Closes #1413

- scope GHCR write permission to the publisher job
- inventory self-hosted findings in executable and managed-template workflow roots
- require explicit repository and runner-profile labels for every Linux job
- keep ordinary jobs isolated from privileged container-build runners
- create the rootless Podman runtime directory and disable container cgroups
- enforce memory, CPU, and task ceilings with per-instance systemd drop-ins
- validate repository profile authorization and resource-policy values

Validation: 56 Python tests; workflow-security integration; Zizmor auditor plus validator (29 governed findings); managed helper matching; governed pin tests; sync-managed-files 77/77; linter config 181/181; actionlint; targeted Ruff checks and format checks; git diff --check.

Tracking issues: #1411 and #1413.