### PR TITLE
fix(runners): pin published Node 22 image digests

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -11,7 +11,7 @@
   },
   "profiles": {
     "ubuntu-24.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:8fa760afed6b45cf4508b350f3899e7604c53e5e8288491025927f159781387a",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:3df631f4b2a7d4b90bed868a545932e39067f9ef4a4f4356a80873c18b962a0c",
       "labels": ["ubuntu-24.04"],
       "memory": "8g",
       "cpus": "4",
@@ -21,7 +21,7 @@
       "docker_socket": false
     },
     "ubuntu-22.04": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:2f46bf299e5c5d6656756660235be1c4d9d45ab763c9eb8c22bfdafc00f21cc2",
+      "image": "ghcr.io/f5-sales-demo/actions-runner@sha256:f4b5bd3e7991f2bdc6f594f899a195e5d639d6450fb05b904912ff0ea7424b9a",
       "labels": ["ubuntu-22.04"],
       "memory": "8g",
       "cpus": "4",
@@ -31,7 +31,7 @@
       "docker_socket": false
     },
     "container-build": {
-      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:716fb43e39ae8ab9d3391ac08c61148abe2eb9bcd78dc1014db83ddedfbe873d",
+      "image": "ghcr.io/f5-sales-demo/actions-runner-container@sha256:b920382a609097f1f89cf64bfb6c36295cd2f341669aeee3ed8a74f910cc3442",
       "labels": ["container-build"],
       "memory": "16g",
       "cpus": "6",


### PR DESCRIPTION
## Summary

- pin the Ubuntu 24.04 socketless image to `sha256:3df631f4b2a7d4b90bed868a545932e39067f9ef4a4f4356a80873c18b962a0c`
- pin the Ubuntu 22.04 socketless image to `sha256:f4b5bd3e7991f2bdc6f594f899a195e5d639d6450fb05b904912ff0ea7424b9a`
- pin the Docker-capable image to `sha256:b920382a609097f1f89cf64bfb6c36295cd2f341669aeee3ed8a74f910cc3442`
- preserve all schema-v3 assignments, socket isolation, and resource limits

## Publication evidence

- official publish run: https://github.com/f5-sales-demo/docs-control/actions/runs/31761047943
- source revision: `12441608cde0a05c819c602d8042527c75cb98e7`
- each raw registry manifest hash independently matched the pinned digest
- exact immutable smoke tests passed for Node 22.22.2, npm/npx, PyYAML/keyring, socketless Docker absence, Docker client 29.7.2, Buildx, Compose, and nested Docker execution

## Verification

- runner/workflow pytest: 73 passed + 44 subtests
- linter contracts: 181 passed
- review routing: 72 passed
- protected-file tests: 138 passed
- Ruff check/format, actionlint, workflow audit, JSON validation, and `git diff --check` passed
- exact-HEAD Antigravity reviewer and verifier passed with no critical/high findings

Closes #1462
Refs #1426