### PR TITLE
fix(security): remove managed IFS mutation

### DIFF
--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -66,14 +66,30 @@ symlink_escapes() {
   esac
   dir=$(dirname "$link_path")
   [ "$dir" = "." ] && dir=""
-  if [ -n "$dir" ]; then
-    local IFS=/
-    for segment in $dir; do
-      [ -n "$segment" ] && depth=$((depth + 1))
-    done
-  fi
-  local IFS=/
-  for segment in $target; do
+  while [ -n "$dir" ]; do
+    case "$dir" in
+    */*)
+      segment=${dir%%/*}
+      dir=${dir#*/}
+      ;;
+    *)
+      segment=$dir
+      dir=""
+      ;;
+    esac
+    [ -n "$segment" ] && depth=$((depth + 1))
+  done
+  while [ -n "$target" ]; do
+    case "$target" in
+    */*)
+      segment=${target%%/*}
+      target=${target#*/}
+      ;;
+    *)
+      segment=$target
+      target=""
+      ;;
+    esac
     case "$segment" in
     "" | .) ;;
     ..)

--- a/tests/test-check-repo-hygiene.sh
+++ b/tests/test-check-repo-hygiene.sh
@@ -82,6 +82,20 @@ ln -s ../shared.md "${repo}/docs/link.md"
 git -C "$repo" add -A
 assert_clean "relative symlink using ../ that stays inside the repository" "$repo"
 
+# --- lexical segment parsing must handle spaces, duplicate slashes and dots ---
+repo=$(new_repo lexical-segments)
+mkdir -p "${repo}/docs with spaces/nested"
+printf 'shared\n' >"${repo}/shared file.md"
+ln -s '.././..//shared file.md' "${repo}/docs with spaces/nested/link.md"
+git -C "$repo" add -A
+assert_clean "lexical symlink segments stay inside the repository" "$repo"
+
+repo=$(new_repo lexical-escape)
+mkdir -p "${repo}/docs/nested"
+ln -s '../../..//outside' "${repo}/docs/nested/escape"
+git -C "$repo" add -A --force
+assert_violation "lexical symlink segments escaping the repository are rejected" "$repo"
+
 # --- hardcoded home directories ------------------------------------------------
 # acct1234 is synthetic but intentionally not a portable placeholder: these fixtures must exercise
 # rejection of a concrete account segment on every supported platform.


### PR DESCRIPTION
## Summary
- parse symlink paths lexically without mutating `IFS`
- retain escape detection for dot, dot-dot, repeated-separator, and space-bearing paths
- add regression coverage for the lexical parser

## Validation
- `bash tests/test-check-repo-hygiene.sh`
- `bash tests/test-protect-managed-files.sh`
- `shellcheck scripts/check-repo-hygiene.sh tests/test-check-repo-hygiene.sh`
- `shfmt -d scripts/check-repo-hygiene.sh tests/test-check-repo-hygiene.sh`
- `bash scripts/preflight-fleet.sh --check scripts/check-repo-hygiene.sh --search-path /data/robin-GIT/security-fixes --json` (38 clean, 0 broken)

Closes #1403