### PR TITLE
fix(governance): diagnose secret provisioning failures safely

### DIFF
--- a/docs/en/architecture.mdx
+++ b/docs/en/architecture.mdx
@@ -41,7 +41,7 @@ Three sets of credentials provide least-privilege separation:
 
 | Token / Secret | Permissions / Scope | Used by |
 | --- | --- | --- |
-| `REPO_SETTINGS_TOKEN` | Administration R/W, Pages R/W, Contents Read, Metadata Read | `enforce-repo-settings.yml`, `dispatch-downstream.yml`, `update-governed-workflow-pins.yml` |
+| `REPO_SETTINGS_TOKEN` | Administration R/W, Pages R/W, Contents Read, Metadata Read, and repository Secrets: write for every enrolled repository (or equivalent classic `repo` scope) | `enforce-repo-settings.yml`, `dispatch-downstream.yml`, `update-governed-workflow-pins.yml`, `provision-governance-secrets.sh` |
 | `REPO_SYNC_TOKEN` | Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read | `sync-managed-files.yml` |
 | `ANTIGRAVITY_TOKEN` & `GCP_PROJECT_ID` | Antigravity AI Authentication & GCP Project Access | `antigravity-review.yml`, `antigravity-translate.yml` |
 

--- a/docs/en/onboarding.mdx
+++ b/docs/en/onboarding.mdx
@@ -10,7 +10,7 @@ This page covers the procedure to enroll a new repository in the docs-control go
 ## Prerequisites
 
 - Org membership in `f5-sales-demo`
-- `REPO_SETTINGS_TOKEN` and `REPO_SYNC_TOKEN` secrets configured as organization-level secrets (or added to the new repository individually)
+- `REPO_SETTINGS_TOKEN` and `REPO_SYNC_TOKEN` secrets configured as organization-level secrets (or added to the new repository individually). `REPO_SETTINGS_TOKEN` must be authorized for every enrolled repository and retain Administration R/W, Pages R/W, Contents Read, Metadata Read, and repository **Secrets: write** permission (or use an equivalent classic `repo`-scoped credential).
 - `ANTIGRAVITY_TOKEN` and `GCP_PROJECT_ID` secrets configured for automated Antigravity AI code review and language translation
 - Access to the `ghcr.io/f5-sales-demo/docs-builder` container image
 

--- a/docs/en/settings-enforcement.mdx
+++ b/docs/en/settings-enforcement.mdx
@@ -16,7 +16,7 @@ The enforcement workflow at `.github/workflows/enforce-repo-settings.yml` is a r
 
 Enforcement is split into two reusable workflows that run as parallel jobs in the caller, each with its own least-privilege token:
 
-- **`enforce-repo-settings.yml`** uses `REPO_SETTINGS_TOKEN` (Administration R/W, Pages R/W, Contents Read, Metadata Read)
+- **`enforce-repo-settings.yml`** uses `REPO_SETTINGS_TOKEN` (Administration R/W, Pages R/W, Contents Read, Metadata Read, and repository Secrets: write for every enrolled repository; or an equivalent classic `repo`-scoped credential)
 - **`sync-managed-files.yml`** uses `REPO_SYNC_TOKEN` (Contents R/W, Issues R/W, Pull Requests R/W, Metadata Read)
 
 This page covers the settings enforcement workflow. See [File Synchronization](./file-sync/) for the managed files workflow.

--- a/scripts/provision-governance-secrets.sh
+++ b/scripts/provision-governance-secrets.sh
@@ -36,8 +36,21 @@ if ! jq -e '
   exit 1
 fi
 
+github_error_class() {
+  local err_file="$1" http_status
+  http_status=$(grep -Eo 'HTTP[[:space:]]+[0-9]{3}' "$err_file" | head -n 1 | awk '{print $2}' || true)
+  if [ -n "$http_status" ]; then
+    printf 'http-%s' "$http_status"
+  elif grep -qiE 'rate[[:space:]-]*limit|abuse[ -]?detection' "$err_file"; then
+    printf 'rate-limit'
+  else
+    printf 'github-cli-error'
+  fi
+}
+
 run_gh() {
-  local err_file rc
+  local operation="$1" slug="$2" err_file rc error_class
+  shift 2
   err_file=$(mktemp "$work/gh-err.XXXXXX")
   set +e
   GH_TOKEN="$REPO_SETTINGS_TOKEN" command gh "$@" 2>"$err_file"
@@ -47,20 +60,23 @@ run_gh() {
     rm -f "$err_file"
     return 0
   fi
+  error_class=$(github_error_class "$err_file")
   if grep -qiE 'rate[[:space:]-]*limit|HTTP 429|abuse[ -]?detection' "$err_file"; then
     rm -f "$err_file"
-    echo "[DEFER] GitHub API rate capacity was exhausted; scheduled recovery is active" >&2
+    printf '[DEFER] repository=%s operation=%s error_class=%s; GitHub API rate capacity was exhausted; scheduled recovery is active\n' \
+      "$slug" "$operation" "$error_class" >&2
     return 84
   fi
   rm -f "$err_file"
-  echo "[ERROR] GitHub repository-secret operation failed closed" >&2
+  printf '[ERROR] repository=%s operation=%s error_class=%s; GitHub repository-secret operation failed closed\n' \
+    "$slug" "$operation" "$error_class" >&2
   return 1
 }
 
 list_secret_inventory() {
   local slug="$1" inventory rc
   set +e
-  inventory=$(run_gh secret list --repo "$slug" --json name)
+  inventory=$(run_gh list "$slug" secret list --repo "$slug" --json name)
   rc=$?
   set -e
   if [ "$rc" -ne 0 ]; then
@@ -108,7 +124,7 @@ while IFS= read -r name; do
     esac
     set +e
     printf '%s' "$secret_value" |
-      run_gh secret set "$secret_name" --repo "$slug"
+      run_gh set "$slug" secret set "$secret_name" --repo "$slug"
     rc=$?
     set -e
     if [ "$rc" -ne 0 ]; then

--- a/tests/test-provision-governance-secrets.sh
+++ b/tests/test-provision-governance-secrets.sh
@@ -68,6 +68,10 @@ if [ "$operation" = "list" ]; then
       echo 'gh: forbidden (HTTP 403)' >&2
       exit 1
       ;;
+    list-token-error)
+      printf 'gh: forbidden %s %s (HTTP 403)\n' "$EXPECTED_SETTINGS_TOKEN" "$EXPECTED_SYNC_TOKEN" >&2
+      exit 1
+      ;;
     list-rate)
       echo 'gh: API rate limit exceeded (HTTP 403)' >&2
       exit 1
@@ -157,6 +161,17 @@ if grep -Eq -- '--(org|env|visibility|repos)( |$)' "$WORK/gh.log"; then
 fi
 pass "secret values stay out of logs and only repository secrets are used"
 
+assert_safe_diagnostic() {
+  local output="$1" repository="$2" operation="$3" error_class="$4"
+  if ! printf '%s' "$output" |
+    grep -Fq "repository=${repository} operation=${operation} error_class=${error_class}"; then
+    fail "${operation} failure reports repository, operation, and sanitized error class"
+  fi
+  if printf '%s' "$output" | grep -Fq -e "$SETTINGS_TOKEN" -e "$SYNC_TOKEN"; then
+    fail "${operation} failure diagnostics never expose governance tokens"
+  fi
+}
+
 : >"$WORK/gh.log"
 run_provisioner >/dev/null 2>&1 || fail "idempotent rerun succeeds"
 if grep -q '^secret set ' "$WORK/gh.log"; then
@@ -200,30 +215,34 @@ set -e
 pass "missing source credentials fail closed"
 
 set +e
-PROVISION_FAKE_MODE=list-error run_provisioner >/dev/null 2>&1
+list_error_output=$(PROVISION_FAKE_MODE=list-token-error run_provisioner 2>&1)
 rc=$?
 set -e
 [ "$rc" -ne 0 ] || fail "inventory API failure fails closed"
+assert_safe_diagnostic "$list_error_output" f5-sales-demo/alpha list http-403
 
 set +e
-PROVISION_FAKE_MODE=list-rate run_provisioner >/dev/null 2>&1
+list_rate_output=$(PROVISION_FAKE_MODE=list-rate run_provisioner 2>&1)
 rc=$?
 set -e
 [ "$rc" -eq 84 ] || fail "inventory rate exhaustion returns 84"
+assert_safe_diagnostic "$list_rate_output" f5-sales-demo/alpha list http-403
 pass "inventory API failures fail closed and rate exhaustion returns 84"
 
 printf 'REPO_SETTINGS_TOKEN\n' >"$WORK/state/f5-sales-demo__beta"
 set +e
-PROVISION_FAKE_MODE=set-error run_provisioner >/dev/null 2>&1
+set_error_output=$(PROVISION_FAKE_MODE=set-error run_provisioner 2>&1)
 rc=$?
 set -e
 [ "$rc" -ne 0 ] || fail "secret write API failure fails closed"
+assert_safe_diagnostic "$set_error_output" f5-sales-demo/beta set http-403
 
 set +e
-PROVISION_FAKE_MODE=set-rate run_provisioner >/dev/null 2>&1
+set_rate_output=$(PROVISION_FAKE_MODE=set-rate run_provisioner 2>&1)
 rc=$?
 set -e
 [ "$rc" -eq 84 ] || fail "secret write rate exhaustion returns 84"
+assert_safe_diagnostic "$set_rate_output" f5-sales-demo/beta set http-403
 pass "secret write failures fail closed and rate exhaustion returns 84"
 
 set +e


### PR DESCRIPTION
## Summary

- emit only the repository, `list`/`set` operation, and a derived HTTP/error class when governance-secret provisioning fails
- retain fail-closed and rate-limit deferral behavior while proving raw stderr cannot expose either governance token
- document the required per-repository Secrets: write permission in English only

## Validation

- `bash tests/test-provision-governance-secrets.sh`
- `bash tests/test-dispatch-matrix.sh`
- `bash tests/test-governed-workflow-pins.sh`
- `shellcheck scripts/provision-governance-secrets.sh tests/test-provision-governance-secrets.sh`
- `shfmt -d scripts/provision-governance-secrets.sh tests/test-provision-governance-secrets.sh`
- `npx --yes markdownlint-cli@0.49.1 docs/en/onboarding.mdx docs/en/architecture.mdx docs/en/settings-enforcement.mdx`

Closes #1428