### PR TITLE
fix: stop ephemeral runners after successful job

### DIFF
--- a/scripts/provision-ephemeral-runners.py
+++ b/scripts/provision-ephemeral-runners.py
@@ -196,7 +196,7 @@ Environment=RUNNER_FLEET_GITHUB_TOKEN_FILE={TOKEN_PATH}
 EnvironmentFile={INSTANCE_ROOT}/%i.env
 ExecStartPre=/usr/bin/test -r {TOKEN_PATH}
 ExecStart=/usr/bin/python3 {INSTALL_ROOT}/ephemeral-runner-controller.py --policy {INSTALL_ROOT}/self-hosted-runner-policy.json --base-dir {STATE_ROOT} serve ${{RUNNER_REPOSITORY}} --profile ${{RUNNER_PROFILE}} --slot ${{RUNNER_SLOT}}
-Restart=always
+Restart=on-failure
 RestartSec=5
 TimeoutStopSec=6min
 KillMode=mixed

--- a/tests/test_provision_ephemeral_runners.py
+++ b/tests/test_provision_ephemeral_runners.py
@@ -44,6 +44,8 @@ class ProvisionRunnerTests(unittest.TestCase):
         self.assertNotIn("ProtectKernelTunables=true", unit)
         self.assertIn("ProtectKernelModules=true", unit)
         self.assertIn("ProtectControlGroups=true", unit)
+        self.assertIn("Restart=on-failure", unit)
+        self.assertNotIn("Restart=always", unit)
         self.assertNotIn("github.token serve", unit)
         self.assertNotIn("RuntimeDirectory=", unit)
         self.assertIn("/run/f5-actions-runner", unit)


### PR DESCRIPTION
Closes #1422\n\nSuccessful one-job runner exits no longer restart into a new registration; failed services still restart.