### PR TITLE
fix(governance): roll Docker-routed workflow pins

### DIFF
--- a/.github/config/governed-workflow-pin.json
+++ b/.github/config/governed-workflow-pin.json
@@ -1,3 +1,3 @@
 {
-  "revision": "6aaca252b0fb0816618cb56a4c95b19d1ce91856"
+  "revision": "fa0c7a5fd25b300fac3287c6d8753e7e79e2c531"
 }

--- a/tests/test-governed-workflow-pins.sh
+++ b/tests/test-governed-workflow-pins.sh
@@ -68,6 +68,15 @@ if not refs or set(refs) != {expected}:
     raise SystemExit(f"configured={expected}; callers={sorted(set(refs))}")
 PY
 
+check "governed Super-Linter pin references Docker-routed trusted implementation" \
+  bash -c '
+    revision=$(jq -er '\''.revision | select(type == "string" and test("^[0-9a-f]{40}$"))'\'' "$2") &&
+      implementation=$(git -C "$1" show "${revision}:.github/workflows/super-linter.yml") &&
+      grep -Fq '\''runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", container-build]'\'' <<<"$implementation" &&
+      grep -Fq '\''github.event.pull_request.head.repo.full_name == github.repository'\'' <<<"$implementation" &&
+      grep -Fq '\''Docker-capable lint is forbidden for fork pull requests.'\'' <<<"$implementation"
+  ' _ "$REPO_ROOT" "$PIN_CONFIG"
+
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 mkdir -p "$WORK/workflows" "$WORK/.github/config"

--- a/tests/test-governed-workflow-pins.sh
+++ b/tests/test-governed-workflow-pins.sh
@@ -68,17 +68,26 @@ if not refs or set(refs) != {expected}:
     raise SystemExit(f"configured={expected}; callers={sorted(set(refs))}")
 PY
 
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
 check "governed Super-Linter pin references Docker-routed trusted implementation" \
   bash -c '
     revision=$(jq -er '\''.revision | select(type == "string" and test("^[0-9a-f]{40}$"))'\'' "$2") &&
-      implementation=$(git -C "$1" show "${revision}:.github/workflows/super-linter.yml") &&
+      if git -C "$1" cat-file -e "${revision}^{commit}" 2>/dev/null; then
+        implementation=$(git -C "$1" show "${revision}:.github/workflows/super-linter.yml")
+      else
+        remote=$(git -C "$1" remote get-url origin) &&
+          git init --quiet "$3" &&
+          git -C "$3" fetch --no-tags --quiet --depth=1 "$remote" "$revision" &&
+          test "$(git -C "$3" rev-parse FETCH_HEAD)" = "$revision" &&
+          implementation=$(git -C "$3" show "FETCH_HEAD:.github/workflows/super-linter.yml")
+      fi &&
       grep -Fq '\''runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", container-build]'\'' <<<"$implementation" &&
       grep -Fq '\''github.event.pull_request.head.repo.full_name == github.repository'\'' <<<"$implementation" &&
       grep -Fq '\''Docker-capable lint is forbidden for fork pull requests.'\'' <<<"$implementation"
-  ' _ "$REPO_ROOT" "$PIN_CONFIG"
+  ' _ "$REPO_ROOT" "$PIN_CONFIG" "$WORK/pinned-revision"
 
-WORK=$(mktemp -d)
-trap 'rm -rf "$WORK"' EXIT
 mkdir -p "$WORK/workflows" "$WORK/.github/config"
 cp "$REPO_ROOT"/workflows/*.yml "$WORK/workflows/"
 cp "$PIN_CONFIG" "$WORK/.github/config/governed-workflow-pin.json"

--- a/workflows/antigravity-review.yml
+++ b/workflows/antigravity-review.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   review:
     if: vars.ANTIGRAVITY_REVIEW_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-review.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}

--- a/workflows/antigravity-translate.yml
+++ b/workflows/antigravity-translate.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   translate:
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/antigravity-translate.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     with:
       pr_number: ${{ inputs.pr_number }}
       expected_base_sha: ${{ inputs.expected_base_sha }}

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -54,7 +54,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     permissions:
       contents: write # the reusable completes the merge
       pull-requests: write # enable auto-merge and update the pull request

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -255,7 +255,7 @@ jobs:
   enforce-settings:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
     secrets:
@@ -264,7 +264,7 @@ jobs:
   sync-files:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
       downstream_sha: ${{ github.sha }}

--- a/workflows/github-pages-deploy.yml
+++ b/workflows/github-pages-deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     with:
       content-ref: ${{ github.sha }}
     permissions:

--- a/workflows/super-linter.yml
+++ b/workflows/super-linter.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     # No `secrets:` — least privilege. The reusable uses only the automatic
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
-    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531
     with:
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
     permissions:

--- a/workflows/translation-audit.yml
+++ b/workflows/translation-audit.yml
@@ -27,4 +27,4 @@ jobs:
     # toward not spending money. The audit stays advisory because this job can
     # skip when the runtime switch is disabled.
     if: vars.TRANSLATIONS_ENABLED == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@6aaca252b0fb0816618cb56a4c95b19d1ce91856
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@fa0c7a5fd25b300fac3287c6d8753e7e79e2c531


### PR DESCRIPTION
## Summary

- roll all governed reusable-workflow callers from `6aaca252` to protected-main commit `fa0c7a5f`
- add a regression test proving the configured Super-Linter revision contains the `container-build` route, complete same-repository guard, and explicit fork rejection
- unblock the 17 exact-caller recovery PRs that currently fail with `docker: command not found` on socketless runners

## Verification

- all `tests/test-*.sh`
- runner/workflow Python unit suite (96 tests)
- Actionlint with the existing local `SC2153` warning excluded
- exact Ruff 0.16.0 lint/format contract at 88, 100, and 120 columns
- workflow routing audit
- Zizmor 1.29.0 plus fail-closed workflow-security validator (30 governed routes)
- PII head enforcement
- `git diff --check`
- exact-HEAD Antigravity review

Closes #1447
