### PR TITLE
fix(runners): include npm toolchain in runner images

### DIFF
--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -115,14 +115,14 @@ jobs:
           fi
           if [[ "$TARGET" == socketless ]]; then
             docker run --rm --entrypoint bash "$published" -c \
-              'python3 -c "import yaml" && gh --version | grep -q "gh version 2.97.0" && gh api --help | grep -q -- "--slurp" && node --version && ! command -v docker'
+              'python3 -c "import yaml" && gh --version | grep -q "gh version 2.97.0" && gh api --help | grep -q -- "--slurp" && node --version && npx --version && ! command -v docker'
           else
             socket_gid="$(stat -c '%g' /run/docker.sock)"
             docker run --rm --entrypoint bash \
               --group-add "$socket_gid" \
               --volume /run/docker.sock:/run/docker.sock:rw \
               "$published" -c \
-              'python3 -c "import yaml" && gh --version | grep -q "gh version 2.97.0" && gh api --help | grep -q -- "--slurp" && node --version && docker version && docker buildx version && docker compose version'
+              'python3 -c "import yaml" && gh --version | grep -q "gh version 2.97.0" && gh api --help | grep -q -- "--slurp" && node --version && npx --version && docker version && docker buildx version && docker compose version'
           fi
           # shellcheck disable=SC2016
           printf '### %s\n\n`%s@%s`\n' "$PROFILE" "$IMAGE" "$digest" >> "$GITHUB_STEP_SUMMARY"

--- a/runner-images/Containerfile
+++ b/runner-images/Containerfile
@@ -12,7 +12,7 @@ ARG GH_SHA256=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
-      bash ca-certificates curl git git-lfs jq libssl3 nodejs python3 python3-venv python3-yaml \
+      bash ca-certificates curl git git-lfs jq libssl3 nodejs npm python3 python3-venv python3-yaml \
       unzip xz-utils zip \
     && if apt-cache show libicu74 >/dev/null 2>&1; then \
       apt-get install --yes --no-install-recommends libicu74; \


### PR DESCRIPTION
Fixes #1442.

Adds the Ubuntu npm package (which provides `npx`) to both ephemeral runner image profiles and verifies it in the image-publication canary. This fixes fleet MDX lint on the migrated Docker-capable runner.