### PR TITLE
fix(runners): retry transient Docker inspections

### DIFF
--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -39,6 +39,8 @@ CONTAINER_ID_RE = re.compile(r"[0-9a-f]{64}")
 DOCKER_SOCKET = "/run/docker.sock"
 MINIMUM_DOCKER_VERSION = "29.2.1"
 TARGET_DOCKER_VERSION = "29.7.2"
+TRANSIENT_INSPECT_ATTEMPTS = 5
+TRANSIENT_INSPECT_DELAY_SECONDS = 0.1
 
 
 class FleetError(RuntimeError):
@@ -424,38 +426,42 @@ class EphemeralController:
         return ids
 
     def _inspect_container(self, container_id, *, allow_disappeared=False):
-        result = self.command(
-            ["docker", "container", "inspect", container_id], check=False
-        )
-        if result.returncode != 0:
-            if allow_disappeared:
-                inventory = self.command(
-                    [
-                        "docker",
-                        "container",
-                        "ls",
-                        "--all",
-                        "--quiet",
-                        "--no-trunc",
-                        "--filter",
-                        f"id={container_id}",
-                    ],
-                    check=False,
+        attempts = TRANSIENT_INSPECT_ATTEMPTS if allow_disappeared else 1
+        for attempt in range(attempts):
+            result = self.command(
+                ["docker", "container", "inspect", container_id], check=False
+            )
+            if result.returncode == 0:
+                break
+            if not allow_disappeared:
+                raise FleetError(f"cannot inspect Docker container {container_id}")
+            inventory = self.command(
+                [
+                    "docker",
+                    "container",
+                    "ls",
+                    "--all",
+                    "--quiet",
+                    "--no-trunc",
+                    "--filter",
+                    f"id={container_id}",
+                ],
+                check=False,
+            )
+            if inventory.returncode != 0:
+                raise FleetError(
+                    f"cannot confirm disappeared Docker container {container_id}"
                 )
-                if inventory.returncode != 0:
-                    raise FleetError(
-                        f"cannot confirm disappeared Docker container {container_id}"
-                    )
-                ids = self._container_ids(
-                    inventory.stdout, "exact disappeared container"
+            ids = self._container_ids(inventory.stdout, "exact disappeared container")
+            if not ids:
+                return None
+            if ids != [container_id]:
+                raise FleetError(
+                    f"unexpected Docker exact container inventory for {container_id}"
                 )
-                if not ids:
-                    return None
-                if ids != [container_id]:
-                    raise FleetError(
-                        f"unexpected Docker exact container inventory for {container_id}"
-                    )
-            raise FleetError(f"cannot inspect Docker container {container_id}")
+            if attempt + 1 == attempts:
+                raise FleetError(f"cannot inspect Docker container {container_id}")
+            time.sleep(TRANSIENT_INSPECT_DELAY_SECONDS)
         try:
             payload = json.loads(result.stdout)
         except (TypeError, ValueError) as exc:

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -621,6 +621,71 @@ class EphemeralRunnerTests(unittest.TestCase):
             calls,
         )
 
+    def test_nested_cleanup_retries_container_removal_in_progress(self):
+        workspace = self.root / "state/workspaces/fixture/ubuntu-24.04/0"
+        (workspace / "_work").mkdir(parents=True)
+        disappearing_id = "5" * 64
+        nested_id = "6" * 64
+        calls = []
+        exact_inventories = 0
+
+        def docker_fixture(command, **_kwargs):
+            nonlocal exact_inventories
+            calls.append(command)
+            if command[:4] == ["docker", "container", "ls", "--all"]:
+                if "--filter" not in command:
+                    return SimpleNamespace(
+                        returncode=0,
+                        stdout=f"{disappearing_id}\n{nested_id}\n",
+                        stderr="",
+                    )
+                container_filter = command[command.index("--filter") + 1]
+                if container_filter == f"id={disappearing_id}":
+                    exact_inventories += 1
+                    output = f"{disappearing_id}\n" if exact_inventories == 1 else ""
+                    return SimpleNamespace(returncode=0, stdout=output, stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if command == ["docker", "container", "inspect", disappearing_id]:
+                return SimpleNamespace(
+                    returncode=1,
+                    stdout="",
+                    stderr="removal in progress",
+                )
+            if command == ["docker", "container", "inspect", nested_id]:
+                payload = {
+                    "Id": nested_id,
+                    "Name": "/nested",
+                    "Config": {"Labels": {}},
+                    "Mounts": [
+                        {
+                            "Type": "bind",
+                            "Source": str(workspace / "_work"),
+                        }
+                    ],
+                }
+                return SimpleNamespace(
+                    returncode=0, stdout=json.dumps(payload), stderr=""
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        controller = MODULE.EphemeralController(
+            self.policy(), FakeGitHub(), self.root / "state", docker_fixture
+        )
+        spec = self.policy().repository("f5-sales-demo/fixture")
+
+        with mock.patch.object(MODULE.time, "sleep") as sleep:
+            controller.cleanup(spec, spec.profiles[0], 0)
+
+        self.assertEqual(exact_inventories, 2)
+        sleep.assert_called_once()
+        self.assertEqual(
+            calls.count(["docker", "container", "inspect", disappearing_id]), 2
+        )
+        self.assertIn(
+            ["docker", "container", "rm", "--force", nested_id],
+            calls,
+        )
+
     def test_nested_cleanup_fails_closed_when_disappearance_is_not_proven(self):
         workspace = self.root / "state/workspaces/fixture/ubuntu-24.04/0"
         workspace.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- retry failed nested-container inspections for a bounded 500 ms while an exact full-ID Docker inventory proves the container still exists
- accept disappearance only after a successful exact inventory proves absence
- preserve fail-closed behavior for persistent inspection failures, inventory failures, malformed IDs, duplicate IDs, and unexpected IDs
- add the exact live removal-in-progress regression from fleet batch 2

## Verification

- `python3 -m unittest discover -s tests -p "test_*.py"` — 91 passed
- all `tests/test-*.sh` scripts — 36 passed
- Ruff check/format, Mypy, and repository Pylint — clean (10.00/10)
- actionlint native validation and the shell-suite integrated actionlint assertion — clean
- staged and HEAD PII enforcement — clean
- `git diff --check` — clean
- `bash scripts/agy-pre-push-review.sh` at exact HEAD `efdacfc` — passed, no critical/high findings

Closes #1436
Follow-up to #1434
Part of #1426