### PR TITLE
fix(runners): forward container stop signals

### DIFF
--- a/scripts/ephemeral-runner-controller.py
+++ b/scripts/ephemeral-runner-controller.py
@@ -841,6 +841,8 @@ class EphemeralController:
             "--env",
             "RUNNER_EPHEMERAL=1",
             "--env",
+            "RUNNER_MANUALLY_TRAP_SIG=1",
+            "--env",
             f"RUNNER_REPOSITORY={spec.full_name}",
             "--env",
             f"RUNNER_NAME={name}-{secrets.token_hex(4)}",

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -556,7 +556,12 @@ class EphemeralRunnerTests(unittest.TestCase):
                 controller = MODULE.EphemeralController(
                     self.policy(), FakeGitHub(), self.root / "state", recorder
                 )
-                controller.run_once("f5-sales-demo/fixture", profile)
+                with mock.patch.object(
+                    MODULE.EphemeralController,
+                    "docker_socket_group",
+                    return_value=997,
+                ):
+                    controller.run_once("f5-sales-demo/fixture", profile)
                 command = next(
                     call[0]
                     for call in recorder.calls

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -556,7 +556,18 @@ class EphemeralRunnerTests(unittest.TestCase):
                 controller = MODULE.EphemeralController(
                     self.policy(), FakeGitHub(), self.root / "state", recorder
                 )
-                controller.run_once("f5-sales-demo/fixture", profile)
+                if profile == "container-build":
+                    # The contract under test is Docker argv construction, not
+                    # the host's Docker-socket metadata. Socketless CI runners
+                    # deliberately have no /run/docker.sock.
+                    with mock.patch.object(
+                        MODULE.EphemeralController,
+                        "docker_socket_group",
+                        return_value=997,
+                    ):
+                        controller.run_once("f5-sales-demo/fixture", profile)
+                else:
+                    controller.run_once("f5-sales-demo/fixture", profile)
                 command = next(
                     call[0]
                     for call in recorder.calls

--- a/tests/test_ephemeral_runner_controller.py
+++ b/tests/test_ephemeral_runner_controller.py
@@ -549,6 +549,23 @@ class EphemeralRunnerTests(unittest.TestCase):
         self.assertNotIn("--privileged", command)
         self.assertNotIn("/dev/fuse", command)
 
+    def test_every_outer_runner_enables_manual_signal_forwarding(self):
+        for profile in ("ubuntu-24.04", "container-build"):
+            with self.subTest(profile=profile):
+                recorder = CommandRecorder()
+                controller = MODULE.EphemeralController(
+                    self.policy(), FakeGitHub(), self.root / "state", recorder
+                )
+                controller.run_once("f5-sales-demo/fixture", profile)
+                command = next(
+                    call[0]
+                    for call in recorder.calls
+                    if call[0][:2] == ["docker", "run"]
+                )
+                self.assertEqual(command.count("RUNNER_MANUALLY_TRAP_SIG=1"), 1)
+                signal_env = command.index("RUNNER_MANUALLY_TRAP_SIG=1")
+                self.assertEqual(command[signal_env - 1], "--env")
+
     def test_engine_below_minimum_fails_before_runner_launch(self):
         recorder = CommandRecorder()
 


### PR DESCRIPTION
## Summary

- enable the official GitHub runner manual signal trap for every Docker outer-runner profile
- prove the Docker argv contains the signal-forwarding environment exactly once for socketless and Docker-capable runners
- preserve all existing resource, isolation, socket, and timeout policy

## Verification

- 74 runner/workflow Python unit tests
- all 36 repository shell test scripts
- 138 protected-file checks
- 181 linter-contract checks
- workflow security integration, privileged workflow tests, actionlint, Ruff, and `git diff --check`
- exact-HEAD Antigravity reviewer and verifier: approved

Closes #1464