### PR TITLE
fix(runners): pin capable GitHub CLI release

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -11,7 +11,7 @@
   },
   "profiles": {
     "ubuntu-24.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:f0935d51ab674600b4674c909a2e35c8f822f6b65b6faa42e89d172819081eb5",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:8fa760afed6b45cf4508b350f3899e7604c53e5e8288491025927f159781387a",
       "labels": ["ubuntu-24.04"],
       "memory": "8g",
       "cpus": "4",
@@ -21,7 +21,7 @@
       "docker_socket": false
     },
     "ubuntu-22.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:17e539e26eecd2eb1e8be6a2f5f0451d9dcc76268e51f08929b72ecfae05bb82",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:2f46bf299e5c5d6656756660235be1c4d9d45ab763c9eb8c22bfdafc00f21cc2",
       "labels": ["ubuntu-22.04"],
       "memory": "8g",
       "cpus": "4",
@@ -31,7 +31,7 @@
       "docker_socket": false
     },
     "container-build": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:f6264aae93eface6c773dcf34aa786d86a7f21d8aceba2c9d319b245b3f72c41",
+      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:716fb43e39ae8ab9d3391ac08c61148abe2eb9bcd78dc1014db83ddedfbe873d",
       "labels": ["container-build"],
       "memory": "16g",
       "cpus": "6",

--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -115,14 +115,14 @@ jobs:
           fi
           if [[ "$TARGET" == socketless ]]; then
             docker run --rm --entrypoint bash "$published" -c \
-              'python3 -c "import yaml" && gh --version && node --version && ! command -v docker'
+              'python3 -c "import yaml" && gh --version | grep -q "gh version 2.97.0" && gh api --help | grep -q -- "--slurp" && node --version && ! command -v docker'
           else
             socket_gid="$(stat -c '%g' /run/docker.sock)"
             docker run --rm --entrypoint bash \
               --group-add "$socket_gid" \
               --volume /run/docker.sock:/run/docker.sock:rw \
               "$published" -c \
-              'python3 -c "import yaml" && gh --version && node --version && docker version && docker buildx version && docker compose version'
+              'python3 -c "import yaml" && gh --version | grep -q "gh version 2.97.0" && gh api --help | grep -q -- "--slurp" && node --version && docker version && docker buildx version && docker compose version'
           fi
           # shellcheck disable=SC2016
           printf '### %s\n\n`%s@%s`\n' "$PROFILE" "$IMAGE" "$digest" >> "$GITHUB_STEP_SUMMARY"

--- a/runner-images/Containerfile
+++ b/runner-images/Containerfile
@@ -6,11 +6,13 @@ FROM ${UBUNTU_IMAGE} AS runner-base
 
 ARG RUNNER_VERSION=2.336.0
 ARG RUNNER_SHA256=04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d
+ARG GH_VERSION=2.97.0
+ARG GH_SHA256=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-      bash ca-certificates curl git git-lfs gh jq libssl3 nodejs python3 python3-venv python3-yaml \
+      bash ca-certificates curl git git-lfs jq libssl3 nodejs python3 python3-venv python3-yaml \
       unzip xz-utils zip \
     && if apt-cache show libicu74 >/dev/null 2>&1; then \
       apt-get install --yes --no-install-recommends libicu74; \
@@ -20,6 +22,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home --uid 1001 --shell /bin/bash runner \
     && install -d -o runner -g runner /opt/actions-runner \
+    && curl --fail --location --proto '=https' --tlsv1.2 \
+      --output /tmp/gh.tar.gz \
+      "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum --check --strict \
+    && tar --extract --gzip --file /tmp/gh.tar.gz --directory /tmp \
+    && install -o root -g root -m 0555 \
+      "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh \
+    && rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64" /tmp/gh.tar.gz \
     && curl --fail --location --proto '=https' --tlsv1.2 \
       --output /tmp/actions-runner.tar.gz \
       "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \

--- a/tests/test_provision_ephemeral_runners.py
+++ b/tests/test_provision_ephemeral_runners.py
@@ -26,8 +26,16 @@ class ProvisionRunnerTests(unittest.TestCase):
     def test_runner_images_include_pyyaml_and_separate_docker_target(self):
         content = (ROOT / "runner-images/Containerfile").read_text(encoding="utf-8")
         self.assertIn("python3-yaml", content)
-        self.assertIn(" gh ", content)
         self.assertIn(" nodejs ", content)
+        self.assertIn("ARG GH_VERSION=2.97.0", content)
+        self.assertIn(
+            "ARG GH_SHA256="
+            "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
+            content,
+        )
+        self.assertIn("gh_${GH_VERSION}_linux_amd64.tar.gz", content)
+        self.assertIn("/usr/local/bin/gh", content)
+        self.assertNotIn("git git-lfs gh jq", content)
         self.assertLess(content.index("python3-yaml"), content.index("AS socketless"))
         socketless = content.split("FROM runner-base AS socketless", 1)[1].split(
             "FROM runner-base AS docker-capable", 1
@@ -62,7 +70,8 @@ class ProvisionRunnerTests(unittest.TestCase):
             "docker cp",
             'runner_root="${RUNNER_RUNTIME_DIR:?}"',
             'python3 -c "import yaml"',
-            "gh --version",
+            "gh version 2.97.0",
+            'gh api --help | grep -q -- "--slurp"',
             "node --version",
             "docker buildx version",
             "docker compose version",


### PR DESCRIPTION
## Problem

PR #1430 restored `gh`, but Ubuntu 24.04 packages GitHub CLI 2.45.0 and Ubuntu 22.04 packages 2.4.0. Protected-main workflow run 31721579711 requires `gh api --slurp` and fails closed because those versions do not expose the flag.

## Scope

- Pin official GitHub CLI 2.97.0 for Linux/amd64 by the release checksum.
- Remove distro `gh` packages from both runner bases.
- Require the publisher smoke test to prove the exact version and `gh api --slurp` capability on socketless and Docker-capable profiles.
- Keep all existing PyYAML, Node, Docker isolation, Buildx, and Compose checks.

## Acceptance criteria

- Both Ubuntu runner images and the builder contain GitHub CLI 2.97.0 with `gh api --slurp`.
- All local governance/security checks and exact-HEAD Antigravity review pass.
- All three immutable images publish and are pinned by verified digest.
- PR Super-Linter and Shell Unit Tests pass on the rebuilt profiles.
- Protected-main managed-manifest and governed-pin workflows pass, followed by downstream convergence.

Closes #1426