### PR TITLE
fix(runners): restore GitHub CLI in Docker images

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -11,7 +11,7 @@
   },
   "profiles": {
     "ubuntu-24.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:533443971b4bac3aa5f93f29d583910c876783cc5ae33d788ebfd299cff3b14c",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:e808851624018eb3d9047f734d074353b30beb6273a6fbd964d3cd209faf2ec9",
       "labels": ["ubuntu-24.04"],
       "memory": "8g",
       "cpus": "4",
@@ -21,7 +21,7 @@
       "docker_socket": false
     },
     "ubuntu-22.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:167ce9063de04f844395c348207a0b5c50089dde130929a9d92323d1c9091288",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:534fcfe099936033f8d64980c3149905d17f4774d07c3107a2004bdf62b8b3ce",
       "labels": ["ubuntu-22.04"],
       "memory": "8g",
       "cpus": "4",
@@ -31,7 +31,7 @@
       "docker_socket": false
     },
     "container-build": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:5edf7d6a779a4f6fa92ee5296761c976ad09eeb55dbf6670bd2e4dc0e6703dbe",
+      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:ce71b94a55c86e0a4b8fa34eb8574cf9b6acf0aad49dd7c057916e0ed90e9d08",
       "labels": ["container-build"],
       "memory": "16g",
       "cpus": "6",

--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -11,7 +11,7 @@
   },
   "profiles": {
     "ubuntu-24.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:e808851624018eb3d9047f734d074353b30beb6273a6fbd964d3cd209faf2ec9",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:f0935d51ab674600b4674c909a2e35c8f822f6b65b6faa42e89d172819081eb5",
       "labels": ["ubuntu-24.04"],
       "memory": "8g",
       "cpus": "4",
@@ -21,7 +21,7 @@
       "docker_socket": false
     },
     "ubuntu-22.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:534fcfe099936033f8d64980c3149905d17f4774d07c3107a2004bdf62b8b3ce",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:17e539e26eecd2eb1e8be6a2f5f0451d9dcc76268e51f08929b72ecfae05bb82",
       "labels": ["ubuntu-22.04"],
       "memory": "8g",
       "cpus": "4",
@@ -31,7 +31,7 @@
       "docker_socket": false
     },
     "container-build": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:ce71b94a55c86e0a4b8fa34eb8574cf9b6acf0aad49dd7c057916e0ed90e9d08",
+      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:f6264aae93eface6c773dcf34aa786d86a7f21d8aceba2c9d319b245b3f72c41",
       "labels": ["container-build"],
       "memory": "16g",
       "cpus": "6",

--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -115,14 +115,14 @@ jobs:
           fi
           if [[ "$TARGET" == socketless ]]; then
             docker run --rm --entrypoint bash "$published" -c \
-              'python3 -c "import yaml" && gh --version && ! command -v docker'
+              'python3 -c "import yaml" && gh --version && node --version && ! command -v docker'
           else
             socket_gid="$(stat -c '%g' /run/docker.sock)"
             docker run --rm --entrypoint bash \
               --group-add "$socket_gid" \
               --volume /run/docker.sock:/run/docker.sock:rw \
               "$published" -c \
-              'python3 -c "import yaml" && gh --version && docker version && docker buildx version && docker compose version'
+              'python3 -c "import yaml" && gh --version && node --version && docker version && docker buildx version && docker compose version'
           fi
           # shellcheck disable=SC2016
           printf '### %s\n\n`%s@%s`\n' "$PROFILE" "$IMAGE" "$digest" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -115,14 +115,14 @@ jobs:
           fi
           if [[ "$TARGET" == socketless ]]; then
             docker run --rm --entrypoint bash "$published" -c \
-              'python3 -c "import yaml" && ! command -v docker'
+              'python3 -c "import yaml" && gh --version && ! command -v docker'
           else
             socket_gid="$(stat -c '%g' /run/docker.sock)"
             docker run --rm --entrypoint bash \
               --group-add "$socket_gid" \
               --volume /run/docker.sock:/run/docker.sock:rw \
               "$published" -c \
-              'python3 -c "import yaml" && docker version && docker buildx version && docker compose version'
+              'python3 -c "import yaml" && gh --version && docker version && docker buildx version && docker compose version'
           fi
           # shellcheck disable=SC2016
           printf '### %s\n\n`%s@%s`\n' "$PROFILE" "$IMAGE" "$digest" >> "$GITHUB_STEP_SUMMARY"

--- a/runner-images/Containerfile
+++ b/runner-images/Containerfile
@@ -10,7 +10,7 @@ ARG RUNNER_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-      bash ca-certificates curl git git-lfs jq libssl3 python3 python3-venv python3-yaml \
+      bash ca-certificates curl git git-lfs gh jq libssl3 python3 python3-venv python3-yaml \
       unzip xz-utils zip \
     && if apt-cache show libicu74 >/dev/null 2>&1; then \
       apt-get install --yes --no-install-recommends libicu74; \

--- a/runner-images/Containerfile
+++ b/runner-images/Containerfile
@@ -10,7 +10,7 @@ ARG RUNNER_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-      bash ca-certificates curl git git-lfs gh jq libssl3 python3 python3-venv python3-yaml \
+      bash ca-certificates curl git git-lfs gh jq libssl3 nodejs python3 python3-venv python3-yaml \
       unzip xz-utils zip \
     && if apt-cache show libicu74 >/dev/null 2>&1; then \
       apt-get install --yes --no-install-recommends libicu74; \

--- a/tests/test_provision_ephemeral_runners.py
+++ b/tests/test_provision_ephemeral_runners.py
@@ -27,6 +27,7 @@ class ProvisionRunnerTests(unittest.TestCase):
         content = (ROOT / "runner-images/Containerfile").read_text(encoding="utf-8")
         self.assertIn("python3-yaml", content)
         self.assertIn(" gh ", content)
+        self.assertIn(" nodejs ", content)
         self.assertLess(content.index("python3-yaml"), content.index("AS socketless"))
         socketless = content.split("FROM runner-base AS socketless", 1)[1].split(
             "FROM runner-base AS docker-capable", 1
@@ -62,6 +63,7 @@ class ProvisionRunnerTests(unittest.TestCase):
             'runner_root="${RUNNER_RUNTIME_DIR:?}"',
             'python3 -c "import yaml"',
             "gh --version",
+            "node --version",
             "docker buildx version",
             "docker compose version",
         ):

--- a/tests/test_provision_ephemeral_runners.py
+++ b/tests/test_provision_ephemeral_runners.py
@@ -26,6 +26,7 @@ class ProvisionRunnerTests(unittest.TestCase):
     def test_runner_images_include_pyyaml_and_separate_docker_target(self):
         content = (ROOT / "runner-images/Containerfile").read_text(encoding="utf-8")
         self.assertIn("python3-yaml", content)
+        self.assertIn(" gh ", content)
         self.assertLess(content.index("python3-yaml"), content.index("AS socketless"))
         socketless = content.split("FROM runner-base AS socketless", 1)[1].split(
             "FROM runner-base AS docker-capable", 1
@@ -60,6 +61,7 @@ class ProvisionRunnerTests(unittest.TestCase):
             "docker cp",
             'runner_root="${RUNNER_RUNTIME_DIR:?}"',
             'python3 -c "import yaml"',
+            "gh --version",
             "docker buildx version",
             "docker compose version",
         ):


### PR DESCRIPTION
## Problem

The native Docker runner images merged in #1427 omitted the `gh` binary required by protected-main governance workflows. Runs 31716482257 and 31716482242 failed immediately with `gh: command not found`, blocking managed-file propagation.

## Changes

- install GitHub CLI in the shared base for Ubuntu 22.04, Ubuntu 24.04, and container-build images
- smoke-test `gh --version` in all three publication paths
- retain socketless Docker isolation and the pinned Docker 29.7.2 CLI stage

## Acceptance

- [x] failing tests reproduced before implementation
- [x] local runner, workflow-policy, protected-file, actionlint, Ruff, Mypy, and Pylint checks pass
- [x] exact-HEAD Antigravity review passes
- [ ] publish all three images and pin immutable returned digests
- [ ] required PR checks pass
- [ ] protected-main manifest and governed-pin workflows pass
- [ ] managed runner policy and validator converge downstream

Closes #1426