### PR TITLE
fix(runners): cover Docker removal latency

### DIFF
--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -39,8 +39,10 @@ CONTAINER_ID_RE = re.compile(r"[0-9a-f]{64}")
 DOCKER_SOCKET = "/run/docker.sock"
 MINIMUM_DOCKER_VERSION = "29.2.1"
 TARGET_DOCKER_VERSION = "29.7.2"
-TRANSIENT_INSPECT_ATTEMPTS = 5
-TRANSIENT_INSPECT_DELAY_SECONDS = 0.1
+TRANSIENT_INSPECT_ATTEMPTS = 8
+TRANSIENT_INSPECT_INITIAL_DELAY_SECONDS = 0.1
+TRANSIENT_INSPECT_MAX_DELAY_SECONDS = 2.0
+TRANSIENT_INSPECT_MAX_TOTAL_SECONDS = 8.0
 
 
 class FleetError(RuntimeError):
@@ -461,7 +463,11 @@ class EphemeralController:
                 )
             if attempt + 1 == attempts:
                 raise FleetError(f"cannot inspect Docker container {container_id}")
-            time.sleep(TRANSIENT_INSPECT_DELAY_SECONDS)
+            delay = min(
+                TRANSIENT_INSPECT_INITIAL_DELAY_SECONDS * (2**attempt),
+                TRANSIENT_INSPECT_MAX_DELAY_SECONDS,
+            )
+            time.sleep(delay)
         try:
             payload = json.loads(result.stdout)
         except (TypeError, ValueError) as exc:

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -642,7 +642,7 @@ class EphemeralRunnerTests(unittest.TestCase):
                 container_filter = command[command.index("--filter") + 1]
                 if container_filter == f"id={disappearing_id}":
                     exact_inventories += 1
-                    output = f"{disappearing_id}\n" if exact_inventories == 1 else ""
+                    output = f"{disappearing_id}\n" if exact_inventories <= 7 else ""
                     return SimpleNamespace(returncode=0, stdout=output, stderr="")
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             if command == ["docker", "container", "inspect", disappearing_id]:
@@ -676,14 +676,57 @@ class EphemeralRunnerTests(unittest.TestCase):
         with mock.patch.object(MODULE.time, "sleep") as sleep:
             controller.cleanup(spec, spec.profiles[0], 0)
 
-        self.assertEqual(exact_inventories, 2)
-        sleep.assert_called_once()
+        self.assertEqual(exact_inventories, 8)
+        self.assertEqual(sleep.call_count, 7)
         self.assertEqual(
-            calls.count(["docker", "container", "inspect", disappearing_id]), 2
+            calls.count(["docker", "container", "inspect", disappearing_id]), 8
         )
         self.assertIn(
             ["docker", "container", "rm", "--force", nested_id],
             calls,
+        )
+
+    def test_nested_cleanup_bounds_persistent_removal_in_progress(self):
+        workspace = self.root / "state/workspaces/fixture/ubuntu-24.04/0"
+        workspace.mkdir(parents=True)
+        container_id = "7" * 64
+        calls = []
+
+        def docker_fixture(command, **_kwargs):
+            calls.append(command)
+            if command[:4] == ["docker", "container", "ls", "--all"]:
+                if "--filter" in command:
+                    container_filter = command[command.index("--filter") + 1]
+                    if container_filter.startswith("name="):
+                        return SimpleNamespace(returncode=0, stdout="", stderr="")
+                return SimpleNamespace(
+                    returncode=0, stdout=f"{container_id}\n", stderr=""
+                )
+            if command == ["docker", "container", "inspect", container_id]:
+                return SimpleNamespace(
+                    returncode=1, stdout="", stderr="removal in progress"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        controller = MODULE.EphemeralController(
+            self.policy(), FakeGitHub(), self.root / "state", docker_fixture
+        )
+        spec = self.policy().repository("f5-sales-demo/fixture")
+
+        with (
+            mock.patch.object(MODULE.time, "sleep") as sleep,
+            self.assertRaises(MODULE.FleetError),
+        ):
+            controller.cleanup(spec, spec.profiles[0], 0)
+
+        self.assertEqual(
+            calls.count(["docker", "container", "inspect", container_id]),
+            MODULE.TRANSIENT_INSPECT_ATTEMPTS,
+        )
+        self.assertEqual(sleep.call_count, MODULE.TRANSIENT_INSPECT_ATTEMPTS - 1)
+        self.assertLessEqual(
+            sum(call.args[0] for call in sleep.call_args_list),
+            MODULE.TRANSIENT_INSPECT_MAX_TOTAL_SECONDS,
         )
 
     def test_nested_cleanup_fails_closed_when_disappearance_is_not_proven(self):
@@ -724,7 +767,10 @@ class EphemeralRunnerTests(unittest.TestCase):
                 )
                 spec = self.policy().repository("f5-sales-demo/fixture")
 
-                with self.assertRaises(MODULE.FleetError):
+                with (
+                    mock.patch.object(MODULE.time, "sleep"),
+                    self.assertRaises(MODULE.FleetError),
+                ):
                     controller.cleanup(spec, spec.profiles[0], 0)
 
     def test_nested_cleanup_rejects_malformed_or_mixed_bind_mounts(self):


### PR DESCRIPTION
## Summary

- replace the 500 ms fixed retry with an eight-attempt exponential schedule bounded to 7.1 seconds
- cap individual delays at two seconds while validating every exact full-ID Docker inventory
- test late disappearance after the observed five-second removal window
- prove persistent exact-container presence still fails closed after bounded exhaustion

## Verification

- `python3 -m unittest discover -s tests -p "test_*.py"` — 92 passed
- all `tests/test-*.sh` scripts — 36 passed
- Ruff check/format, Mypy, and repository Pylint — clean (10.00/10)
- actionlint native validation and integrated shell-suite assertion — clean
- staged and HEAD PII enforcement — clean
- `git diff --check` — clean
- `bash scripts/agy-pre-push-review.sh` at exact HEAD `03f8ba8` — passed, no critical/high findings

Closes #1437
Follow-up to #1436 and #1434
Part of #1426