### PR TITLE
fix: harden ephemeral runner lifecycle

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -49,6 +49,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${RUNNER_EPHEMERAL:-0}" == 1 ]]; then
+            echo "Ephemeral runner workspace needs no host ownership repair."
+            exit 0
+          fi
           workspace="${GITHUB_WORKSPACE:?}"
           repository="${GITHUB_REPOSITORY:?}"
           repository_name="${repository##*/}"
@@ -455,6 +459,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${RUNNER_EPHEMERAL:-0}" == 1 ]]; then
+            echo "Ephemeral runner workspace needs no host ownership repair."
+            exit 0
+          fi
           workspace="${GITHUB_WORKSPACE:?}"
           repository="${GITHUB_REPOSITORY:?}"
           repository_name="${repository##*/}"
@@ -482,6 +490,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [[ "${RUNNER_EPHEMERAL:-0}" == 1 ]]; then
+            echo "Ephemeral runner workspace needs no host ownership repair."
+            exit 0
+          fi
           workspace="${GITHUB_WORKSPACE:?}"
           repository="${GITHUB_REPOSITORY:?}"
           repository_name="${repository##*/}"

--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 DEFAULT_ORG = "f5-sales-demo"
+HOST_ENTRYPOINT = Path("/opt/f5-actions-runner/runner-entrypoint.sh")
 DEFAULT_BASE_DIR = Path("/data/actions-runners/f5-sales-demo-ephemeral")
 DEFAULT_POLICY = (
     Path(__file__).resolve().parent.parent
@@ -33,6 +34,10 @@ CPU_RE = re.compile(r"[1-9][0-9]*(?:\.[0-9]+)?")
 
 class FleetError(RuntimeError):
     """A fail-closed runner fleet error."""
+
+
+class StopRequestedError(Exception):
+    """Interrupt a blocking runner cycle for prompt systemd shutdown."""
 
 
 def run_command(command, *, input_text=None, check=True, capture=True):
@@ -248,7 +253,8 @@ class GitHubClient:
         )
         try:
             with self.opener(request, timeout=30) as response:
-                return json.load(response)
+                response_body = response.read()
+                return json.loads(response_body) if response_body else {}
         except urllib.error.HTTPError as exc:
             raise FleetError(f"GitHub API {method} {path} returned {exc.code}") from exc
 
@@ -269,6 +275,9 @@ class GitHubClient:
         if not isinstance(runners, list):
             raise FleetError("GitHub returned a malformed runner inventory")
         return runners
+
+    def delete_runner(self, full_name, runner_id):
+        self.request("DELETE", f"/repos/{full_name}/actions/runners/{runner_id}")
 
 
 class EphemeralController:
@@ -330,6 +339,7 @@ class EphemeralController:
             f"HOME=/data/actions-runners/users/{account}",
             f"XDG_RUNTIME_DIR={runtime}",
             "podman",
+            "--cgroup-manager=cgroupfs",
         ]
 
     def cleanup(self, spec, profile, slot):
@@ -337,6 +347,23 @@ class EphemeralController:
         account, runtime = self.prepare_account(spec, profile)
         prefix = self.podman_prefix(account, runtime)
         self.command([*prefix, "rm", "--force", "--ignore", name], check=False)
+
+    def remove_registration(self, spec, profile, slot):
+        """Remove registrations left behind when an idle runner is stopped."""
+        prefix = self.container_name(spec, profile, slot) + "-"
+        for runner in self.github.runners(spec.full_name):
+            name = runner.get("name")
+            runner_id = runner.get("id")
+            if isinstance(name, str) and name.startswith(prefix):
+                if not isinstance(runner_id, int) or runner_id <= 0:
+                    raise FleetError(f"managed runner has an invalid id: {name}")
+                self.github.delete_runner(spec.full_name, runner_id)
+
+    def release_namespace(self, spec, profile, slot):
+        """Stop Podman pause processes before systemd removes the runtime directory."""
+        account, runtime = self.prepare_account(spec, profile)
+        prefix = self.podman_prefix(account, runtime)
+        self.command([*prefix, "system", "migrate"], check=False)
 
     def podman_command(self, spec, profile, slot):
         state = self.state_dir(spec, profile, slot)
@@ -374,17 +401,20 @@ class EphemeralController:
             "--read-only",
             "--cap-drop=all",
             "--security-opt=no-new-privileges",
-            "--cgroups=disabled",
             "--network",
             "slirp4netns:allow_host_loopback=false",
             "--tmpfs",
             "/tmp:rw,nosuid,nodev,size=2g",
             "--tmpfs",
-            "/home/runner:rw,nosuid,nodev,size=4g",
-            "--tmpfs",
             "/runner-runtime:rw,nosuid,nodev,size=20g",
             "--volume",
             f"{state}:/runner-runtime/_diag:rw",
+            "--volume",
+            f"{HOST_ENTRYPOINT}:/usr/local/bin/runner-entrypoint:ro",
+            "--env",
+            "HOME=/runner-runtime/home",
+            "--env",
+            "RUNNER_EPHEMERAL=1",
             "--env",
             f"RUNNER_REPOSITORY={spec.full_name}",
             "--env",
@@ -434,24 +464,30 @@ class EphemeralController:
             return result.returncode
         finally:
             token = ""  # Shorten the credential lifetime.
-            self.cleanup(spec, profile, slot)
+            try:
+                self.cleanup(spec, profile, slot)
+                self.remove_registration(spec, profile, slot)
+            finally:
+                self.release_namespace(spec, profile, slot)
 
     def serve(self, full_name, profile_name, slot=0, backoff=5):
         def stop(_signum, _frame):
             self.stopping = True
+            raise StopRequestedError
 
         signal.signal(signal.SIGTERM, stop)
         signal.signal(signal.SIGINT, stop)
         while not self.stopping:
             try:
-                code = self.run_once(full_name, profile_name, slot)
-            except (FleetError, OSError, subprocess.SubprocessError) as exc:
-                print(f"runner cycle failed: {exc}", file=sys.stderr, flush=True)
-                code = 1
-            if self.stopping:
+                try:
+                    code = self.run_once(full_name, profile_name, slot)
+                except (FleetError, OSError, subprocess.SubprocessError) as exc:
+                    print(f"runner cycle failed: {exc}", file=sys.stderr, flush=True)
+                    code = 1
+                if code != 0:
+                    time.sleep(backoff)
+            except StopRequestedError:
                 break
-            if code != 0:
-                time.sleep(backoff)
         return 0
 
     def audit(self, full_name):

--- a/scripts/provision-ephemeral-runners.py
+++ b/scripts/provision-ephemeral-runners.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 SOURCE_ROOT = Path(__file__).resolve().parent.parent
 CONTROLLER_SOURCE = SOURCE_ROOT / "scripts/ephemeral-runner-controller.py"
+ENTRYPOINT_SOURCE = SOURCE_ROOT / "scripts/runner-entrypoint.sh"
 POLICY_SOURCE = SOURCE_ROOT / ".github/config/self-hosted-runner-policy.json"
 INSTALL_ROOT = Path("/opt/f5-actions-runner")
 CONFIG_ROOT = Path("/etc/f5-actions-runner")
@@ -203,20 +204,27 @@ UMask=0077
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ProtectKernelTunables=true
+# ProtectKernelTunables blocks rootless runc from mounting the container procfs.
 ProtectKernelModules=true
 ProtectControlGroups=true
-ReadWritePaths={DATA_ROOT} /run/f5-actions-podman
+ReadWritePaths={DATA_ROOT} /run/f5-actions-podman /run/f5-actions-runner
 
 [Install]
 WantedBy=multi-user.target
 """
 
 
+def systemd_memory_limit(memory):
+    """Translate the validated policy suffix to systemd byte unit syntax."""
+    return memory[:-1] + memory[-1].upper()
+
+
 def resource_dropin_text(item):
     cpu_quota = int(float(item.cpus) * 100)
     return f"""[Service]
-MemoryMax={item.memory}
+RuntimeDirectory=f5-actions-runner/{item.account}
+RuntimeDirectoryMode=0700
+MemoryMax={systemd_memory_limit(item.memory)}
 CPUQuota={cpu_quota}%
 TasksMax={item.pids_limit}
 """
@@ -266,19 +274,20 @@ def install_definition():
         path.mkdir(parents=True, exist_ok=True)
     for account in sorted(all_accounts()):
         ensure_account(account)
-    command(
-        [
-            "install",
-            "-o",
-            "root",
-            "-g",
-            "root",
-            "-m",
-            "0755",
-            str(CONTROLLER_SOURCE),
-            str(INSTALL_ROOT / CONTROLLER_SOURCE.name),
-        ]
-    )
+    for source in (CONTROLLER_SOURCE, ENTRYPOINT_SOURCE):
+        command(
+            [
+                "install",
+                "-o",
+                "root",
+                "-g",
+                "root",
+                "-m",
+                "0755",
+                str(source),
+                str(INSTALL_ROOT / source.name),
+            ]
+        )
     command(
         [
             "install",

--- a/scripts/runner-entrypoint.sh
+++ b/scripts/runner-entrypoint.sh
@@ -11,11 +11,14 @@ if [[ -z "$registration_token" ]]; then
   exit 1
 fi
 
-if [[ ! -d /runner-runtime || -n "$(find /runner-runtime -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
-  echo "runner runtime tmpfs is missing or not empty" >&2
+unexpected_path="$(find /runner-runtime -mindepth 1 -maxdepth 1 ! -name _diag -print -quit)"
+if [[ ! -d /runner-runtime/_diag || -n "$unexpected_path" ]]; then
+  echo "runner runtime tmpfs or diagnostics mount is invalid" >&2
   exit 1
 fi
-cp --archive /opt/actions-runner/. /runner-runtime/
+find /opt/actions-runner -mindepth 1 -maxdepth 1 \
+  -exec cp --archive --no-preserve=ownership --target-directory=/runner-runtime {} +
+install -d -m 0700 /runner-runtime/home
 cd /runner-runtime
 ./config.sh \
   --url "https://github.com/${RUNNER_REPOSITORY}" \

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parent.parent
 SPEC = importlib.util.spec_from_file_location(
@@ -25,6 +26,7 @@ class FakeGitHub:
     def __init__(self):
         self.requested = []
         self.records = []
+        self.deleted = []
 
     def registration_token(self, repository):
         self.requested.append(repository)
@@ -32,6 +34,9 @@ class FakeGitHub:
 
     def runners(self, _repository):
         return self.records
+
+    def delete_runner(self, repository, runner_id):
+        self.deleted.append((repository, runner_id))
 
 
 class CommandRecorder:
@@ -147,12 +152,53 @@ class EphemeralRunnerTests(unittest.TestCase):
         self.assertIn("slirp4netns:allow_host_loopback=false", command)
         self.assertNotIn("/var/run/docker.sock", " ".join(command))
         self.assertIn("--userns=keep-id:uid=1001,gid=1001", command)
-        self.assertIn("--cgroups=disabled", command)
+        self.assertIn("HOME=/runner-runtime/home", command)
+        self.assertIn("RUNNER_EPHEMERAL=1", command)
+        self.assertNotIn("/home/runner:rw,nosuid,nodev,size=4g", command)
+        self.assertNotIn("--cgroups=disabled", command)
+        self.assertIn("--cgroup-manager=cgroupfs", command)
+        self.assertIn("/run/f5-actions-runner/gha-fixture", " ".join(command))
+        self.assertIn(
+            "/opt/f5-actions-runner/runner-entrypoint.sh:/usr/local/bin/runner-entrypoint:ro",
+            command,
+        )
         self.assertNotIn("--memory", command)
         self.assertNotIn("--cpus", command)
         self.assertNotIn("--pids-limit", command)
         install_calls = [call for call in recorder.calls if call[0][0] == "install"]
         self.assertGreaterEqual(len(install_calls), 2)
+        migrate_calls = [
+            call for call in recorder.calls if call[0][-2:] == ["system", "migrate"]
+        ]
+        self.assertEqual(len(migrate_calls), 1)
+        self.assertFalse(migrate_calls[0][1]["check"])
+
+    def test_shutdown_cleanup_removes_exact_slot_registration(self):
+        github = FakeGitHub()
+        github.records = [
+            {"id": 42, "name": "gha-fixture-ubuntu-24.04-0-deadbeef"},
+            {"id": 43, "name": "persistent-fixture"},
+        ]
+        controller = MODULE.EphemeralController(
+            self.policy(), github, self.root / "state", CommandRecorder()
+        )
+        controller.run_once("f5-sales-demo/fixture", "ubuntu-24.04")
+        self.assertEqual(github.deleted, [("f5-sales-demo/fixture", 42)])
+
+    def test_serve_stops_when_blocking_cycle_is_interrupted(self):
+        controller = MODULE.EphemeralController(
+            self.policy(), FakeGitHub(), self.root / "state", CommandRecorder()
+        )
+
+        def interrupted(*_args):
+            raise MODULE.StopRequestedError
+
+        controller.run_once = interrupted
+        with mock.patch.object(MODULE.signal, "signal"):
+            self.assertEqual(
+                controller.serve("f5-sales-demo/fixture", "ubuntu-24.04", backoff=0),
+                0,
+            )
 
     def test_container_profile_uses_isolated_repository_socket(self):
         recorder = CommandRecorder()

--- a/tests/test_provision_ephemeral_runners.py
+++ b/tests/test_provision_ephemeral_runners.py
@@ -41,7 +41,13 @@ class ProvisionRunnerTests(unittest.TestCase):
         unit = MODULE.runner_unit_text()
         self.assertIn("RUNNER_FLEET_GITHUB_TOKEN_FILE=", unit)
         self.assertIn("ProtectSystem=strict", unit)
+        self.assertNotIn("ProtectKernelTunables=true", unit)
+        self.assertIn("ProtectKernelModules=true", unit)
+        self.assertIn("ProtectControlGroups=true", unit)
         self.assertNotIn("github.token serve", unit)
+        self.assertNotIn("RuntimeDirectory=", unit)
+        self.assertIn("/run/f5-actions-runner", unit)
+        self.assertTrue(MODULE.ENTRYPOINT_SOURCE.is_file())
 
     def test_systemd_dropin_enforces_profile_resource_limits(self):
         item = next(
@@ -51,7 +57,8 @@ class ProvisionRunnerTests(unittest.TestCase):
             and item.profile == "ubuntu-24.04"
         )
         dropin = MODULE.resource_dropin_text(item)
-        self.assertIn("MemoryMax=8g", dropin)
+        self.assertIn("RuntimeDirectory=f5-actions-runner/gha-docs-control", dropin)
+        self.assertIn("MemoryMax=8G", dropin)
         self.assertIn("CPUQuota=400%", dropin)
         self.assertIn("TasksMax=4096", dropin)
 


### PR DESCRIPTION
Closes #1417

- emit systemd-compatible memory units and make the actual per-account Podman runroot systemd-owned
- use rootless Podman with cgroupfs instead of the runc-incompatible no-cgroups mode
- preserve diagnostics while copying the immutable runner payload into tmpfs
- provide a writable tmpfs-backed HOME and an explicit ephemeral marker
- stop Podman pause namespaces, interrupt blocking cycles promptly, and delete stale slot registrations
- retain legacy workspace ownership repair while making it a no-op for ephemeral jobs

Validation: 58 Python tests; Bash syntax; Ruff check/format; Actionlint; Zizmor; systemd-analyze verify; finite 8 GiB/400%/4096 effective limits; rootless runc host probes; git diff --check.

The live pilot remains disabled until this change merges and its workflow copy is active.