### PR TITLE
fix(runners): propagate service stops

### DIFF
--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -366,11 +366,25 @@ class GitHubClient:
 
 
 class EphemeralController:
-    def __init__(self, policy, github, base_dir=DEFAULT_BASE_DIR, command=run_command):
+    def __init__(
+        self,
+        policy,
+        github,
+        base_dir=DEFAULT_BASE_DIR,
+        command=run_command,
+        popen=None,
+    ):
         self.policy = policy
         self.github = github
         self.base_dir = Path(base_dir)
         self.command = command
+        self.popen = (
+            popen
+            if popen is not None
+            else subprocess.Popen
+            if command is run_command
+            else None
+        )
         self.stopping = False
 
     def state_dir(self, spec, profile, slot):
@@ -496,7 +510,7 @@ class EphemeralController:
             config["Labels"] = {}
         return payload
 
-    def _stop_outer(self, spec, profile, slot):
+    def _exact_outer_id(self, spec, profile, slot):
         name = self.container_name(spec, profile, slot)
         result = self.command(
             [
@@ -517,7 +531,7 @@ class EphemeralController:
         if len(ids) > 1:
             raise FleetError(f"multiple exact runner containers matched {name}")
         if not ids:
-            return
+            return None
         container_id = ids[0]
         inspected = self._inspect_container(container_id)
         expected_labels = {
@@ -531,6 +545,13 @@ class EphemeralController:
             labels.get(key) != value for key, value in expected_labels.items()
         ):
             raise FleetError(f"exact runner container identity mismatch: {name}")
+        return container_id
+
+    def _request_outer_stop(self, spec, profile, slot):
+        name = self.container_name(spec, profile, slot)
+        container_id = self._exact_outer_id(spec, profile, slot)
+        if container_id is None:
+            return None
         stopped = self.command(
             [
                 "docker",
@@ -544,6 +565,13 @@ class EphemeralController:
         )
         if stopped.returncode != 0:
             raise FleetError(f"cannot stop exact runner container {name}")
+        return container_id
+
+    def _stop_outer(self, spec, profile, slot):
+        name = self.container_name(spec, profile, slot)
+        container_id = self._request_outer_stop(spec, profile, slot)
+        if container_id is None:
+            return
         removed = self.command(
             ["docker", "container", "rm", "--force", container_id], check=False
         )
@@ -844,6 +872,33 @@ class EphemeralController:
         command.append(profile.image)
         return command
 
+    def _run_outer(self, spec, profile, slot, command, token):
+        if self.popen is None:
+            return self.command(
+                command,
+                input_text=token + "\n",
+                check=False,
+                capture=False,
+            )
+        process = self.popen(
+            command,
+            stdin=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            process.communicate(token + "\n")
+        except StopRequestedError:
+            container_id = self._request_outer_stop(spec, profile, slot)
+            if container_id is None and process.poll() is None:
+                process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            raise
+        return subprocess.CompletedProcess(command, process.returncode)
+
     def run_once(self, full_name, profile_name, slot=0):
         spec = self.policy.repository(full_name)
         profile = next(
@@ -859,11 +914,12 @@ class EphemeralController:
         self.reset_workspace(spec, profile, slot)
         token = self.github.registration_token(full_name)
         try:
-            result = self.command(
+            result = self._run_outer(
+                spec,
+                profile,
+                slot,
                 self.docker_command(spec, profile, slot),
-                input_text=token + "\n",
-                check=False,
-                capture=False,
+                token,
             )
             return result.returncode
         finally:

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -412,6 +412,120 @@ class EphemeralRunnerTests(unittest.TestCase):
                 0,
             )
 
+    def test_stop_request_reaches_exact_blocking_outer_container_then_cleans(self):
+        outer_id = "a" * 64
+        events = []
+        exact_inventories = 0
+        github = FakeGitHub()
+        github.records = [{"id": 42, "name": "gha-fixture-ubuntu-24.04-0-deadbeef"}]
+
+        class InterruptedRunnerProcess:
+            returncode = -MODULE.signal.SIGTERM
+
+            @staticmethod
+            def communicate(input_text):
+                events.append(("communicate", input_text))
+                raise MODULE.StopRequestedError
+
+            @staticmethod
+            def terminate():
+                events.append(("terminate",))
+
+            @staticmethod
+            def wait(timeout=None):
+                events.append(("wait", timeout))
+                return -MODULE.signal.SIGTERM
+
+        def popen(command, **kwargs):
+            events.append(("popen", command, kwargs))
+            return InterruptedRunnerProcess()
+
+        def docker_fixture(command, **_kwargs):
+            nonlocal exact_inventories
+            events.append(("command", command))
+            if command[:3] == ["docker", "version", "--format"]:
+                return SimpleNamespace(returncode=0, stdout="29.2.1\n", stderr="")
+            if command[:4] == ["docker", "container", "ls", "--all"]:
+                if "--filter" not in command:
+                    return SimpleNamespace(returncode=0, stdout="", stderr="")
+                exact_inventories += 1
+                output = outer_id + "\n" if exact_inventories == 2 else ""
+                return SimpleNamespace(returncode=0, stdout=output, stderr="")
+            if command == ["docker", "container", "inspect", outer_id]:
+                payload = {
+                    "Id": outer_id,
+                    "Name": "/gha-fixture-ubuntu-24.04-0",
+                    "Config": {
+                        "Labels": {
+                            "f5.runner.managed": "true",
+                            "f5.runner.repository": "f5-sales-demo/fixture",
+                            "f5.runner.profile": "ubuntu-24.04",
+                            "f5.runner.slot": "0",
+                        }
+                    },
+                    "Mounts": [],
+                }
+                return SimpleNamespace(
+                    returncode=0, stdout=json.dumps(payload), stderr=""
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        controller = MODULE.EphemeralController(
+            self.policy(),
+            github,
+            self.root / "state",
+            docker_fixture,
+            popen=popen,
+        )
+
+        with self.assertRaises(MODULE.StopRequestedError):
+            controller.run_once("f5-sales-demo/fixture", "ubuntu-24.04")
+
+        runner_command = next(event[1] for event in events if event[0] == "popen")
+        self.assertEqual(runner_command[:2], ["docker", "run"])
+        self.assertIn(("communicate", "registration-secret\n"), events)
+        stop_event = (
+            "command",
+            ["docker", "container", "stop", "--time", "300", outer_id],
+        )
+        self.assertIn(stop_event, events)
+        self.assertLess(events.index(stop_event), events.index(("wait", 5)))
+        self.assertNotIn(("terminate",), events)
+        self.assertEqual(github.deleted, [("f5-sales-demo/fixture", 42)])
+
+    def test_completed_outer_process_does_not_request_an_extra_stop(self):
+        events = []
+
+        class CompletedRunnerProcess:
+            returncode = 0
+
+            @staticmethod
+            def communicate(input_text):
+                events.append(("communicate", input_text))
+                return None, None
+
+            @staticmethod
+            def terminate():
+                events.append(("terminate",))
+
+            @staticmethod
+            def wait():
+                events.append(("wait",))
+                return 0
+
+        controller = MODULE.EphemeralController(
+            self.policy(),
+            FakeGitHub(),
+            self.root / "state",
+            CommandRecorder(),
+            popen=lambda *_args, **_kwargs: CompletedRunnerProcess(),
+        )
+
+        self.assertEqual(
+            controller.run_once("f5-sales-demo/fixture", "ubuntu-24.04"), 0
+        )
+        self.assertEqual(events, [("communicate", "registration-secret\n")])
+
     def test_container_profile_uses_exact_host_docker_socket(self):
         recorder = CommandRecorder()
         controller = MODULE.EphemeralController(

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -414,7 +414,7 @@ class EphemeralRunnerTests(unittest.TestCase):
 
     def test_stop_request_reaches_exact_blocking_outer_container_then_cleans(self):
         outer_id = "a" * 64
-        events = []
+        events: list[tuple[Any, ...]] = []
         exact_inventories = 0
         github = FakeGitHub()
         github.records = [{"id": 42, "name": "gha-fixture-ubuntu-24.04-0-deadbeef"}]
@@ -494,7 +494,7 @@ class EphemeralRunnerTests(unittest.TestCase):
         self.assertEqual(github.deleted, [("f5-sales-demo/fixture", 42)])
 
     def test_completed_outer_process_does_not_request_an_extra_stop(self):
-        events = []
+        events: list[tuple[Any, ...]] = []
 
         class CompletedRunnerProcess:
             returncode = 0


### PR DESCRIPTION
## Summary

Make a systemd stop request reach the exact validated outer Docker runner while the controller is blocked on `docker run`. The controller preserves the profile's graceful stop timeout and then proceeds through the serialized fail-closed cleanup transaction.

## Related Issue

Closes #1443
Part of #1426

## Changes

- own the production `docker run` process explicitly while retaining the injected hermetic command path
- on a stop request, re-inventory and validate the exact managed outer container before applying its configured 300-second timeout
- bound Docker CLI settlement and preserve the existing exact cleanup, registration removal, and workspace erasure
- test the blocked-stop path, exact stop argv, cleanup completion, and normal completed-runner path

## Verification evidence

- failing-first focused stop tests reproduced the missing controller process interface before implementation
- `python3 -m unittest discover -s tests -p 'test_*.py'`: 96 passed
- all 36 `tests/test-*.sh`: passed, including privileged-workflow and Zizmor integration suites
- Ruff format/check, MyPy, Pylint, Actionlint, PII enforcement, and `git diff --check`: passed
- exact-HEAD `bash scripts/agy-pre-push-review.sh` on `b24b000`: passed reviewer and verifier with no critical/high findings
- host reproduction: 11 units stayed deactivating and all 11 exact containers remained running under the previous controller; exact manual container exit then proved serialized cleanup removed every selected registration/workspace with no cleanup errors

## Delivery evidence

- After merge, install the exact merged controller and repeat the identical 11-unit concurrent `systemctl stop` canary without manual Docker commands, then restart and audit the fleet.

## Checklist

- [x] Linked to a detailed issue with `Closes #N`
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests written first (TDD) and passing; the issue's acceptance criteria are met
- [x] Verified locally by running or exercising the change — evidence pasted above
- [ ] Pending, failed, behind, or conflicted states repaired through `MERGED`
- [ ] Worktree and confirmed-merged branch cleaned; fleet convergence confirmed when applicable
- [x] Follows project conventions
