### PR TITLE
fix(runners): serialize exact fleet cleanup

### DIFF
--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import fcntl
 import json
 import os
 import re
@@ -622,8 +623,30 @@ class EphemeralController:
                 )
 
     def cleanup(self, spec, profile, slot):
-        self._stop_outer(spec, profile, slot)
-        self._remove_nested_containers(spec, profile, slot)
+        lock_path = self.base_dir / ".cleanup.lock"
+        try:
+            descriptor = os.open(
+                lock_path,
+                os.O_CREAT | os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW,
+                0o600,
+            )
+        except OSError as exc:
+            raise FleetError(f"cannot open runner cleanup lock: {exc}") from exc
+        try:
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                raise FleetError("runner cleanup lock is unsafe")
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            self._stop_outer(spec, profile, slot)
+            self._remove_nested_containers(spec, profile, slot)
+        except OSError as exc:
+            raise FleetError(f"cannot use runner cleanup lock: {exc}") from exc
+        finally:
+            os.close(descriptor)
 
     def prepare_workspace(self, spec, profile, slot):
         """Create the exact host-visible workspace owned by runner UID/GID 1001."""

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=consider-using-with
+# pylint: disable=consider-using-with,too-many-lines
 """Hermetic tests for the ephemeral runner lifecycle."""
 
 import importlib.util
@@ -552,6 +552,42 @@ class EphemeralRunnerTests(unittest.TestCase):
             ["docker", "container", "rm", "--force", nested_id],
             calls,
         )
+
+    def test_cleanup_serializes_host_global_container_inventory(self):
+        workspace = self.root / "state/workspaces/fixture/ubuntu-24.04/0"
+        workspace.mkdir(parents=True)
+        controller = MODULE.EphemeralController(
+            self.policy(), FakeGitHub(), self.root / "state", CommandRecorder()
+        )
+        spec = self.policy().repository("f5-sales-demo/fixture")
+
+        with mock.patch.object(MODULE.fcntl, "flock") as flock:
+            controller.cleanup(spec, spec.profiles[0], 0)
+
+        flock.assert_called_once()
+        descriptor, operation = flock.call_args.args
+        self.assertIsInstance(descriptor, int)
+        self.assertEqual(operation, MODULE.fcntl.LOCK_EX)
+        lock_path = self.root / "state/.cleanup.lock"
+        metadata = lock_path.stat(follow_symlinks=False)
+        self.assertTrue(stat.S_ISREG(metadata.st_mode))
+        self.assertEqual(stat.S_IMODE(metadata.st_mode), 0o600)
+
+    def test_cleanup_rejects_symlink_lock_without_following_it(self):
+        workspace = self.root / "state/workspaces/fixture/ubuntu-24.04/0"
+        workspace.mkdir(parents=True)
+        outside = self.root / "outside-lock"
+        outside.write_text("preserve", encoding="utf-8")
+        (self.root / "state/.cleanup.lock").symlink_to(outside)
+        controller = MODULE.EphemeralController(
+            self.policy(), FakeGitHub(), self.root / "state", CommandRecorder()
+        )
+        spec = self.policy().repository("f5-sales-demo/fixture")
+
+        with self.assertRaises(MODULE.FleetError):
+            controller.cleanup(spec, spec.profiles[0], 0)
+
+        self.assertEqual(outside.read_text(encoding="utf-8"), "preserve")
 
     def test_nested_cleanup_tolerates_confirmed_concurrent_container_removal(self):
         workspace = self.root / "state/workspaces/fixture/ubuntu-24.04/0"


### PR DESCRIPTION
## Summary

Serialize the complete Docker runner cleanup transaction across the host so concurrent runner exits cannot race the host-global nested-container inventory. The shared lock is fail-closed, owner-only, and symlink-safe under the managed `/data` runner state root.

## Related Issue

Closes #1439
Part of #1426

## Changes

- acquire one exclusive fleet cleanup lock before stopping an exact outer runner and inspecting nested containers
- reject unsafe cleanup lock metadata and refuse to follow a substituted symlink
- cover lock acquisition and symlink rejection in controller unit tests

## Verification evidence

- `python3 -m unittest discover -s tests -p 'test_*.py'`: 94 passed
- all 36 `tests/test-*.sh`: passed, including privileged workflow and Zizmor integration coverage
- Ruff format/check, MyPy, and Pylint: passed
- Actionlint, PII enforcement, and `git diff --check`: passed
- exact-HEAD `bash scripts/agy-pre-push-review.sh` on `2e6fd1b9e4bab64350c023ece10b994a0d9a314a`: passed both reviewer and verifier with no critical/high findings

## Delivery evidence

- Host acceptance will install the merged controller byte-for-byte, reconcile the four exact stale offline registrations, rotate the final 11 runner units concurrently, and audit the full fleet.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions
